### PR TITLE
Fix "Cannot read property 'getVoiceVideoCalling' of undefined" on botframework-webchat-control

### DIFF
--- a/samples/botframework-webchat-control/src/components/WebChat/WebChat.tsx
+++ b/samples/botframework-webchat-control/src/components/WebChat/WebChat.tsx
@@ -152,7 +152,7 @@ function WebChat() {
     setChatAdapter(chatAdapter);
     dispatch({type: ActionType.SET_LOADING, payload: false});
 
-    if ((chatSDK as any).getVoiceVideoCalling) {
+    if ((chatSDK as any)?.getVoiceVideoCalling) {
       const chatToken: any = await chatSDK?.getChatToken();
       setChatToken(chatToken);
     }


### PR DESCRIPTION
Fix following error

![image](https://user-images.githubusercontent.com/8888565/123476138-2d3f8f80-d5b1-11eb-9574-ffbfcbf61260.png)
