### PR TITLE
Pass ACS chat client  during adapter initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add `sendDefaultInitContext` optional parameter to `ChatSDK.startChat()` to automatically populate `browser`, `device`, `originurl` & `os` as default init context on web
 - Add `sendCacheHeaders` as optional paramater to `ChatSDK.initialize()` and `ChatSDK.getLiveChatConfig()`
+- Pass `ChatClient` during `ACSAdapter` initialization
 
 ### Fixed
 - Prevent `AMSFileManager.getFileIds()` & `AMSFileManager.getFileMetadata()` to be triggered on all activities with null checks

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1523,7 +1523,7 @@ class OmnichannelChatSDK {
                             fileManager,
                             30000,
                             ACSParticipantDisplayName.Customer,
-                            undefined, // chatClient
+                            this.ACSClient?.getChatClient(),
                             this.acsAdapterLogger, // logger
                             featuresOption,
                         );

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -438,6 +438,10 @@ class ACSClient {
         await conversation.initialize(sessionInfo);
         return conversation;
     }
+
+    public getChatClient() : ChatClient | null {
+        return this.chatClient;
+    }
 }
 
 export default ACSClient;


### PR DESCRIPTION
1. Tested multiple chats without closing or refreshing the browser. Exchanged messages between the customer and agent. Works fine.
2. Tested the chat after refreshing the browser window. Exchanged messages between the customer and agent. Works fine.
