### PR TITLE
Create Chat Adapter Error Handling & Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add ability to use `ChatSDK.createChatAdapter()` for `DirectLine` protocol
 - Add `CreateACSAdapter` telemetry event
+- Improve `ChatSDK.createChatAdapter()` with retries using exponential backoff & additional details on failures
 
 ### Fixed
 - Fix `ChatAdapterOptionalParams.ACSAdapter.options.egressMiddleware` being used as `ingressMiddleware`

--- a/__tests__/utils/sleep.spec.ts
+++ b/__tests__/utils/sleep.spec.ts
@@ -1,0 +1,16 @@
+import sleep from "../../src/utils/sleep";
+
+describe('Sleep', () => {
+    it('sleep() should delay function execution', async () => {
+        const delay = 5 * 1000;
+        const threshold = delay * (50/100);
+        const before = new Date().getTime();
+        await sleep(delay);
+        const after = new Date().getTime();
+        const difference = after - before;
+        const lowerBound = delay - threshold;
+        const upperbound = delay + threshold;
+
+        expect(difference >= lowerBound && difference <= upperbound).toBe(true);
+    }, 10 * 1000);
+});

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -516,12 +516,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
     test('ChatSDK.createChatAdapter() should load ACSAdapter', async ({page}) => {
         await page.goto(testPage);
 
-        const [createChatAdapterRequest, runtimeContext] = await Promise.all([
-            page.waitForRequest(request => {
-                return request.url().includes("https://unpkg.com/acs_webchat-chat-adapter");
+        const [createChatAdapterResponse, runtimeContext] = await Promise.all([
+            page.waitForResponse(response => {
+                return response.url().includes("https://unpkg.com/acs_webchat-chat-adapter");
             }),
             await page.evaluate(async ({ omnichannelConfig }) => {
-                const { sleep, preloadChatAdapter } = window;
+                const { preloadChatAdapter } = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -547,6 +547,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             }, { omnichannelConfig })
         ]);
 
+        expect(createChatAdapterResponse.status()).toBe(200);
         expect(runtimeContext.errorMessage).not.toBeDefined();
         expect(runtimeContext.errorObject).not.toBeDefined();
     });

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -566,7 +566,6 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
 
         const [runtimeContext] = await Promise.all([
             await page.evaluate(async ({ omnichannelConfig }) => {
-                const { patchLoadScript } = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -579,7 +578,6 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 await chatSDK.startChat();
 
                 try {
-                    patchLoadScript();
                     const chatAdapter = await chatSDK.createChatAdapter();
                 } catch (err) {
                     runtimeContext.errorMessage = `${err.message}`;

--- a/playwright/integrations/utilities.spec.ts
+++ b/playwright/integrations/utilities.spec.ts
@@ -62,4 +62,44 @@ test.describe('Utilities @Utilities', () => {
         expect(runtimeContext?.errorMessage).toBeDefined();
         expect(runtimeContext?.errorMessage).toBe(expectedErrorMessage);
     });
+
+    test('WebUtils.loadScript() retries should be using exponential backoff', async ({page}) => {
+        test.setTimeout(60 * 1000);
+
+        await page.goto(testPage);
+
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async () => {
+                const {require_WebUtils, require_libraries} = window;
+                const WebUtils = require_WebUtils();
+                const libraries = require_libraries();
+                const scriptURL = `${libraries.getACSAdapterCDNUrl()}/invalid`;
+
+                const runtimeContext = {};
+
+                try {
+                    await WebUtils.default.loadScript(scriptURL, () => {}, () => {}, 4);
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                }
+
+                runtimeContext.traces = performance.getEntries().filter((entry) => entry.initiatorType === 'script' && entry.name === scriptURL);
+
+                return runtimeContext;
+            })
+        ]);
+
+        const createDifference = (arr) => {
+            const differenceArray = [];
+            for (let i = 1; i < arr.length; i++) {
+                differenceArray.push(arr[i].startTime - arr[i - 1].startTime);
+            }
+
+            return differenceArray;
+        };
+
+        const isAscending = (arr) => arr.every((value, index) => index === 0 || value >= arr[index - 1])
+        const differenceArray = createDifference(runtimeContext.traces);
+        expect(isAscending(differenceArray)).toBe(true);
+    });
 });

--- a/playwright/integrations/utilities.spec.ts
+++ b/playwright/integrations/utilities.spec.ts
@@ -1,0 +1,65 @@
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import { test, expect } from '@playwright/test';
+
+const testPage = fetchTestPageUrl();
+
+test.describe('Utilities @Utilities', () => {
+    test('WebUtils.loadScript() should add the script in the DOM', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async () => {
+                const {require_WebUtils, require_libraries} = window;
+                const WebUtils = require_WebUtils();
+                const libraries = require_libraries();
+                const scriptURL = libraries.getACSAdapterCDNUrl();
+
+                const runtimeContext = {};
+                runtimeContext.expectedScriptUrl = scriptURL;
+
+                try {
+                    await WebUtils.default.loadScript(scriptURL);
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                }
+
+                const scriptElements = document.getElementsByTagName('script');
+                const result = Array.from(scriptElements).filter((script) => script.src === scriptURL);
+                runtimeContext.loadedScriptUrl = result[0].src;
+
+                return runtimeContext;
+            })
+        ]);
+
+        expect(runtimeContext?.errorMessage).not.toBeDefined();
+        expect(runtimeContext.loadedScriptUrl).toBeDefined();
+        expect(runtimeContext.loadedScriptUrl === runtimeContext.expectedScriptUrl).toBe(true);
+    });
+
+    test('WebUtils.loadScript() failure should return an error message', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async () => {
+                const {require_WebUtils, require_libraries} = window;
+                const WebUtils = require_WebUtils();
+                const libraries = require_libraries();
+                const scriptURL = `${libraries.getACSAdapterCDNUrl()}/invalid`;
+
+                const runtimeContext = {};
+
+                try {
+                    await WebUtils.default.loadScript(scriptURL);
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                }
+
+                return runtimeContext;
+            })
+        ]);
+
+        const expectedErrorMessage = "Resource failed to load, or can't be used.";
+        expect(runtimeContext?.errorMessage).toBeDefined();
+        expect(runtimeContext?.errorMessage).toBe(expectedErrorMessage);
+    });
+});

--- a/playwright/public/scripts/globals.js
+++ b/playwright/public/scripts/globals.js
@@ -1,3 +1,12 @@
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+const preloadChatAdapter = async () => {
+    const {require_libraries, require_WebUtils} = window;
+    const chatAdapterUrl = require_libraries().getACSAdapterCDNUrl();
+    const loadScript = require_WebUtils().default.loadScript;
+    exports = undefined; // Fix for ChatAdapter not available in window object;
+    await loadScript(chatAdapterUrl);
+};
+
 window.sleep = sleep;
+window.preloadChatAdapter = preloadChatAdapter;

--- a/playwright/public/scripts/globals.js
+++ b/playwright/public/scripts/globals.js
@@ -1,5 +1,14 @@
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+const patchLoadScript = () => {
+    const { require_WebUtils} = window;
+    const loadScript = require_WebUtils().default.loadScript;
+    require_WebUtils().default.loadScript = async (scriptUrl, callbackOnload, callbackError, retries, attempt) => {
+        exports = undefined;
+        await loadScript(scriptUrl, callbackOnload, callbackError, retries, attempt);
+    }
+};
+
 const preloadChatAdapter = async () => {
     const {require_libraries, require_WebUtils} = window;
     const chatAdapterUrl = require_libraries().getACSAdapterCDNUrl();
@@ -9,4 +18,5 @@ const preloadChatAdapter = async () => {
 };
 
 window.sleep = sleep;
+window.patchLoadScript = patchLoadScript;
 window.preloadChatAdapter = preloadChatAdapter;

--- a/src/core/ChatSDKErrors.ts
+++ b/src/core/ChatSDKErrors.ts
@@ -1,4 +1,5 @@
 enum ChatSDKErrors {
+    ChatAdapterInitializationFailure = "ChatAdapterInitializationFailure",
     ScriptLoadFailure = "ScriptLoadFailure",
     UnsupportedPlatform = "UnsupportedPlatform"
 }

--- a/src/core/ChatSDKErrors.ts
+++ b/src/core/ChatSDKErrors.ts
@@ -1,4 +1,5 @@
 enum ChatSDKErrors {
+    ScriptLoadFailure = "ScriptLoadFailure",
     UnsupportedPlatform = "UnsupportedPlatform"
 }
 

--- a/src/core/ChatSDKExceptionDetails.ts
+++ b/src/core/ChatSDKExceptionDetails.ts
@@ -1,6 +1,7 @@
 interface ChatSDKExceptionDetails {
     response: string;
     message?: string;
+    errorObject?: string;
 }
 
 export default ChatSDKExceptionDetails;

--- a/src/utils/WebUtils.ts
+++ b/src/utils/WebUtils.ts
@@ -1,4 +1,4 @@
-const loadScript = async (scriptUrl: string, callbackOnload: CallableFunction = () => void(0), callbackError: CallableFunction = () => void(0)): Promise<void> => {
+const loadScript = async (scriptUrl: string, callbackOnload: CallableFunction = () => void(0), callbackError: CallableFunction = () => void(0), retries = 0, attempt = 0): Promise<void> => {
   return new Promise (async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
     const scriptElements = Array.from(document.getElementsByTagName('script'));
     const foundScriptElement = scriptElements.filter(scriptElement => scriptElement.src == scriptUrl);
@@ -19,8 +19,20 @@ const loadScript = async (scriptUrl: string, callbackOnload: CallableFunction = 
     });
 
     scriptElement.addEventListener('error', async () => {
-      await callbackError();
-      reject();
+      if (++attempt >= retries) {
+        await callbackError();
+
+        // Reference: https://developer.mozilla.org/en-US/docs/Web/API/Element/error_event
+        return reject(new Error("Resource failed to load, or can't be used."));
+      }
+
+      scriptElement.remove();
+
+      try {
+        await loadScript(scriptUrl, callbackOnload, callbackError, retries, attempt);
+      } catch (e) {
+        reject(e);
+      }
     });
   });
 };

--- a/src/utils/WebUtils.ts
+++ b/src/utils/WebUtils.ts
@@ -1,3 +1,6 @@
+import sleep from "./sleep";
+
+const maxBackoffSeconds = 60;
 const loadScript = async (scriptUrl: string, callbackOnload: CallableFunction = () => void(0), callbackError: CallableFunction = () => void(0), retries = 0, attempt = 0): Promise<void> => {
   return new Promise (async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
     const scriptElements = Array.from(document.getElementsByTagName('script'));
@@ -27,6 +30,9 @@ const loadScript = async (scriptUrl: string, callbackOnload: CallableFunction = 
       }
 
       scriptElement.remove();
+
+      const exponentialBackoffWaitTime = Math.min((2 ** attempt) + Math.random(), maxBackoffSeconds) * 1000;
+      await sleep(exponentialBackoffWaitTime);
 
       try {
         await loadScript(scriptUrl, callbackOnload, callbackError, retries, attempt);

--- a/src/utils/WebUtils.ts
+++ b/src/utils/WebUtils.ts
@@ -1,7 +1,8 @@
 import sleep from "./sleep";
 
+const defaultLoadScriptRetries = 3;
 const maxBackoffSeconds = 60;
-const loadScript = async (scriptUrl: string, callbackOnload: CallableFunction = () => void(0), callbackError: CallableFunction = () => void(0), retries = 0, attempt = 0): Promise<void> => {
+const loadScript = async (scriptUrl: string, callbackOnload: CallableFunction = () => void(0), callbackError: CallableFunction = () => void(0), retries = defaultLoadScriptRetries, attempt = 0): Promise<void> => {
   return new Promise (async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
     const scriptElements = Array.from(document.getElementsByTagName('script'));
     const foundScriptElement = scriptElements.filter(scriptElement => scriptElement.src == scriptUrl);

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -5,6 +5,8 @@ import AriaTelemetry from "../telemetry/AriaTelemetry";
 import ChatAdapterOptionalParams from "../core/messaging/ChatAdapterOptionalParams";
 import { ChatClient } from "@azure/communication-chat";
 import ChatSDKConfig from "../core/ChatSDKConfig";
+import ChatSDKErrors from "../core/ChatSDKErrors";
+import ChatSDKExceptionDetails from "../core/ChatSDKExceptionDetails";
 import createChannelDataEgressMiddleware from "../external/ACSAdapter/createChannelDataEgressMiddleware";
 import createFormatEgressTagsMiddleware from "../external/ACSAdapter/createFormatEgressTagsMiddleware";
 import createFormatIngressTagsMiddleware from "../external/ACSAdapter/createFormatIngressTagsMiddleware";
@@ -29,8 +31,16 @@ const createDirectLine = async (optionalParams: ChatAdapterOptionalParams, chatS
 
     try {
         await loadScript(directLineCDNUrl);
-    } catch {
-        scenarioMarker.failScenario(TelemetryEvent.CreateDirectLine);
+    } catch (error) {
+        const exceptionDetails: ChatSDKExceptionDetails = {
+            response: ChatSDKErrors.ScriptLoadFailure,
+            errorObject: `${error}`
+        };
+
+        scenarioMarker.failScenario(TelemetryEvent.CreateDirectLine, {
+            ExceptionDetails: JSON.stringify(exceptionDetails)
+        });
+
         throw new Error('Failed to load DirectLine');
     }
 
@@ -71,8 +81,16 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
 
     try {
         await loadScript(acsAdapterCDNUrl);
-    } catch {
-        scenarioMarker.failScenario(TelemetryEvent.CreateACSAdapter);
+    } catch (error) {
+        const exceptionDetails: ChatSDKExceptionDetails = {
+            response: ChatSDKErrors.ScriptLoadFailure,
+            errorObject: `${error}`
+        };
+
+        scenarioMarker.failScenario(TelemetryEvent.CreateACSAdapter, {
+            ExceptionDetails: JSON.stringify(exceptionDetails)
+        });
+
         throw new Error('Failed to load ACSAdapter');
     }
 
@@ -111,8 +129,16 @@ const createIC3Adapter = async (optionalParams: ChatAdapterOptionalParams, chatS
 
     try {
         await loadScript(ic3AdapterCDNUrl);
-    } catch {
-        scenarioMarker.failScenario(TelemetryEvent.CreateIC3Adapter);
+    } catch (error) {
+        const exceptionDetails: ChatSDKExceptionDetails = {
+            response: ChatSDKErrors.ScriptLoadFailure,
+            errorObject: `${error}`
+        };
+
+        scenarioMarker.failScenario(TelemetryEvent.CreateIC3Adapter, {
+            ExceptionDetails: JSON.stringify(exceptionDetails)
+        });
+
         throw new Error('Failed to load IC3Adapter');
     }
 

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -49,8 +49,16 @@ const createDirectLine = async (optionalParams: ChatAdapterOptionalParams, chatS
         const adapter = new DirectLine.DirectLine({...options});
         scenarioMarker.completeScenario(TelemetryEvent.CreateDirectLine);
         return adapter;
-    } catch {
-        scenarioMarker.failScenario(TelemetryEvent.CreateDirectLine);
+    } catch (error) {
+        const exceptionDetails: ChatSDKExceptionDetails = {
+            response: ChatSDKErrors.ChatAdapterInitializationFailure,
+            errorObject: `${error}`
+        };
+
+        scenarioMarker.failScenario(TelemetryEvent.CreateDirectLine, {
+            ExceptionDetails: JSON.stringify(exceptionDetails)
+        });
+
         throw new Error('Failed to create DirectLine');
     }
 };
@@ -111,8 +119,16 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
 
         scenarioMarker.completeScenario(TelemetryEvent.CreateACSAdapter);
         return adapter;
-    } catch {
-        scenarioMarker.failScenario(TelemetryEvent.CreateACSAdapter);
+    } catch (error) {
+        const exceptionDetails: ChatSDKExceptionDetails = {
+            response: ChatSDKErrors.ChatAdapterInitializationFailure,
+            errorObject: `${error}`
+        };
+
+        scenarioMarker.failScenario(TelemetryEvent.CreateACSAdapter, {
+            ExceptionDetails: JSON.stringify(exceptionDetails)
+        });
+
         throw new Error('Failed to create ACSAdapter');
     }
 };
@@ -156,8 +172,16 @@ const createIC3Adapter = async (optionalParams: ChatAdapterOptionalParams, chatS
         adapter.logger = logger;
         scenarioMarker.completeScenario(TelemetryEvent.CreateIC3Adapter);
         return adapter;
-    } catch {
-        scenarioMarker.failScenario(TelemetryEvent.CreateIC3Adapter);
+    } catch (error) {
+        const exceptionDetails: ChatSDKExceptionDetails = {
+            response: ChatSDKErrors.ChatAdapterInitializationFailure,
+            errorObject: `${error}`
+        };
+
+        scenarioMarker.failScenario(TelemetryEvent.CreateIC3Adapter, {
+            ExceptionDetails: JSON.stringify(exceptionDetails)
+        });
+
         throw new Error('Failed to create IC3Adapter');
     }
 };

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+export default sleep;


### PR DESCRIPTION
- Add additional details on `ChatSDK.createChatAdapter()` failure when script fails to load
  - It should provide the following exception details: `{"response":"ScriptLoadFailure","errorObject":"Error: Resource failed to load, or can't be used."}`
- Add chat adapter script load retries for up to 3 times with exponential backoff mechanism
- Add integration tests for `ChatSDK.createChatAdapter()`