### PR TITLE
Fix attachment property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Uptake [@microsoft/ocsdk@0.3.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.1)
 - Uptake [acs_webchat-chat-adapter@0.0.35-beta.8](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.8/dist/chat-adapter.js)
 - Uptake [acs_webchat-chat-adapter@0.0.35-beta.9](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.9/dist/chat-adapter.js)
+- Uptake [acs_webchat-chat-adapter@0.0.35-beta.12](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.12/dist/chat-adapter.js)
 
 ## [1.1.0] - 2022-04-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Prevent `AMSFileManager.getFileIds()` & `AMSFileManager.getFileMetadata()` to be triggered on all activities with null checks
 - Add `LiveChatVersion` check on `ChatSDK.updateChatToken()`
+- Use `amsreferences` property instead of `amsReferences` by default
 
 ### Changed
 - Uptake [@microsoft/ocsdk@0.3.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.1)

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -64,6 +64,25 @@ describe('AMSFileManager', () => {
         expect(logger.startScenario).toBeCalledTimes(1);
     });
 
+    it('AMSFileManager.getFileIds() should return a JSON data when \'amsreferences\' is part of the metadata', async () => {
+        const amsClient: any = {};
+        const logger: any = {};
+        logger.startScenario = jest.fn();
+        logger.completeScenario = jest.fn();
+        logger.failScenario = jest.fn();
+
+        const fileManager = new AMSFileManager(amsClient, logger);
+
+        const amsReferences = [{id: 'id'}];
+        const metadata = {
+            amsreferences: JSON.stringify(amsReferences)
+        };
+
+        const response = fileManager.getFileIds(metadata);
+        expect(response).toStrictEqual(amsReferences);
+        expect(logger.startScenario).toBeCalledTimes(1);
+    });
+
     it('AMSFileManager.getFileIds() should return nothing if invalid', async () => {
         const amsClient: any = {};
         const logger: any = {};
@@ -111,7 +130,6 @@ describe('AMSFileManager', () => {
         };
 
         const response: any = fileManager.getFileIds(metadata);
-        console.log(response);
         expect(response[0]).toBe(JSON.parse(metadata.amsreferences)[0]);
     });
 

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -142,6 +142,7 @@ describe('AMSFileManager', () => {
 
         const response: any = fileManager.createFileIdProperty(fileIds);
         expect(response.amsReferences).toBe(JSON.stringify(fileIds));
+        expect(response.amsreferences).toBe(JSON.stringify(fileIds));
     });
 
     it('AMSFileManager.getFileMetadata() should return a JSON data', async () => {

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -234,4 +234,32 @@ describe('AMSFileManager', () => {
         expect((fileManager as any).amsClient.getView).toHaveBeenCalledTimes(1);
         expect(response).not.toBeFalsy();
     });
+
+    it('AMSFileManager.createBotAttachment() should return null by default', async () => {
+        const amsClient: any = {};
+
+        const fileManager = new AMSFileManager(amsClient);
+
+        const amsReferences = [{id: 'id'}];
+        const amsMetadata  = {
+            data: 'data'
+        };
+
+        const metadata = {
+            amsReferences: JSON.stringify(amsReferences),
+            amsMetadata: JSON.stringify(amsMetadata)
+
+        };
+
+        const response = fileManager.createBotAttachment(metadata);
+        expect(response).toBe(null);
+    });
+
+    it('AMSFileManager.createBotAttachment() should return null if metadata is null', async () => {
+        const amsClient: any = {};
+
+        const fileManager = new AMSFileManager(amsClient);
+        const response = fileManager.createBotAttachment(null as any);
+        expect(response).toBe(null);
+    });
 });

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -73,11 +73,46 @@ describe('AMSFileManager', () => {
 
         const fileManager = new AMSFileManager(amsClient, logger);
 
+        const metadata = undefined;
+
+        const response = fileManager.getFileIds(metadata);
+        expect(response).toBeFalsy();
+        expect(logger.startScenario).toBeCalledTimes(0);
+    });
+
+    it('AMSFileManager.getFileIds() should return nothing if \'amsReferences\' or \'amsreferences\' properties were not present', async () => {
+        const amsClient: any = {};
+        const logger: any = {};
+        logger.startScenario = jest.fn();
+        logger.completeScenario = jest.fn();
+        logger.failScenario = jest.fn();
+
+        const fileManager = new AMSFileManager(amsClient, logger);
+
         const metadata = {};
 
         const response = fileManager.getFileIds(metadata);
         expect(response).toBeFalsy();
         expect(logger.startScenario).toBeCalledTimes(0);
+    });
+
+    it('AMSFileManager.getFileIds() should take precendence of \'amsreferences\'', async () => {
+        const amsClient: any = {};
+        const logger: any = {};
+        logger.startScenario = jest.fn();
+        logger.completeScenario = jest.fn();
+        logger.failScenario = jest.fn();
+
+        const fileManager = new AMSFileManager(amsClient, logger);
+
+        const metadata = {
+            amsReferences: `["amsReferences"]`,
+            amsreferences: `["amsreferences"]`,
+        };
+
+        const response: any = fileManager.getFileIds(metadata);
+        console.log(response);
+        expect(response[0]).toBe(JSON.parse(metadata.amsreferences)[0]);
     });
 
     it('AMSFileManager.createFileIdProperty() should return a JSON data', async () => {

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -83,4 +83,39 @@ describe('createOmnichannelMessage', () => {
             url: ''
         });
     });
+
+    it('createOmnichannelMessage with LiveChatV2 message should take precedence of \'amsreferences\'', () => {
+        const amsReferences = ['amsReferences'];
+        const amsreferences = ['amsreferences'];
+        const amsMetadata = [{fileName: 'fileName.ext', size: 0, contentType: 'type'}]
+        const sampleMessage = {
+            id: 'id',
+            content: '',
+            metadata: {
+                tags: 'tags',
+                amsMetadata: JSON.stringify(amsMetadata),
+                amsReferences: JSON.stringify(amsReferences),
+                amsreferences: JSON.stringify(amsreferences)
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        const omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+            liveChatVersion: LiveChatVersion.V2
+        });
+
+        expect(omnichannelMessage.fileMetadata).toEqual({
+            fileSharingProtocolType: 0,
+            id: amsreferences[0],
+            name: amsMetadata[0].fileName,
+            size: 0,
+            type: 'ext',
+            url: ''
+        });
+    });
 });

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -5,7 +5,7 @@ import { DeliveryMode, MessageType } from '../../src/core/messaging/OmnichannelM
 import PersonType from '@microsoft/omnichannel-ic3core/lib/model/PersonType';
 
 describe('createOmnichannelMessage', () => {
-    it ('createOmnichannelMessage with LiveChatV2 messaging contracts should return OmnichannelMessage contracts', () => {
+    it('createOmnichannelMessage with LiveChatV2 messaging contracts should return OmnichannelMessage contracts', () => {
         const amsReferences = ['id'];
         const amsMetadata = [{fileName: 'fileName.ext', size: 0, contentType: 'type'}]
         const sampleMessage = {
@@ -41,6 +41,39 @@ describe('createOmnichannelMessage', () => {
             displayName: sampleMessage.senderDisplayName,
             type: PersonType.Bot
         });
+        expect(omnichannelMessage.fileMetadata).toEqual({
+            fileSharingProtocolType: 0,
+            id: amsReferences[0],
+            name: amsMetadata[0].fileName,
+            size: 0,
+            type: 'ext',
+            url: ''
+        });
+    });
+
+    it('createOmnichannelMessage with LiveChatV2 message containing \'amsreferences\' should return the correct fileMetadata', () => {
+        const amsReferences = ['id'];
+        const amsMetadata = [{fileName: 'fileName.ext', size: 0, contentType: 'type'}]
+        const sampleMessage = {
+            id: 'id',
+            content: '',
+            metadata: {
+                tags: 'tags',
+                amsMetadata: JSON.stringify(amsMetadata),
+                amsreferences: JSON.stringify(amsReferences)
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        const omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+            liveChatVersion: LiveChatVersion.V2
+        });
+
         expect(omnichannelMessage.fileMetadata).toEqual({
             fileSharingProtocolType: 0,
             id: amsReferences[0],

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1258,7 +1258,8 @@ class OmnichannelChatSDK {
             const uploadDocumentResponse: any = await this.AMSClient?.uploadDocument(documentId, fileInfo as any);  // eslint-disable-line @typescript-eslint/no-explicit-any
 
             const fileIdsProperty = {
-                amsReferences: JSON.stringify([documentId])
+                amsReferences: JSON.stringify([documentId]),
+                amsreferences: JSON.stringify([documentId])
             };
 
             const fileMetaProperty = {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,6 +1,6 @@
 const ic3ClientVersion = '2021.08.14.1';
 const webChatIC3AdapterVersion = '0.1.0-master.2dba07b';
-const webChatACSAdapterVersion = '0.0.35-beta.9';
+const webChatACSAdapterVersion = '0.0.35-beta.12';
 const ariaTelemetryKey = 'c7655518acf1403f93ff6b9f77942f0a-d01a02fd-6b50-4de3-a566-62eda11f93bc-7083';
 
 export {

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -99,7 +99,8 @@ class AMSFileManager {
 
         try {
             const result = {
-                amsReferences: JSON.stringify(fileIds)
+                amsReferences: JSON.stringify(fileIds),
+                amsreferences: JSON.stringify(fileIds)
             } as Record<string, string>;
             this.logger?.completeScenario(AMSFileManagerEvent.CreateFileIdProperty);
             return result;

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -84,6 +84,12 @@ class AMSFileManager {
         }
     }
 
+    /**
+     * Creates property for the reference of the attachments to be sent to ACS as metadata after successful upload.
+     *
+     * @param fileIds List of fileIds
+     * @returns
+     */
     public createFileIdProperty(fileIds: string[]): Record<string, string> | undefined {
         if (!fileIds) {
             return;
@@ -136,6 +142,13 @@ class AMSFileManager {
         }
     }
 
+    /**
+     *
+     * Creates property for the metadata of the attachments to be sent to ACS as metadata after successful upload.
+     *
+     * @param metadata List of file metadata
+     * @returns
+     */
     public createFileMetadataProperty(metadata: FileMetadata[]): Record<string, string> | undefined {
         if (!metadata) {
             return;

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -29,13 +29,24 @@ interface PermissionsOptions {
     permission: FilePermission;
 }
 
+interface AmsReferenceContent {
+    uniqueId: string;
+}
+
+interface BotAttachment {
+    name: string;
+    contentType: string;
+    content: AmsReferenceContent;
+}
+
 enum AMSFileManagerEvent {
     AMSUpload = 'AMSUpload',
     AMSDownload = 'AMSDownload',
     GetFileIds = 'GetFileIds',
     CreateFileIdProperty = 'CreateFileIdProperty',
     GetFileMetadata = 'GetFileMetadata',
-    CreateFileMetadataProperty = 'CreateFileMetadataProperty'
+    CreateFileMetadataProperty = 'CreateFileMetadataProperty',
+    CreateBotAttachment = 'CreateBotAttachment'
 }
 
 class AMSFileManager {
@@ -187,6 +198,42 @@ class AMSFileManager {
 
             return undefined;
         }
+    }
+
+    public createBotAttachment(metadata: Record<string, string>): BotAttachment | null {
+        if (!metadata || Object.keys(metadata).length === 0) {
+            return null;
+        }
+
+        this.logger?.startScenario(AMSFileManagerEvent.CreateBotAttachment);
+
+        const fileMetadataList = this.getFileMetadata(metadata);
+        const fileIds = this.getFileIds(metadata);
+
+        let fileId;
+        let fileMetadata;
+
+        if (fileIds && fileIds.length > 0) {
+            fileId = fileIds[0];
+        }
+
+        if (fileMetadataList && fileMetadataList.length > 0) {
+            fileMetadata = fileMetadataList[0];
+        }
+
+        if (fileId) {
+            const attachment: BotAttachment = {
+                contentType: fileMetadata?.contentType as string,
+                name: fileMetadata?.fileName as string,
+                content: { uniqueId: fileId }
+            };
+
+            this.logger?.completeScenario(AMSFileManagerEvent.CreateBotAttachment);
+            return attachment;
+        }
+
+        this.logger?.completeScenario(AMSFileManagerEvent.CreateBotAttachment);
+        return null;
     }
 
     private async uploadFileToAMS(fileToUpload: IFileUploadRequest): Promise<IUploadedFile | undefined> {

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -60,14 +60,26 @@ class AMSFileManager {
     }
 
     public getFileIds(metadata?: Record<string, string>): string[] | undefined {
-        if (!metadata || !metadata.amsReferences) {
+        if (!metadata) {
+            return;
+        }
+
+        if (!metadata.amsReferences && !metadata.amsreferences) {
             return;
         }
 
         this.logger?.startScenario(AMSFileManagerEvent.GetFileIds);
 
         try {
-            const result = JSON.parse(metadata?.amsReferences as string) as string[];
+            let result = undefined;
+            if (metadata?.amsReferences) {
+                result = JSON.parse(metadata?.amsReferences as string) as string[];
+            }
+
+            if (metadata?.amsreferences) {
+                result = JSON.parse(metadata?.amsreferences as string) as string[];
+            }
+
             this.logger?.completeScenario(AMSFileManagerEvent.GetFileIds);
             return result;
         } catch (error) {

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -45,8 +45,7 @@ enum AMSFileManagerEvent {
     GetFileIds = 'GetFileIds',
     CreateFileIdProperty = 'CreateFileIdProperty',
     GetFileMetadata = 'GetFileMetadata',
-    CreateFileMetadataProperty = 'CreateFileMetadataProperty',
-    CreateBotAttachment = 'CreateBotAttachment'
+    CreateFileMetadataProperty = 'CreateFileMetadataProperty'
 }
 
 class AMSFileManager {
@@ -200,39 +199,18 @@ class AMSFileManager {
         }
     }
 
+    /**
+     * Creates content to be sent to ACS after successful upload.
+     *
+     * @param metadata List of file metadata
+     * @returns
+     */
     public createBotAttachment(metadata: Record<string, string>): BotAttachment | null {
         if (!metadata || Object.keys(metadata).length === 0) {
             return null;
         }
 
-        this.logger?.startScenario(AMSFileManagerEvent.CreateBotAttachment);
-
-        const fileMetadataList = this.getFileMetadata(metadata);
-        const fileIds = this.getFileIds(metadata);
-
-        let fileId;
-        let fileMetadata;
-
-        if (fileIds && fileIds.length > 0) {
-            fileId = fileIds[0];
-        }
-
-        if (fileMetadataList && fileMetadataList.length > 0) {
-            fileMetadata = fileMetadataList[0];
-        }
-
-        if (fileId) {
-            const attachment: BotAttachment = {
-                contentType: fileMetadata?.contentType as string,
-                name: fileMetadata?.fileName as string,
-                content: { uniqueId: fileId }
-            };
-
-            this.logger?.completeScenario(AMSFileManagerEvent.CreateBotAttachment);
-            return attachment;
-        }
-
-        this.logger?.completeScenario(AMSFileManagerEvent.CreateBotAttachment);
+        // Sending empty content
         return null;
     }
 

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -35,18 +35,30 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
             type: PersonType.Bot
         } as IPerson;
 
-        if (metadata && metadata.amsMetadata && metadata.amsReferences) {
+        if (metadata) {
             try {
-                const references = JSON.parse(metadata.amsReferences);
-                const data = JSON.parse(metadata.amsMetadata);
-                const {fileName} = data[0];
-
                 omnichannelMessage.fileMetadata = {} as IFileMetadata; // Backward compatibility
+
+                if (metadata.amsMetadata) {
+                    const data = JSON.parse(metadata.amsMetadata);
+                    const {fileName} = data[0];
+                    omnichannelMessage.fileMetadata.name = fileName;
+                    omnichannelMessage.fileMetadata.type = fileName.split('.').pop();
+                }
+
+                if (metadata.amsReferences) {
+                    const references = JSON.parse(metadata.amsReferences);
+                    omnichannelMessage.fileMetadata.id = references[0];
+                }
+
+                // "amsreferences" takes precedence
+                if (metadata.amsreferences) {
+                    const references = JSON.parse(metadata.amsreferences);
+                    omnichannelMessage.fileMetadata.id = references[0];
+                }
+
                 omnichannelMessage.fileMetadata.fileSharingProtocolType = 0;
-                omnichannelMessage.fileMetadata.id = references[0];
-                omnichannelMessage.fileMetadata.name = fileName;
                 omnichannelMessage.fileMetadata.size = 0;
-                omnichannelMessage.fileMetadata.type = fileName.split('.').pop();
                 omnichannelMessage.fileMetadata.url = '';
             } catch {
                 // Suppress errors to keep chat flowing


### PR DESCRIPTION
- Attachments longer than 7 days would be deleted due to `amsReferences` was being used instead of `amsreferences`
- Updated code to use `amsreferences` property instead of `amsReferences` & ensure backward compatibility