### PR TITLE
Fix Attachment Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Prevent `AMSFileManager.getFileIds()` & `AMSFileManager.getFileMetadata()` to be triggered on all activities with null checks
 - Add `LiveChatVersion` check on `ChatSDK.updateChatToken()`
 - Use `amsreferences` property instead of `amsReferences` by default
+- Fix attachment download to use MIME types instead of file extensions
 
 ### Changed
 - Uptake [@microsoft/ocsdk@0.3.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.1)

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -46,7 +46,7 @@ describe('createOmnichannelMessage', () => {
             id: amsReferences[0],
             name: amsMetadata[0].fileName,
             size: 0,
-            type: 'ext',
+            type: amsMetadata[0].contentType,
             url: ''
         });
     });
@@ -79,7 +79,7 @@ describe('createOmnichannelMessage', () => {
             id: amsReferences[0],
             name: amsMetadata[0].fileName,
             size: 0,
-            type: 'ext',
+            type: amsMetadata[0].contentType,
             url: ''
         });
     });
@@ -114,7 +114,7 @@ describe('createOmnichannelMessage', () => {
             id: amsreferences[0],
             name: amsMetadata[0].fileName,
             size: 0,
-            type: 'ext',
+            type: amsMetadata[0].contentType,
             url: ''
         });
     });

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -286,7 +286,7 @@ class AMSFileManager {
         if (uploadedFile.fileId && uploadedFile.metadata && uploadedFile.metadata.fileName) {
             const fileMetadata = {
                 id: uploadedFile.fileId,
-                type: uploadedFile.metadata.contentType.split("/").pop() as string
+                type: uploadedFile.metadata.contentType
             };
 
             let response: any;  // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -41,9 +41,9 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
 
                 if (metadata.amsMetadata) {
                     const data = JSON.parse(metadata.amsMetadata);
-                    const {fileName} = data[0];
+                    const {fileName, contentType} = data[0];
                     omnichannelMessage.fileMetadata.name = fileName;
-                    omnichannelMessage.fileMetadata.type = fileName.split('.').pop();
+                    omnichannelMessage.fileMetadata.type = contentType;
                 }
 
                 if (metadata.amsReferences) {


### PR DESCRIPTION
- Uptaking AMSClient required to update the dependents to pass the MIME types instead of file extensions which was not the case with ChatSDK causing attachment download failures, so this PR should address the issue