### PR TITLE
Create DirectLine Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Add ability to use `ChatSDK.createChatAdapter()` for `DirectLine` protocol
+- Add `CreateACSAdapter` telemetry event
 
 ## [1.2.0] - 2022-11-11
 ### Added

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -197,6 +197,58 @@ describe('Omnichannel Chat SDK', () => {
             expect(url).toBe(libraries.getACSAdapterCDNUrl());
         });
 
+        it('ChatSDK should be able to pick custom webChatDirectLineVersion if set', async () => {
+            const omnichannelConfig = {
+                orgUrl: '',
+                orgId: '',
+                widgetId: ''
+            };
+
+            const chatSDKConfig = {
+                chatAdapterConfig: {
+                    webChatDirectLineVersion: 'version'
+                }
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.DirectLine);
+
+            expect(url).toBe(libraries.getDirectLineCDNUrl(chatSDKConfig.chatAdapterConfig.webChatDirectLineVersion));
+        });
+
+        it('ChatSDK should be able to pick custom webChatDirectLineCDNUrl if set', async () => {
+            const omnichannelConfig = {
+                orgUrl: '',
+                orgId: '',
+                widgetId: ''
+            };
+
+            const chatSDKConfig = {
+                chatAdapterConfig: {
+                    webChatDirectLineVersion: 'version',
+                    webChatDirectLineCDNUrl: 'cdn'
+                }
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.DirectLine);
+
+            expect(url).toBe(chatSDKConfig.chatAdapterConfig.webChatDirectLineCDNUrl);
+        });
+
+        it('ChatSDK should pick the default webChatDirectLineCDNUrl if no chatAdapterConfig is set', async () => {
+            const omnichannelConfig = {
+                orgUrl: '',
+                orgId: '',
+                widgetId: ''
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.DirectLine);
+
+            expect(url).toBe(libraries.getDirectLineCDNUrl());
+        });
+
         it('ChatSDK should throw an error if ChatSDK.resolveChatAdapterUrl() is called with other protocol than supported protocols', async () => {
             const omnichannelConfig = {
                 orgUrl: '',

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -206,9 +206,10 @@ describe('Omnichannel Chat SDK', () => {
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
 
-            const protocol = ChatAdapterProtocols.DirectLine;
+            const protocol = "UnsupportedProtocol";
             try {
                 chatSDK.resolveChatAdapterUrl(protocol);
+                fail();
             } catch (error) {
                 expect(error.toString()).toContain(`ChatAdapter for protocol ${protocol} currently not supported`);
             }

--- a/__tests__/OmnichannelChatSDK.web.spec.ts
+++ b/__tests__/OmnichannelChatSDK.web.spec.ts
@@ -109,7 +109,7 @@ describe('Omnichannel Chat SDK (Web)', () => {
         jest.spyOn(platform, 'isReactNative').mockReturnValue(false);
         jest.spyOn(platform, 'isBrowser').mockReturnValue(true);
 
-        const protocol = 'DirectLine';
+        const protocol = 'UnsupportedProtocol';
         const optionalParams = {
             protocol
         }

--- a/__tests__/OmnichannelChatSDK.web.spec.ts
+++ b/__tests__/OmnichannelChatSDK.web.spec.ts
@@ -12,6 +12,7 @@ import CallingOptionsOptionSetNumber from "../src/core/CallingOptionsOptionSetNu
 import AriaTelemetry from "../src/telemetry/AriaTelemetry";
 import * as settings from '../src/config/settings';
 import { AWTLogManager } from "../src/external/aria/webjs/AriaSDK";
+import ChatSDKErrors from "../src/core/ChatSDKErrors";
 
 describe('Omnichannel Chat SDK (Web)', () => {
     (settings as any).ariaTelemetryKey = '';
@@ -65,6 +66,40 @@ describe('Omnichannel Chat SDK (Web)', () => {
         }
 
         expect(chatSDK.OCClient.sessionInit.mock.calls[0][1]).toMatchObject(sessionInitOptionalParams);
+    });
+
+    it('ChatSDK.startChat() with sendDefaultInitContext should throw an error if not used on Web Platform', async () => {
+        const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+        chatSDK.getChatConfig = jest.fn();
+
+        await chatSDK.initialize();
+
+        chatSDK.IC3Client = {
+            initialize: jest.fn(),
+            joinConversation: jest.fn()
+        }
+
+        const optionalParams = {
+            sendDefaultInitContext: true
+        }
+
+        jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve({
+            ChatId: '',
+            Token: '',
+            RegionGtms: '{}'
+        }));
+
+        jest.spyOn(chatSDK.OCClient, 'sessionInit').mockResolvedValue(Promise.resolve());
+
+        jest.spyOn(platform, 'isNode').mockReturnValue(true);
+        jest.spyOn(platform, 'isReactNative').mockReturnValue(false);
+        jest.spyOn(platform, 'isBrowser').mockReturnValue(false);
+
+        try {
+            await chatSDK.startChat(optionalParams);
+        } catch (error) {
+            expect(error.message).toEqual(ChatSDKErrors.UnsupportedPlatform);
+        }
     });
 
     it('ChatSDK.createChatAdapter() should be returned succesfully on Web platform', async () => {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1606,7 +1606,7 @@ class OmnichannelChatSDK {
                     }
                 }, () => {
                     this.scenarioMarker.failScenario(TelemetryEvent.CreateACSAdapter);
-                    reject('Failed to load ACSAdapter');
+                    throw new Error('Failed to load ACSAdapter');
                 });
             });
         } else if (protocol === ChatAdapterProtocols.IC3 || this.liveChatVersion === LiveChatVersion.V1) {
@@ -1639,7 +1639,7 @@ class OmnichannelChatSDK {
                     resolve(adapter);
                 }, () => {
                     this.scenarioMarker.failScenario(TelemetryEvent.CreateIC3Adapter);
-                    reject('Failed to load IC3Adapter');
+                    throw new Error('Failed to load IC3Adapter');
                 });
             });
         }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -80,6 +80,7 @@ import createVoiceVideoCalling from "./api/createVoiceVideoCalling";
 import { defaultMessageTags } from "./core/messaging/MessageTags";
 import {isCustomerMessage} from "./utils/utilities";
 import libraries from "./utils/libraries";
+import urlResolvers from "./utils/urlResolvers";
 import validateOmnichannelConfig from "./validators/OmnichannelConfigValidator";
 
 class OmnichannelChatSDK {
@@ -1917,15 +1918,7 @@ class OmnichannelChatSDK {
     }
 
     private resolveIC3ClientUrl(): string {
-        if (this.chatSDKConfig.ic3Config && 'ic3ClientCDNUrl' in this.chatSDKConfig.ic3Config) {
-            return this.chatSDKConfig.ic3Config.ic3ClientCDNUrl as string;
-        }
-
-        if (this.chatSDKConfig.ic3Config && 'ic3ClientVersion' in this.chatSDKConfig.ic3Config) {
-            return libraries.getIC3ClientCDNUrl(this.chatSDKConfig.ic3Config.ic3ClientVersion);
-        }
-
-        return libraries.getIC3ClientCDNUrl();
+        return urlResolvers.resolveIC3ClientUrl(this.chatSDKConfig);
     }
 
     private resolveChatAdapterUrl(protocol: string): string {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -79,7 +79,6 @@ import createTelemetry from "./utils/createTelemetry";
 import createVoiceVideoCalling from "./api/createVoiceVideoCalling";
 import { defaultMessageTags } from "./core/messaging/MessageTags";
 import {isCustomerMessage} from "./utils/utilities";
-import libraries from "./utils/libraries";
 import urlResolvers from "./utils/urlResolvers";
 import validateOmnichannelConfig from "./validators/OmnichannelConfigValidator";
 
@@ -1922,34 +1921,7 @@ class OmnichannelChatSDK {
     }
 
     private resolveChatAdapterUrl(protocol: string): string {
-        const supportedChatAdapterProtocols = [ChatAdapterProtocols.ACS, ChatAdapterProtocols.IC3];
-        if (protocol && !supportedChatAdapterProtocols.includes(protocol as string)) {
-            throw new Error(`ChatAdapter for protocol ${protocol} currently not supported`);
-        }
-
-        if (protocol === ChatAdapterProtocols.ACS || this.liveChatVersion === LiveChatVersion.V2) {
-            if (this.chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterCDNUrl' in this.chatSDKConfig.chatAdapterConfig) {
-                return this.chatSDKConfig.chatAdapterConfig.webChatACSAdapterCDNUrl as string;
-            }
-
-            if (this.chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterVersion' in this.chatSDKConfig.chatAdapterConfig) {
-                return libraries.getACSAdapterCDNUrl(this.chatSDKConfig.chatAdapterConfig.webChatACSAdapterVersion);
-            }
-
-            return libraries.getACSAdapterCDNUrl();
-        } else if (protocol === ChatAdapterProtocols.IC3 || this.liveChatVersion === LiveChatVersion.V1) {
-            if (this.chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterCDNUrl' in this.chatSDKConfig.chatAdapterConfig) {
-                return this.chatSDKConfig.chatAdapterConfig.webChatIC3AdapterCDNUrl as string;
-            }
-
-            if (this.chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterVersion' in this.chatSDKConfig.chatAdapterConfig) {
-                return libraries.getIC3AdapterCDNUrl(this.chatSDKConfig.chatAdapterConfig.webChatIC3AdapterVersion);
-            }
-
-            return libraries.getIC3AdapterCDNUrl();
-        }
-
-        return '';
+        return urlResolvers.resolveChatAdapterUrl(this.chatSDKConfig, this.liveChatVersion, protocol);
     }
 
     private async updateChatToken(newToken: string, newRegionGTMS: IRegionGtms): Promise<void> {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1447,7 +1447,6 @@ class OmnichannelChatSDK {
         });
 
         try {
-
             if (this.authenticatedUserToken) {
                 emailTranscriptOptionalParams.authenticatedUserToken = this.authenticatedUserToken;
             }
@@ -1555,7 +1554,7 @@ class OmnichannelChatSDK {
                 });
             });
         } else if (protocol === ChatAdapterProtocols.ACS || this.liveChatVersion === LiveChatVersion.V2) {
-            return new Promise (async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
+            return new Promise (async (resolve) => { // eslint-disable-line no-async-promise-executor
                 const options = optionalParams.ACSAdapter? optionalParams.ACSAdapter.options: {};
 
                 // Tags formatting middlewares are required to be the last in the pipeline to ensure tags are converted to the right format

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -19,6 +19,7 @@ import ChatConfig from "./core/ChatConfig";
 import ChatReconnectContext from "./core/ChatReconnectContext";
 import ChatReconnectOptionalParams from "./core/ChatReconnectOptionalParams";
 import ChatSDKConfig from "./core/ChatSDKConfig";
+import ChatSDKErrors from "./core/ChatSDKErrors";
 import ChatSDKExceptionDetails from "./core/ChatSDKExceptionDetails";
 import ChatSDKMessage from "./core/messaging/ChatSDKMessage";
 import ChatTranscriptBody from "./core/ChatTranscriptBody";
@@ -452,7 +453,7 @@ class OmnichannelChatSDK {
         if (optionalParams.sendDefaultInitContext) {
             if (platform.isNode() || platform.isReactNative()) {
                 const exceptionDetails: ChatSDKExceptionDetails = {
-                    response: "UnsupportedPlatform",
+                    response: ChatSDKErrors.UnsupportedPlatform,
                     message: "sendDefaultInitContext is only supported on browser"
                 };
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1547,6 +1547,8 @@ class OmnichannelChatSDK {
                     ACSAdapter: acsAdapterCDNUrl
                 });
 
+                this.scenarioMarker.startScenario(TelemetryEvent.CreateACSAdapter);
+
                 await loadScript(acsAdapterCDNUrl, () => {
                     /* istanbul ignore next */
                     this.debug && console.debug('ACSAdapter loaded!');
@@ -1566,12 +1568,15 @@ class OmnichannelChatSDK {
                             featuresOption,
                         );
 
+                        this.scenarioMarker.completeScenario(TelemetryEvent.CreateACSAdapter);
+
                         resolve(adapter);
                     } catch {
                         throw new Error('Failed to load ACSAdapter');
                     }
                 }, () => {
-                    reject('Failed to load ACSADapter');
+                    this.scenarioMarker.failScenario(TelemetryEvent.CreateACSAdapter);
+                    reject('Failed to load ACSAdapter');
                 });
             });
         } else if (protocol === ChatAdapterProtocols.IC3 || this.liveChatVersion === LiveChatVersion.V1) {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -82,6 +82,7 @@ import { defaultMessageTags } from "./core/messaging/MessageTags";
 import {isCustomerMessage} from "./utils/utilities";
 import urlResolvers from "./utils/urlResolvers";
 import validateOmnichannelConfig from "./validators/OmnichannelConfigValidator";
+import { createDirectLine } from "./utils/chatAdapterCreators";
 
 class OmnichannelChatSDK {
     private debug: boolean;
@@ -1525,35 +1526,7 @@ class OmnichannelChatSDK {
         }
 
         if (protocol === ChatAdapterProtocols.DirectLine) {
-            return new Promise (async (resolve) => { // eslint-disable-line no-async-promise-executor
-                const options = optionalParams.DirectLine? optionalParams.DirectLine.options: {};
-
-                const directLineCDNUrl = this.resolveChatAdapterUrl(protocol || ChatAdapterProtocols.DirectLine);
-
-                this.telemetry?.setCDNPackages({
-                    DirectLine: directLineCDNUrl
-                });
-
-                this.scenarioMarker.startScenario(TelemetryEvent.CreateDirectLine);
-
-                await loadScript(directLineCDNUrl, () => {
-                    /* istanbul ignore next */
-                    this.debug && console.debug('DirectLine loaded!');
-                    try {
-                        const {DirectLine} = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-                        const adapter = new DirectLine.DirectLine({...options});
-
-                        this.scenarioMarker.completeScenario(TelemetryEvent.CreateDirectLine);
-
-                        resolve(adapter);
-                    } catch {
-                        throw new Error('Failed to load DirectLine');
-                    }
-                }, () => {
-                    this.scenarioMarker.failScenario(TelemetryEvent.CreateDirectLine);
-                    throw new Error('Failed to load DirectLine');
-                });
-            });
+            return createDirectLine(optionalParams, this.chatSDKConfig, this.liveChatVersion, ChatAdapterProtocols.DirectLine, this.telemetry as typeof AriaTelemetry, this.scenarioMarker);
         } else if (protocol === ChatAdapterProtocols.ACS || this.liveChatVersion === LiveChatVersion.V2) {
             return new Promise (async (resolve) => { // eslint-disable-line no-async-promise-executor
                 const options = optionalParams.ACSAdapter? optionalParams.ACSAdapter.options: {};

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,11 +1,13 @@
 const ic3ClientVersion = '2021.08.14.1';
 const webChatIC3AdapterVersion = '0.1.0-master.2dba07b';
 const webChatACSAdapterVersion = '0.0.35-beta.12';
+const webChatDirectLineVersion = '0.15.1';
 const ariaTelemetryKey = 'c7655518acf1403f93ff6b9f77942f0a-d01a02fd-6b50-4de3-a566-62eda11f93bc-7083';
 
 export {
     ic3ClientVersion,
     webChatIC3AdapterVersion,
     webChatACSAdapterVersion,
+    webChatDirectLineVersion,
     ariaTelemetryKey
 };

--- a/src/core/ChatSDKErrors.ts
+++ b/src/core/ChatSDKErrors.ts
@@ -1,0 +1,5 @@
+enum ChatSDKErrors {
+    UnsupportedPlatform = "UnsupportedPlatform"
+}
+
+export default ChatSDKErrors;

--- a/src/core/messaging/ChatAdapterConfig.ts
+++ b/src/core/messaging/ChatAdapterConfig.ts
@@ -3,4 +3,6 @@ export default interface ChatAdapterConfig {
     webChatIC3AdapterCDNUrl?: string;
     webChatACSAdapterVersion?: string;
     webChatACSAdapterCDNUrl?: string;
+    webChatDirectLineVersion?: string;
+    webChatDirectLineCDNUrl?: string;
 }

--- a/src/core/messaging/ChatAdapterOptionalParams.ts
+++ b/src/core/messaging/ChatAdapterOptionalParams.ts
@@ -4,12 +4,17 @@ interface ChatAdapterOptionalParams {
         options?: {
             [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
         }
-    }
+    };
     ACSAdapter?: {
         options?: {
             [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
         }
-    }
+    };
+    DirectLine?: {
+        options?: {
+            [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
+        }
+    };
 }
 
 export default ChatAdapterOptionalParams;

--- a/src/telemetry/AriaTelemetry.ts
+++ b/src/telemetry/AriaTelemetry.ts
@@ -35,6 +35,7 @@ interface CDNPackagesInfo {
     IC3Client?: string;
     IC3Adapter?: string;
     ACSAdapter?: string;
+    DirectLine?: string;
     SpoolSDK?: string;
     VoiceVideoCalling?: string;
 }

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -22,6 +22,7 @@ enum TelemetryEvent {
     GetLiveChatTranscript = "GetLiveChatTranscript",
     CreateIC3Adapter = "CreateChatAdapter",
     CreateACSAdapter = "CreateACSAdapter",
+    CreateDirectLine = "CreateDirectLine",
     GetVoiceVideoCalling = "GetVoiceVideoCalling",
     GetIC3Client = "GetIC3Client",
     InitializeVoiceVideoCallingSDK = "InitializeVoiceVideoCallingSDK",

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -99,7 +99,7 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
     }
 };
 
-const createIC3Adapter = async (optionalParams: ChatAdapterOptionalParams, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker, chatToken: IChatToken, ic3Client: any, logger: IC3ClientLogger): Promise<unknown> => {
+const createIC3Adapter = async (optionalParams: ChatAdapterOptionalParams, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker, chatToken: IChatToken, ic3Client: any, logger: IC3ClientLogger): Promise<unknown> => { // eslint-disable-line @typescript-eslint/no-explicit-any,  @typescript-eslint/explicit-module-boundary-types
     const options = optionalParams.IC3Adapter? optionalParams.IC3Adapter.options: {};
     const ic3AdapterCDNUrl = urlResolvers.resolveChatAdapterUrl(chatSDKConfig, liveChatVersion, protocol);
 

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -1,13 +1,22 @@
+import { ACSAdapterLogger } from "./loggers";
+import ACSParticipantDisplayName from "../core/messaging/ACSParticipantDisplayName";
+import AMSFileManager from "../external/ACSAdapter/AMSFileManager";
 import AriaTelemetry from "../telemetry/AriaTelemetry";
 import ChatAdapterOptionalParams from "../core/messaging/ChatAdapterOptionalParams";
+import { ChatClient } from "@azure/communication-chat";
 import ChatSDKConfig from "../core/ChatSDKConfig";
+import createChannelDataEgressMiddleware from "../external/ACSAdapter/createChannelDataEgressMiddleware";
+import createFormatEgressTagsMiddleware from "../external/ACSAdapter/createFormatEgressTagsMiddleware";
+import createFormatIngressTagsMiddleware from "../external/ACSAdapter/createFormatIngressTagsMiddleware";
+import IChatToken from "../external/IC3Adapter/IChatToken";
 import LiveChatVersion from "../core/LiveChatVersion";
 import { loadScript } from "./WebUtils";
+import OmnichannelConfig from "../core/OmnichannelConfig";
 import ScenarioMarker from "../telemetry/ScenarioMarker";
 import TelemetryEvent from "../telemetry/TelemetryEvent";
 import urlResolvers from "./urlResolvers";
 
-const createDirectLine = async (optionalParams: ChatAdapterOptionalParams = {}, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker): Promise<unknown> => {
+const createDirectLine = async (optionalParams: ChatAdapterOptionalParams, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker): Promise<unknown> => {
     const options = optionalParams.DirectLine? optionalParams.DirectLine.options: {};
     const directLineCDNUrl = urlResolvers.resolveChatAdapterUrl(chatSDKConfig, liveChatVersion, protocol);
 
@@ -33,10 +42,63 @@ const createDirectLine = async (optionalParams: ChatAdapterOptionalParams = {}, 
     }
 };
 
+const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker, omnichannelConfig: OmnichannelConfig, chatToken: IChatToken, fileManager: AMSFileManager, chatClient: ChatClient, logger: ACSAdapterLogger): Promise<unknown> => {    const options = optionalParams.ACSAdapter? optionalParams.ACSAdapter.options: {};
+    const acsAdapterCDNUrl = urlResolvers.resolveChatAdapterUrl(chatSDKConfig, liveChatVersion, protocol);
+
+    telemetry?.setCDNPackages({
+        ACSAdapter: acsAdapterCDNUrl
+    });
+
+    // Tags formatting middlewares are required to be the last in the pipeline to ensure tags are converted to the right format
+    const defaultEgressMiddlewares = [createChannelDataEgressMiddleware({widgetId: omnichannelConfig.widgetId}), createFormatEgressTagsMiddleware()];
+    const defaultIngressMiddlewares = [createFormatIngressTagsMiddleware()];
+    const egressMiddleware = options?.egressMiddleware? [...options.egressMiddleware, ...defaultEgressMiddlewares]: [...defaultEgressMiddlewares];
+    const ingressMiddleware = options?.ingressMiddleware? [...options.egressMiddleware, ...defaultIngressMiddlewares]: [...defaultIngressMiddlewares];
+    const featuresOption = {
+        enableAdaptiveCards: true, // Whether to enable adaptive card payload in adapter (payload in JSON string)
+        enableThreadMemberUpdateNotification: true, // Whether to enable chat thread member join/leave notification
+        enableLeaveThreadOnWindowClosed: false, // Whether to remove user on browser close event
+        ...options, // overrides
+        ingressMiddleware,
+        egressMiddleware
+    };
+
+    scenarioMarker.startScenario(TelemetryEvent.CreateACSAdapter);
+
+    try {
+        await loadScript(acsAdapterCDNUrl);
+    } catch {
+        throw new Error('Failed to load ACSAdapter');
+    }
+
+    try {
+        const { ChatAdapter } = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const adapter = ChatAdapter.createACSAdapter(
+            chatToken.token as string,
+            chatToken.visitorId || 'teamsvisitor',
+            chatToken.chatId as string,
+            chatToken.acsEndpoint as string,
+            fileManager,
+            30000,
+            ACSParticipantDisplayName.Customer,
+            chatClient,
+            logger,
+            featuresOption,
+        );
+
+        scenarioMarker.completeScenario(TelemetryEvent.CreateACSAdapter);
+        return adapter;
+    } catch {
+        throw new Error('Failed to create ACSAdapter');
+    }
+};
+
 export default {
-    createDirectLine
+    createDirectLine,
+    createACSAdapter
 };
 
 export {
-    createDirectLine
+    createDirectLine,
+    createACSAdapter
 };

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -42,7 +42,8 @@ const createDirectLine = async (optionalParams: ChatAdapterOptionalParams, chatS
     }
 };
 
-const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker, omnichannelConfig: OmnichannelConfig, chatToken: IChatToken, fileManager: AMSFileManager, chatClient: ChatClient, logger: ACSAdapterLogger): Promise<unknown> => {    const options = optionalParams.ACSAdapter? optionalParams.ACSAdapter.options: {};
+const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker, omnichannelConfig: OmnichannelConfig, chatToken: IChatToken, fileManager: AMSFileManager, chatClient: ChatClient, logger: ACSAdapterLogger): Promise<unknown> => {
+    const options = optionalParams.ACSAdapter? optionalParams.ACSAdapter.options: {};
     const acsAdapterCDNUrl = urlResolvers.resolveChatAdapterUrl(chatSDKConfig, liveChatVersion, protocol);
 
     telemetry?.setCDNPackages({

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -1,0 +1,46 @@
+import AriaTelemetry from "../telemetry/AriaTelemetry";
+import ChatAdapterOptionalParams from "../core/messaging/ChatAdapterOptionalParams";
+import ChatSDKConfig from "../core/ChatSDKConfig";
+import LiveChatVersion from "../core/LiveChatVersion";
+import { loadScript } from "./WebUtils";
+import ScenarioMarker from "../telemetry/ScenarioMarker";
+import TelemetryEvent from "../telemetry/TelemetryEvent";
+import urlResolvers from "./urlResolvers";
+
+const createDirectLine = (optionalParams: ChatAdapterOptionalParams = {}, chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string, telemetry: typeof AriaTelemetry, scenarioMarker: ScenarioMarker): Promise<unknown> => {
+    return new Promise (async (resolve) => { // eslint-disable-line no-async-promise-executor
+        const options = optionalParams.DirectLine? optionalParams.DirectLine.options: {};
+
+        const directLineCDNUrl = urlResolvers.resolveChatAdapterUrl(chatSDKConfig, liveChatVersion, protocol);
+
+        telemetry?.setCDNPackages({
+            DirectLine: directLineCDNUrl
+        });
+
+        scenarioMarker.startScenario(TelemetryEvent.CreateDirectLine);
+
+        await loadScript(directLineCDNUrl, () => {
+            try {
+                const {DirectLine} = window as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+                const adapter = new DirectLine.DirectLine({...options});
+
+                scenarioMarker.completeScenario(TelemetryEvent.CreateDirectLine);
+
+                resolve(adapter);
+            } catch {
+                throw new Error('Failed to load DirectLine');
+            }
+        }, () => {
+            scenarioMarker.failScenario(TelemetryEvent.CreateDirectLine);
+            throw new Error('Failed to load DirectLine');
+        });
+    });
+};
+
+export default {
+    createDirectLine
+};
+
+export {
+    createDirectLine
+};

--- a/src/utils/libraries.ts
+++ b/src/utils/libraries.ts
@@ -1,4 +1,4 @@
-import { ic3ClientVersion, webChatACSAdapterVersion, webChatIC3AdapterVersion } from "../config/settings";
+import { ic3ClientVersion, webChatACSAdapterVersion, webChatDirectLineVersion, webChatIC3AdapterVersion } from "../config/settings";
 
 const getIC3ClientCDNUrl = (version = ic3ClientVersion): string => {
     const IC3ClientCDNUrl = `https://comms.omnichannelengagementhub.com/release/${version}/Scripts/SDK/SDK.min.js`;
@@ -15,14 +15,21 @@ const getACSAdapterCDNUrl = (version = webChatACSAdapterVersion): string => {
     return ACSAdapterCDNUrl;
 }
 
+const getDirectLineCDNUrl = (version = webChatDirectLineVersion): string => {
+    const DirectLineCDNUrl = `https://unpkg.com/botframework-directlinejs@${version}/dist/directline.js`;
+    return DirectLineCDNUrl;
+}
+
 export default {
     getIC3ClientCDNUrl,
     getIC3AdapterCDNUrl,
-    getACSAdapterCDNUrl
+    getACSAdapterCDNUrl,
+    getDirectLineCDNUrl
 }
 
 export {
     getIC3ClientCDNUrl,
     getIC3AdapterCDNUrl,
-    getACSAdapterCDNUrl
+    getACSAdapterCDNUrl,
+    getDirectLineCDNUrl
 }

--- a/src/utils/urlResolvers.ts
+++ b/src/utils/urlResolvers.ts
@@ -1,0 +1,22 @@
+import ChatSDKConfig from "../core/ChatSDKConfig";
+import libraries from "./libraries";
+
+const resolveIC3ClientUrl = (chatSDKConfig: ChatSDKConfig): string => {
+    if (chatSDKConfig.ic3Config && 'ic3ClientCDNUrl' in chatSDKConfig.ic3Config) {
+        return chatSDKConfig.ic3Config.ic3ClientCDNUrl as string;
+    }
+
+    if (chatSDKConfig.ic3Config && 'ic3ClientVersion' in chatSDKConfig.ic3Config) {
+        return libraries.getIC3ClientCDNUrl(chatSDKConfig.ic3Config.ic3ClientVersion);
+    }
+
+    return libraries.getIC3ClientCDNUrl();
+};
+
+export default {
+    resolveIC3ClientUrl
+}
+
+export {
+    resolveIC3ClientUrl
+}

--- a/src/utils/urlResolvers.ts
+++ b/src/utils/urlResolvers.ts
@@ -16,12 +16,22 @@ const resolveIC3ClientUrl = (chatSDKConfig: ChatSDKConfig): string => {
 };
 
 const resolveChatAdapterUrl = (chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string): string => {
-    const supportedChatAdapterProtocols = [ChatAdapterProtocols.ACS, ChatAdapterProtocols.IC3];
+    const supportedChatAdapterProtocols = [ChatAdapterProtocols.ACS, ChatAdapterProtocols.IC3, ChatAdapterProtocols.DirectLine];
     if (protocol && !supportedChatAdapterProtocols.includes(protocol as string)) {
         throw new Error(`ChatAdapter for protocol ${protocol} currently not supported`);
     }
 
-    if (protocol === ChatAdapterProtocols.ACS || liveChatVersion === LiveChatVersion.V2) {
+    if (protocol === ChatAdapterProtocols.DirectLine) {
+        if (chatSDKConfig.chatAdapterConfig && 'webChatDirectLineCDNUrl' in chatSDKConfig.chatAdapterConfig) {
+            return chatSDKConfig.chatAdapterConfig.webChatDirectLineCDNUrl as string;
+        }
+
+        if (chatSDKConfig.chatAdapterConfig && 'webChatDirectLineVersion' in chatSDKConfig.chatAdapterConfig) {
+            return libraries.getDirectLineCDNUrl(chatSDKConfig.chatAdapterConfig.webChatDirectLineVersion);
+        }
+
+        return libraries.getDirectLineCDNUrl();
+    } else if (protocol === ChatAdapterProtocols.ACS || liveChatVersion === LiveChatVersion.V2) {
         if (chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterCDNUrl' in chatSDKConfig.chatAdapterConfig) {
             return chatSDKConfig.chatAdapterConfig.webChatACSAdapterCDNUrl as string;
         }

--- a/src/utils/urlResolvers.ts
+++ b/src/utils/urlResolvers.ts
@@ -1,4 +1,6 @@
 import ChatSDKConfig from "../core/ChatSDKConfig";
+import LiveChatVersion from "../core/LiveChatVersion";
+import ChatAdapterProtocols from "../core/messaging/ChatAdapterProtocols";
 import libraries from "./libraries";
 
 const resolveIC3ClientUrl = (chatSDKConfig: ChatSDKConfig): string => {
@@ -13,10 +15,43 @@ const resolveIC3ClientUrl = (chatSDKConfig: ChatSDKConfig): string => {
     return libraries.getIC3ClientCDNUrl();
 };
 
+const resolveChatAdapterUrl = (chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string): string => {
+    const supportedChatAdapterProtocols = [ChatAdapterProtocols.ACS, ChatAdapterProtocols.IC3];
+    if (protocol && !supportedChatAdapterProtocols.includes(protocol as string)) {
+        throw new Error(`ChatAdapter for protocol ${protocol} currently not supported`);
+    }
+
+    if (protocol === ChatAdapterProtocols.ACS || liveChatVersion === LiveChatVersion.V2) {
+        if (chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterCDNUrl' in chatSDKConfig.chatAdapterConfig) {
+            return chatSDKConfig.chatAdapterConfig.webChatACSAdapterCDNUrl as string;
+        }
+
+        if (chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterVersion' in chatSDKConfig.chatAdapterConfig) {
+            return libraries.getACSAdapterCDNUrl(chatSDKConfig.chatAdapterConfig.webChatACSAdapterVersion);
+        }
+
+        return libraries.getACSAdapterCDNUrl();
+    } else if (protocol === ChatAdapterProtocols.IC3 || liveChatVersion === LiveChatVersion.V1) {
+        if (chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterCDNUrl' in chatSDKConfig.chatAdapterConfig) {
+            return chatSDKConfig.chatAdapterConfig.webChatIC3AdapterCDNUrl as string;
+        }
+
+        if (chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterVersion' in chatSDKConfig.chatAdapterConfig) {
+            return libraries.getIC3AdapterCDNUrl(chatSDKConfig.chatAdapterConfig.webChatIC3AdapterVersion);
+        }
+
+        return libraries.getIC3AdapterCDNUrl();
+    }
+
+    return '';
+}
+
 export default {
-    resolveIC3ClientUrl
+    resolveIC3ClientUrl,
+    resolveChatAdapterUrl
 }
 
 export {
-    resolveIC3ClientUrl
+    resolveIC3ClientUrl,
+    resolveChatAdapterUrl
 }

--- a/src/utils/urlResolvers.ts
+++ b/src/utils/urlResolvers.ts
@@ -15,6 +15,42 @@ const resolveIC3ClientUrl = (chatSDKConfig: ChatSDKConfig): string => {
     return libraries.getIC3ClientCDNUrl();
 };
 
+const resolveDirectLineCDNUrl = (chatSDKConfig: ChatSDKConfig) => {
+    if (chatSDKConfig.chatAdapterConfig && 'webChatDirectLineCDNUrl' in chatSDKConfig.chatAdapterConfig) {
+        return chatSDKConfig.chatAdapterConfig.webChatDirectLineCDNUrl as string;
+    }
+
+    if (chatSDKConfig.chatAdapterConfig && 'webChatDirectLineVersion' in chatSDKConfig.chatAdapterConfig) {
+        return libraries.getDirectLineCDNUrl(chatSDKConfig.chatAdapterConfig.webChatDirectLineVersion);
+    }
+
+    return libraries.getDirectLineCDNUrl();
+}
+
+const resolveACSAdapterCDNUrl = (chatSDKConfig: ChatSDKConfig) => {
+    if (chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterCDNUrl' in chatSDKConfig.chatAdapterConfig) {
+        return chatSDKConfig.chatAdapterConfig.webChatACSAdapterCDNUrl as string;
+    }
+
+    if (chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterVersion' in chatSDKConfig.chatAdapterConfig) {
+        return libraries.getACSAdapterCDNUrl(chatSDKConfig.chatAdapterConfig.webChatACSAdapterVersion);
+    }
+
+    return libraries.getACSAdapterCDNUrl();
+};
+
+const resolveIC3AdapterCDNUrl = (chatSDKConfig: ChatSDKConfig) => {
+    if (chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterCDNUrl' in chatSDKConfig.chatAdapterConfig) {
+        return chatSDKConfig.chatAdapterConfig.webChatIC3AdapterCDNUrl as string;
+    }
+
+    if (chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterVersion' in chatSDKConfig.chatAdapterConfig) {
+        return libraries.getIC3AdapterCDNUrl(chatSDKConfig.chatAdapterConfig.webChatIC3AdapterVersion);
+    }
+
+    return libraries.getIC3AdapterCDNUrl();
+};
+
 const resolveChatAdapterUrl = (chatSDKConfig: ChatSDKConfig, liveChatVersion: LiveChatVersion, protocol: string): string => {
     const supportedChatAdapterProtocols = [ChatAdapterProtocols.ACS, ChatAdapterProtocols.IC3, ChatAdapterProtocols.DirectLine];
     if (protocol && !supportedChatAdapterProtocols.includes(protocol as string)) {
@@ -22,39 +58,15 @@ const resolveChatAdapterUrl = (chatSDKConfig: ChatSDKConfig, liveChatVersion: Li
     }
 
     if (protocol === ChatAdapterProtocols.DirectLine) {
-        if (chatSDKConfig.chatAdapterConfig && 'webChatDirectLineCDNUrl' in chatSDKConfig.chatAdapterConfig) {
-            return chatSDKConfig.chatAdapterConfig.webChatDirectLineCDNUrl as string;
-        }
-
-        if (chatSDKConfig.chatAdapterConfig && 'webChatDirectLineVersion' in chatSDKConfig.chatAdapterConfig) {
-            return libraries.getDirectLineCDNUrl(chatSDKConfig.chatAdapterConfig.webChatDirectLineVersion);
-        }
-
-        return libraries.getDirectLineCDNUrl();
+        return resolveDirectLineCDNUrl(chatSDKConfig);
     } else if (protocol === ChatAdapterProtocols.ACS || liveChatVersion === LiveChatVersion.V2) {
-        if (chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterCDNUrl' in chatSDKConfig.chatAdapterConfig) {
-            return chatSDKConfig.chatAdapterConfig.webChatACSAdapterCDNUrl as string;
-        }
-
-        if (chatSDKConfig.chatAdapterConfig && 'webChatACSAdapterVersion' in chatSDKConfig.chatAdapterConfig) {
-            return libraries.getACSAdapterCDNUrl(chatSDKConfig.chatAdapterConfig.webChatACSAdapterVersion);
-        }
-
-        return libraries.getACSAdapterCDNUrl();
+        return resolveACSAdapterCDNUrl(chatSDKConfig);
     } else if (protocol === ChatAdapterProtocols.IC3 || liveChatVersion === LiveChatVersion.V1) {
-        if (chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterCDNUrl' in chatSDKConfig.chatAdapterConfig) {
-            return chatSDKConfig.chatAdapterConfig.webChatIC3AdapterCDNUrl as string;
-        }
-
-        if (chatSDKConfig.chatAdapterConfig && 'webChatIC3AdapterVersion' in chatSDKConfig.chatAdapterConfig) {
-            return libraries.getIC3AdapterCDNUrl(chatSDKConfig.chatAdapterConfig.webChatIC3AdapterVersion);
-        }
-
-        return libraries.getIC3AdapterCDNUrl();
+        return resolveIC3AdapterCDNUrl(chatSDKConfig);
     }
 
     return '';
-}
+};
 
 export default {
     resolveIC3ClientUrl,


### PR DESCRIPTION
- Allow `ChatSDK.createChatAdapter()` to return adapter for `DirectLine` protocol
- Add telemetry event for `CreateACSAdapter`

```
const chatAdapter = await chatSDK.createChatAdapter({
  protocol: 'DirectLine',
  DirectLine: {
    options: {
      token: 'token'
    }
  }
});
```