### PR TITLE
Bubble up session init failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Add ability to automatically detect locale from chat config
 - Add `runtimeId` attribute in `OmnichannelChatSDK` & `ChatSDKRuntimeId` field in telemetry
 - Add ability to automatically pass locale from chat config on calling `ChatSDK.emailLiveChatTranscript()`
+- Bubble up `session init` exceptions
 
 ### Fix
 - Add `acs_webchat-chat-adapter` middlewares to format `channelData.tags`

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -581,7 +581,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.ACSClient.joinConversation).toHaveBeenCalledTimes(1);
         });
 
-        it('ChatSDK.startChat() should fail if OCClient.sessiontInit() fails', async () => {
+        it('ChatSDK.startChat() should fail if OCClient.sessionInit() fails', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -981,6 +981,7 @@ describe('Omnichannel Chat SDK', () => {
 
             chatSDK.OCClient = {};
             chatSDK.OCClient.getChatToken = jest.fn();
+            chatSDK.OCClient.sessionInit = jest.fn();
 
             chatSDK.IC3Client = {
                 initialize: jest.fn(),
@@ -1012,6 +1013,7 @@ describe('Omnichannel Chat SDK', () => {
 
             chatSDK.OCClient = {};
             chatSDK.OCClient.getChatToken = jest.fn();
+            chatSDK.OCClient.sessionInit = jest.fn();
 
             chatSDK.IC3Client = {
                 initialize: jest.fn(),
@@ -1034,6 +1036,7 @@ describe('Omnichannel Chat SDK', () => {
 
             chatSDK.OCClient = {};
             chatSDK.OCClient.getChatToken = jest.fn();
+            chatSDK.OCClient.sessionInit = jest.fn();
 
             chatSDK.IC3Client = {
                 initialize: jest.fn(),
@@ -2763,6 +2766,7 @@ describe('Omnichannel Chat SDK', () => {
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize();
 
@@ -2800,6 +2804,7 @@ describe('Omnichannel Chat SDK', () => {
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize();
 
@@ -2839,6 +2844,7 @@ describe('Omnichannel Chat SDK', () => {
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize();
 
@@ -2881,6 +2887,7 @@ describe('Omnichannel Chat SDK', () => {
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize();
 
@@ -2931,6 +2938,7 @@ describe('Omnichannel Chat SDK', () => {
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize();
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -429,7 +429,7 @@ class OmnichannelChatSDK {
                 });
 
                 console.error(`OmnichannelChatSDK/startChat/sessionInit/error ${error}`);
-                return error;
+                throw error;
             }
         }
 


### PR DESCRIPTION
Session Init failures can be caught as follow:

```js
try {
  await chatSDK.startChat();
} catch (error) {
  console.log(`Unable to start chat: ${error.message}`);
}
```