### PR TITLE
[botframework-webchat-control] Add optional check to VoiceVideoCalling

### DIFF
--- a/samples/botframework-webchat-control/src/components/WebChat/WebChat.tsx
+++ b/samples/botframework-webchat-control/src/components/WebChat/WebChat.tsx
@@ -136,7 +136,7 @@ function WebChat() {
     await chatSDK?.endChat();
 
     // Clean up
-    (VoiceVideoCallingSDK as any).close();
+    (VoiceVideoCallingSDK as any)?.close();
     setChatAdapter(undefined);
     setChatToken(undefined);
     localStorage.removeItem('liveChatContext');


### PR DESCRIPTION
Currently VoiceVideoCalling is loaded dynamically based on:
https://github.com/microsoft/omnichannel-chat-sdk/blob/3b3e3ff4f8a3afd1677be4da94b4382277ffaf8e/samples/botframework-webchat-control/src/components/WebChat/WebChat.tsx#L56

The close button will try to close this session first, which fails if the `VoiceVideoCallingSDK` is not loaded. Due to this, the following calls to clean the session state / local storage will fail as well.