### PR TITLE
Fix messages with invalid fileMetadata property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Add `LiveChatVersion` check on `ChatSDK.updateChatToken()`
 - Use `amsreferences` property instead of `amsReferences` by default
 - Fix attachment download to use MIME types instead of file extensions
+- Remove `fileMetadata` property on messages not containing any attachment
 
 ### Changed
 - Uptake [@microsoft/ocsdk@0.3.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.1)

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -51,6 +51,41 @@ describe('createOmnichannelMessage', () => {
         });
     });
 
+    it('createOmnichannelMessage with LiveChatV2 message without attachment should not have fileMetadata', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: 'tags',
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        const omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+            liveChatVersion: LiveChatVersion.V2
+        });
+
+        expect(omnichannelMessage.id).toBeDefined();
+        expect(omnichannelMessage.messageid).toBe(undefined);
+        expect(omnichannelMessage.clientmessageid).toBe(undefined);
+        expect(omnichannelMessage.deliveryMode).toBe(undefined);
+        expect(omnichannelMessage.content).toBe(sampleMessage.content);
+        expect(omnichannelMessage.tags).toEqual(sampleMessage.metadata.tags.split(','));
+        expect(omnichannelMessage.timestamp).toBe(sampleMessage.createdOn);
+        expect(omnichannelMessage.messageType).toBe(MessageType.UserMessage);
+        expect(omnichannelMessage.sender).toEqual({
+            id: sampleMessage.sender.communicationUserId,
+            displayName: sampleMessage.senderDisplayName,
+            type: PersonType.Bot
+        });
+        expect(omnichannelMessage.fileMetadata).not.toBeDefined();
+    });
+
     it('createOmnichannelMessage with LiveChatV2 message containing \'amsreferences\' should return the correct fileMetadata', () => {
         const amsReferences = ['id'];
         const amsMetadata = [{fileName: 'fileName.ext', size: 0, contentType: 'type'}]

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -51,7 +51,7 @@ describe('createOmnichannelMessage', () => {
         });
     });
 
-    it('createOmnichannelMessage with LiveChatV2 message without attachment should not have fileMetadata', () => {
+    it('createOmnichannelMessage with LiveChatV2 message without attachment should not have fileMetadata defined', () => {
         const sampleMessage = {
             id: 'id',
             content: 'content',

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -35,30 +35,21 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
             type: PersonType.Bot
         } as IPerson;
 
-        if (metadata) {
+        if (metadata && metadata.amsMetadata && metadata.amsReferences || metadata.amsreferences) {
             try {
-                omnichannelMessage.fileMetadata = {} as IFileMetadata; // Backward compatibility
-
-                if (metadata.amsMetadata) {
-                    const data = JSON.parse(metadata.amsMetadata);
-                    const {fileName, contentType} = data[0];
-                    omnichannelMessage.fileMetadata.name = fileName;
-                    omnichannelMessage.fileMetadata.type = contentType;
-                }
-
-                if (metadata.amsReferences) {
-                    const references = JSON.parse(metadata.amsReferences);
-                    omnichannelMessage.fileMetadata.id = references[0];
-                }
+                const data = JSON.parse(metadata.amsMetadata);
 
                 // "amsreferences" takes precedence
-                if (metadata.amsreferences) {
-                    const references = JSON.parse(metadata.amsreferences);
-                    omnichannelMessage.fileMetadata.id = references[0];
-                }
+                const references = JSON.parse(metadata.amsreferences || metadata.amsReferences);
+                const {fileName, contentType} = data[0];
 
+                // fileMetadata should be defined only when there's an attachment
+                omnichannelMessage.fileMetadata = {} as IFileMetadata; // Backward compatibility
                 omnichannelMessage.fileMetadata.fileSharingProtocolType = 0;
+                omnichannelMessage.fileMetadata.id = references[0];
+                omnichannelMessage.fileMetadata.name = fileName;
                 omnichannelMessage.fileMetadata.size = 0;
+                omnichannelMessage.fileMetadata.type = contentType;
                 omnichannelMessage.fileMetadata.url = '';
             } catch {
                 // Suppress errors to keep chat flowing


### PR DESCRIPTION
- Messages without attachment should not contain `fileMetadata` property
- We usually use check if `message.fileMetadata` is defined to validate if there's an attachment or not