### PR TITLE
Fix ams file manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 - Add `sendDefaultInitContext` optional parameter to `ChatSDK.startChat()` to automatically populate `browser`, `device`, `originurl` & `os` as default init context on web
 - Add `sendCacheHeaders` as optional paramater to `ChatSDK.initialize()` and `ChatSDK.getLiveChatConfig()`
 
+### Fixed
+- Prevent `AMSFileManager.getFileIds()` & `AMSFileManager.getFileMetadata()` to be triggered on all activities with null checks
+
 ### Changed
 - Uptake [@microsoft/ocsdk@0.3.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.1)
 
@@ -26,7 +29,7 @@ All notable changes to this project will be documented in this file.
 - Add support for separate bot post chat survey feature
 - Pass `logger` to `acs_webchat-chat-adapter`
 
-### Fix
+### Fixed
 - Add `acs_webchat-chat-adapter` middlewares to format `channelData.tags`
 - Skip `session init` call on existing conversation
 - Fix `chat reconnect` not ending the conversation on calling `ChatSDK.endChat()`

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -108,7 +108,7 @@ describe('AMSFileManager', () => {
         expect(response).toStrictEqual(amsMetadata);
     });
 
-    it('AMSFileManager.getFileMetadata() should return a nothing if invalid', async () => {
+    it('AMSFileManager.getFileMetadata() should return nothing if invalid', async () => {
         const amsClient: any = {};
 
         const fileManager = new AMSFileManager(amsClient);

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -47,8 +47,12 @@ describe('AMSFileManager', () => {
 
     it('AMSFileManager.getFileIds() should return a JSON data', async () => {
         const amsClient: any = {};
+        const logger: any = {};
+        logger.startScenario = jest.fn();
+        logger.completeScenario = jest.fn();
+        logger.failScenario = jest.fn();
 
-        const fileManager = new AMSFileManager(amsClient);
+        const fileManager = new AMSFileManager(amsClient, logger);
 
         const amsReferences = [{id: 'id'}];
         const metadata = {
@@ -57,19 +61,24 @@ describe('AMSFileManager', () => {
 
         const response = fileManager.getFileIds(metadata);
         expect(response).toStrictEqual(amsReferences);
+        expect(logger.startScenario).toBeCalledTimes(1);
     });
 
-    it('AMSFileManager.getFileIds() should return a nothing if invalid', async () => {
+    it('AMSFileManager.getFileIds() should return nothing if invalid', async () => {
         const amsClient: any = {};
+        const logger: any = {};
+        logger.startScenario = jest.fn();
+        logger.completeScenario = jest.fn();
+        logger.failScenario = jest.fn();
 
-        const fileManager = new AMSFileManager(amsClient);
+        const fileManager = new AMSFileManager(amsClient, logger);
 
         const metadata = {};
 
         const response = fileManager.getFileIds(metadata);
         expect(response).toBeFalsy();
+        expect(logger.startScenario).toBeCalledTimes(0);
     });
-
 
     it('AMSFileManager.createFileIdProperty() should return a JSON data', async () => {
         const amsClient: any = {};

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -124,9 +124,9 @@ describe('AMSFileManager', () => {
 
         const fileManager = new AMSFileManager(amsClient);
 
-        const metadata: any = {
-            data: 'data'
-        };
+        const metadata: any = [
+            {contentType: 'contentType', fileName: 'fileName'}
+        ]
 
         const response: any = fileManager.createFileMetadataProperty(metadata);
         expect(response.amsMetadata).toBe(JSON.stringify(metadata));

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -60,6 +60,10 @@ class AMSFileManager {
     }
 
     public getFileIds(metadata?: Record<string, string>): string[] | undefined {
+        if (!metadata || !metadata.amsReferences) {
+            return;
+        }
+
         this.logger?.startScenario(AMSFileManagerEvent.GetFileIds);
 
         try {
@@ -104,6 +108,10 @@ class AMSFileManager {
     }
 
     public getFileMetadata(metadata?: Record<string, string>): FileMetadata[] | undefined {
+        if (!metadata || !metadata.amsMetadata) {
+            return;
+        }
+
         this.logger?.startScenario(AMSFileManagerEvent.GetFileMetadata);
 
         try {

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -85,6 +85,10 @@ class AMSFileManager {
     }
 
     public createFileIdProperty(fileIds: string[]): Record<string, string> | undefined {
+        if (!fileIds) {
+            return;
+        }
+
         this.logger?.startScenario(AMSFileManagerEvent.CreateFileIdProperty);
 
         try {
@@ -133,6 +137,10 @@ class AMSFileManager {
     }
 
     public createFileMetadataProperty(metadata: FileMetadata[]): Record<string, string> | undefined {
+        if (!metadata) {
+            return;
+        }
+
         this.logger?.startScenario(AMSFileManagerEvent.CreateFileMetadataProperty);
 
         try {


### PR DESCRIPTION
- Adding checks to prevent methods to be called when properties with attachment are not present