### PR TITLE
Raise start chat ooh failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Add `runtimeId` attribute in `OmnichannelChatSDK` & `ChatSDKRuntimeId` field in telemetry
 - Add ability to automatically pass locale from chat config on calling `ChatSDK.emailLiveChatTranscript()`
 - Bubble up `session init` exceptions
+- Bubble up `WidgetUseOutsideOperatingHour` exception
 
 ### Fix
 - Add `acs_webchat-chat-adapter` middlewares to format `channelData.tags`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to this project will be documented in this file.
 - Add ability to automatically detect locale from chat config
 - Add `runtimeId` attribute in `OmnichannelChatSDK` & `ChatSDKRuntimeId` field in telemetry
 - Add ability to automatically pass locale from chat config on calling `ChatSDK.emailLiveChatTranscript()`
-- Bubble up `session init` exceptions
 - Bubble up `WidgetUseOutsideOperatingHour` exception
 
 ### Fix

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -581,7 +581,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.ACSClient.joinConversation).toHaveBeenCalledTimes(1);
         });
 
-        it('ChatSDK.startChat() should fail if OCClient.sessionInit() fails', async () => {
+        it('ChatSDK.startChat() should throw an error if OCClient.sessionInit() fails', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
 
@@ -597,12 +597,10 @@ describe('Omnichannel Chat SDK', () => {
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve());
 
-            jest.spyOn(console, 'error');
-
             try {
                 await chatSDK.startChat();
             } catch (error) {
-                expect(console.error).toHaveBeenCalled();
+                expect(error).toBeDefined();
             }
 
             expect(chatSDK.OCClient.sessionInit).toHaveBeenCalledTimes(1);
@@ -740,7 +738,6 @@ describe('Omnichannel Chat SDK', () => {
                 expect(error.message).toEqual('InvalidConversation');
             }
         });
-
 
         it('ChatSDK.startChat() with liveChatContext of a closed conversation should throw an error', async() => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -425,6 +425,7 @@ class OmnichannelChatSDK {
 
                 if ((error as any)?.isAxiosError && (error as any).response?.headers?.errorcode.toString() === OmnichannelErrorCodes.WidgetUseOutsideOperatingHour.toString()) {
                     exceptionDetails.response = OmnichannelErrorCodes[OmnichannelErrorCodes.WidgetUseOutsideOperatingHour].toString();
+                    console.error(`Widget used outside of operating hours`);
                 }
 
                 this.scenarioMarker.failScenario(TelemetryEvent.StartChat, {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -424,6 +424,7 @@ class OmnichannelChatSDK {
                     response: "OCClientSessionInitFailed"
                 };
 
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 if ((error as any)?.isAxiosError && (error as any).response?.headers?.errorcode.toString() === OmnichannelErrorCodes.WidgetUseOutsideOperatingHour.toString()) {
                     exceptionDetails.response = OmnichannelErrorCodes[OmnichannelErrorCodes.WidgetUseOutsideOperatingHour].toString();
                     exceptionDetails.message = 'Widget used outside of operating hours';

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -14,6 +14,7 @@ import CallingOptionsOptionSetNumber from "./core/CallingOptionsOptionSetNumber"
 import ChatAdapterOptionalParams from "./core/messaging/ChatAdapterOptionalParams";
 import ChatAdapterProtocols from "./core/messaging/ChatAdapterProtocols";
 import ChatConfig from "./core/ChatConfig";
+import ChatSDKExceptionDetails from "./core/ChatSDKExceptionDetails";
 import ChatReconnectContext from "./core/ChatReconnectContext";
 import ChatReconnectOptionalParams from "./core/ChatReconnectOptionalParams";
 import ChatSDKConfig from "./core/ChatSDKConfig";
@@ -419,13 +420,14 @@ class OmnichannelChatSDK {
             try {
                 await this.OCClient.sessionInit(this.requestId, sessionInitOptionalParams);
             } catch (error) {
-                const exceptionDetails = {
+                const exceptionDetails: ChatSDKExceptionDetails = {
                     response: "OCClientSessionInitFailed"
                 };
 
                 if ((error as any)?.isAxiosError && (error as any).response?.headers?.errorcode.toString() === OmnichannelErrorCodes.WidgetUseOutsideOperatingHour.toString()) {
                     exceptionDetails.response = OmnichannelErrorCodes[OmnichannelErrorCodes.WidgetUseOutsideOperatingHour].toString();
-                    console.error(`Widget used outside of operating hours`);
+                    exceptionDetails.message = 'Widget used outside of operating hours';
+                    console.error(exceptionDetails.message);
                 }
 
                 this.scenarioMarker.failScenario(TelemetryEvent.StartChat, {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -58,6 +58,7 @@ import MessageContentType from "@microsoft/omnichannel-ic3core/lib/model/Message
 import MessageType from "@microsoft/omnichannel-ic3core/lib/model/MessageType";
 import OmnichannelChatToken from "@microsoft/omnichannel-amsclient/lib/OmnichannelChatToken";
 import OmnichannelConfig from "./core/OmnichannelConfig";
+import OmnichannelErrorCodes from "./core/OmnichannelErrorCodes";
 import OmnichannelMessage from "./core/messaging/OmnichannelMessage";
 import OnNewMessageOptionalParams from "./core/messaging/OnNewMessageOptionalParams";
 import PersonType from "@microsoft/omnichannel-ic3core/lib/model/PersonType";
@@ -422,6 +423,10 @@ class OmnichannelChatSDK {
                     response: "OCClientSessionInitFailed"
                 };
 
+                if ((error as any)?.isAxiosError && (error as any).response?.headers?.errorcode.toString() === OmnichannelErrorCodes.WidgetUseOutsideOperatingHour.toString()) {
+                    exceptionDetails.response = OmnichannelErrorCodes[OmnichannelErrorCodes.WidgetUseOutsideOperatingHour].toString();
+                }
+
                 this.scenarioMarker.failScenario(TelemetryEvent.StartChat, {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string,
@@ -429,7 +434,7 @@ class OmnichannelChatSDK {
                 });
 
                 console.error(`OmnichannelChatSDK/startChat/sessionInit/error ${error}`);
-                throw error;
+                throw new Error(exceptionDetails.response);
             }
         }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -434,7 +434,6 @@ class OmnichannelChatSDK {
                     ExceptionDetails: JSON.stringify(exceptionDetails)
                 });
 
-                console.error(`OmnichannelChatSDK/startChat/sessionInit/error ${error}`);
                 throw new Error(exceptionDetails.response);
             }
         }

--- a/src/core/ChatSDKExceptionDetails.ts
+++ b/src/core/ChatSDKExceptionDetails.ts
@@ -1,0 +1,6 @@
+interface ChatSDKExceptionDetails {
+    response: string;
+    message?: string;
+}
+
+export default ChatSDKExceptionDetails;

--- a/src/core/OmnichannelErrorCodes.ts
+++ b/src/core/OmnichannelErrorCodes.ts
@@ -1,0 +1,5 @@
+enum OmnichannelErrorCodes {
+    WidgetUseOutsideOperatingHour = 705,
+}
+
+export default OmnichannelErrorCodes;


### PR DESCRIPTION
Usage 

```js
try {
  await chatSDK.startChat();
} catch (error) {
  if (error.message === 'WidgetUseOutsideOperatingHour') {
    // Handles widget outside of operating hours
  }
}
```
