### PR TITLE
Calling error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Bubble up `WidgetUseOutsideOperatingHour` exception
 - Add `acs_webchat-chat-adapter` middleware to add default `channelData.tags` & `channelData.metadata`
 - Update `ChatConfig` interface with `msdyn_enablemarkdown` property
+- Throw exception on `ChatSDK.getVoiceVideoCalling()` if feature is disabled or platform is not supported
 
 ### Fix
 - Add `acs_webchat-chat-adapter` middlewares to format `channelData.tags`

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The following steps will be required to run Omnichannel Chat SDK on React Native
         if (context.participantJoined) { // participantJoined will be true if an agent has joined the conversation, or a bot has joined the conversation and the bot survey flag has been turned on on the admin side.
             // formsProLocale is the default language you have set on the CustomerVoice portal. You can override this url parameter with any locale that CustomerVoice supports.
             // If "&lang=" is not set on the url, the locale will be English.
-            const linkToSend = context.surveyInviteLink + "&lang=" + context.formsProLocale; 
+            const linkToSend = context.surveyInviteLink + "&lang=" + context.formsProLocale;
             // This link is accessible and will redirect to the survey page. Use it as you see fit.
         }
     } catch (ex) {
@@ -596,82 +596,93 @@ The following steps will be required to run Omnichannel Chat SDK on React Native
         console.log("VoiceVideoCalling loaded");
     } catch (e) {
         console.log(`Failed to load VoiceVideoCalling: ${e}`);
+
+        if (e.message === 'UnsupportedPlatform') {
+            // Voice Video Calling feature is not supported on this platform
+        }
+
+        if (e.message === 'FeatureDisabled') {
+            // Voice Video Calling feature is disabled on admin side
+        }
     }
 
     await chatSDK.startChat();
 
     const chatToken: any = await chatSDK.getChatToken();
 
-    try {
-        await VoiceVideoCallingSDK.initialize({
-            chatToken,
-            selfVideoHTMLElementId: 'selfVideo', // HTML element id where video stream of the agent will be rendered
-            remoteVideoHTMLElementId: 'remoteVideo', // HTML element id where video stream of the customer will be rendered
-            OCClient: chatSDK.OCClient
+    // Initialize only if VoiceVideoCallingSDK is defined
+    if (VoiceVideoCallingSDK) {
+        try {
+            await VoiceVideoCallingSDK.initialize({
+                chatToken,
+                selfVideoHTMLElementId: 'selfVideo', // HTML element id where video stream of the agent will be rendered
+                remoteVideoHTMLElementId: 'remoteVideo', // HTML element id where video stream of the customer will be rendered
+                OCClient: chatSDK.OCClient
+            });
+        } catch (e) {
+            console.error("Failed to initialize VoiceVideoCalling!");
+        }
+
+        // Triggered when there's an incoming call
+        VoiceVideoCallingSDK.onCallAdded(() => {
+            ...
         });
-    } catch (e) {
-        console.error("Failed to initialize VoiceVideoCalling!");
+
+        // Triggered when local video stream is available (e.g.: Local video added succesfully in selfVideoHTMLElement)
+        VoiceVideoCallingSDK.onLocalVideoStreamAdded(() => {
+            ...
+        });
+
+        // Triggered when local video stream is unavailable (e.g.: Customer turning off local video)
+        VoiceVideoCallingSDK.onLocalVideoStreamRemoved(() => {
+            ...
+        });
+
+        // Triggered when remote video stream is available (e.g.: Remote video added succesfully in remoteVideoHTMLElement)
+        VoiceVideoCallingSDK.onRemoteVideoStreamAdded(() => {
+            ...
+        });
+
+        // Triggered when remote video stream is unavailable (e.g.: Agent turning off remote video)
+        VoiceVideoCallingSDK.onRemoteVideoStreamRemoved(() => {
+            ...
+        });
+
+        // Triggered when current call has ended or disconnected regardless the party
+        VoiceVideoCalling.onCallDisconnected(() => {
+            ...
+        });
+
+        // Check if microphone is muted
+        const isMicrophoneMuted = VoiceVideoCallingSDK.isMicrophoneMuted();
+
+        // Check if remote video is available
+        const isRemoteVideoEnabled = VoiceVideoCallingSDK.isRemoteVideoEnabled();
+
+        // Check if local video is available
+        const isLocalVideoEnabled = VoiceVideoCallingSDK.isLocalVideoEnabled();
+
+        // Accepts incoming call
+        const acceptCallConfig = {
+            withVideo: true // Accept call with/without video stream
+        };
+        await VoiceVideoCallingSDK.acceptCall(acceptCallConfig);
+
+        // Rejects incoming call
+        await VoiceVideoCallingSDK.rejectCall();
+
+        // Ends/Stops current call
+        await VoiceVideoCallingSDK.stopCall();
+
+        // Mute/Unmute current call
+        await VoiceVideoCallingSDK.toggleMute()
+
+        // Display/Hide local video of current call
+        await VoiceVideoCallingSDK.toggleLocalVideo()
+
+        // Clean up VoiceVideoCallingSDK (e.g.: Usually called when customer ends chat session)
+        VoiceVideoCallingSDK.close();
     }
-
-    // Triggered when there's an incoming call
-    VoiceVideoCallingSDK.onCallAdded(() => {
-        ...
-    });
-
-    // Triggered when local video stream is available (e.g.: Local video added succesfully in selfVideoHTMLElement)
-    VoiceVideoCallingSDK.onLocalVideoStreamAdded(() => {
-        ...
-    });
-
-    // Triggered when local video stream is unavailable (e.g.: Customer turning off local video)
-    VoiceVideoCallingSDK.onLocalVideoStreamRemoved(() => {
-        ...
-    });
-
-    // Triggered when remote video stream is available (e.g.: Remote video added succesfully in remoteVideoHTMLElement)
-    VoiceVideoCallingSDK.onRemoteVideoStreamAdded(() => {
-        ...
-    });
-
-    // Triggered when remote video stream is unavailable (e.g.: Agent turning off remote video)
-    VoiceVideoCallingSDK.onRemoteVideoStreamRemoved(() => {
-        ...
-    });
-
-    // Triggered when current call has ended or disconnected regardless the party
-    VoiceVideoCalling.onCallDisconnected(() => {
-        ...
-    });
-
-    // Check if microphone is muted
-    const isMicrophoneMuted = VoiceVideoCallingSDK.isMicrophoneMuted();
-
-    // Check if remote video is available
-    const isRemoteVideoEnabled = VoiceVideoCallingSDK.isRemoteVideoEnabled();
-
-    // Check if local video is available
-    const isLocalVideoEnabled = VoiceVideoCallingSDK.isLocalVideoEnabled();
-
-    // Accepts incoming call
-    const acceptCallConfig = {
-        withVideo: true // Accept call with/without video stream
-    };
-    await VoiceVideoCallingSDK.acceptCall(acceptCallConfig);
-
-    // Rejects incoming call
-    await VoiceVideoCallingSDK.rejectCall();
-
-    // Ends/Stops current call
-    await VoiceVideoCallingSDK.stopCall();
-
-    // Mute/Unmute current call
-    await VoiceVideoCallingSDK.toggleMute()
-
-    // Display/Hide local video of current call
-    await VoiceVideoCallingSDK.toggleLocalVideo()
-
-    // Clean up VoiceVideoCallingSDK (e.g.: Usually called when customer ends chat session)
-    VoiceVideoCallingSDK.close();
 ```
 
 ## Feature Comparisons

--- a/__tests__/OmnichannelChatSDK.node.spec.ts
+++ b/__tests__/OmnichannelChatSDK.node.spec.ts
@@ -74,7 +74,7 @@ describe('Omnichannel Chat SDK (Node)', () => {
         try {
             await chatSDK.getVoiceVideoCalling();
         } catch (error) {
-            expect(error).toEqual('VoiceVideoCalling is only supported on browser');
+            expect(error.message).toEqual('UnsupportedPlatform');
         }
     });
 

--- a/__tests__/OmnichannelChatSDK.web.spec.ts
+++ b/__tests__/OmnichannelChatSDK.web.spec.ts
@@ -103,7 +103,7 @@ describe('Omnichannel Chat SDK (Web)', () => {
         try {
             await chatSDK.getVoiceVideoCalling();
         } catch (error) {
-            expect(error).toEqual('Voice and video call is not enabled');
+            expect(error.message).toEqual('FeatureDisabled');
         }
     });
 });

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1532,12 +1532,32 @@ class OmnichannelChatSDK {
     }
 
     public async getVoiceVideoCalling(params: any = {}): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
+        this.scenarioMarker.startScenario(TelemetryEvent.GetVoiceVideoCalling);
+
         if (platform.isNode() || platform.isReactNative()) {
-            return Promise.reject('VoiceVideoCalling is only supported on browser');
+            const exceptionDetails: ChatSDKExceptionDetails = {
+                response: "UnsupportedPlatform",
+                message: "VoiceVideoCalling is only supported on browser"
+            };
+
+            this.scenarioMarker.failScenario(TelemetryEvent.GetVoiceVideoCalling, {
+                ExceptionDetails: JSON.stringify(exceptionDetails)
+            });
+
+            throw new Error(exceptionDetails.response);
         }
 
         if (this.callingOption.toString() === CallingOptionsOptionSetNumber.NoCalling.toString()) {
-            return Promise.reject('Voice and video call is not enabled');
+            const exceptionDetails: ChatSDKExceptionDetails = {
+                response: "FeatureDisabled",
+                message: "Voice and video call is not enabled"
+            };
+
+            this.scenarioMarker.failScenario(TelemetryEvent.GetVoiceVideoCalling, {
+                ExceptionDetails: JSON.stringify(exceptionDetails)
+            });
+
+            throw new Error(exceptionDetails.response);
         }
 
         const chatConfig = await this.getChatConfig();
@@ -1549,8 +1569,6 @@ class OmnichannelChatSDK {
         const result = msdyn_widgetsnippet.match(widgetSnippetSourceRegex);
         if (result && result.length) {
             return new Promise (async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
-                this.scenarioMarker.startScenario(TelemetryEvent.GetVoiceVideoCalling);
-
                 const LiveChatWidgetLibCDNUrl = `${result[1]}/livechatwidget/WebChatControl/lib/CallingBundle.js`;
 
                 this.telemetry?.setCDNPackages({

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1568,7 +1568,7 @@ class OmnichannelChatSDK {
         const widgetSnippetSourceRegex = new RegExp(`src="(https:\\/\\/[\\w-.]+)[\\w-.\\/]+"`);
         const result = msdyn_widgetsnippet.match(widgetSnippetSourceRegex);
         if (result && result.length) {
-            return new Promise (async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
+            return new Promise (async (resolve) => { // eslint-disable-line no-async-promise-executor
                 const LiveChatWidgetLibCDNUrl = `${result[1]}/livechatwidget/WebChatControl/lib/CallingBundle.js`;
 
                 this.telemetry?.setCDNPackages({

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1586,14 +1586,15 @@ class OmnichannelChatSDK {
                     resolve(VoiceVideoCalling);
                 }, async () => {
                     const exceptionDetails = {
-                        response: "VoiceVideoCallingLoadFailed"
+                        response: "VoiceVideoCallingLoadFailed",
+                        message: "Failed to load VoiceVideoCalling"
                     };
 
                     this.scenarioMarker.failScenario(TelemetryEvent.GetVoiceVideoCalling, {
                         ExceptionDetails: JSON.stringify(exceptionDetails)
                     });
 
-                    reject('Failed to load VoiceVideoCalling');
+                    throw new Error(exceptionDetails.response);
                 });
             });
         }


### PR DESCRIPTION
We can capture `ChatSDK.getVoiceVideoCalling()` errors as follow:

```js
try {
  const VoiceVideoCalling = await chatSDK.getVoiceVideoCalling();
} catch (e) {
  if (e.message === 'FeatureDisabled') {
    // Voice Video Calling feature is disabled on admin side
  }
}

// VoiceVideoCalling is undefined at this point

if (!VoiceVideoCalling) {
  // Handle scenario if VoiceVideoCalling is undefined
}
```