### PR TITLE
Fix on typing event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fix `ChatAdapterOptionalParams.ACSAdapter.options.egressMiddleware` being used as `ingressMiddleware`
+- Fix `ChatSDK.onTypingEvent()` being triggered on current user typing
 
 ## [1.2.0] - 2022-11-11
 ### Added

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -366,8 +366,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         const {acsEndpoint, chatId} = runtimeContext;
         const getMessagesRequestPartialUrl = `${acsEndpoint}chat/threads/${encodeURIComponent(chatId)}/messages?api-version=`;
         const getMessagesResponseDataJson = await getMessagesResponse.json();
-        const sentMessages = getMessagesResponseDataJson.value.filter((message) => message.type === 'text');
-        const sentMessage = sentMessages.filter((message) => message.content.message === content);
+        const sentMessage = getMessagesResponseDataJson.value.filter((message) => message.type === 'text' && message.content.message === content);
         const sentMessageContent = sentMessage[0].content.message;
 
         expect(getMessagesRequest.url().includes(getMessagesRequestPartialUrl)).toBe(true);

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -367,7 +367,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         const getMessagesRequestPartialUrl = `${acsEndpoint}chat/threads/${encodeURIComponent(chatId)}/messages?api-version=`;
         const getMessagesResponseDataJson = await getMessagesResponse.json();
         const sentMessages = getMessagesResponseDataJson.value.filter((message) => message.type === 'text');
-        const sentMessageContent = sentMessages[0].content.message;
+        const sentMessage = sentMessages.filter((message) => message.content.message === content);
+        const sentMessageContent = sentMessage[0].content.message;
 
         expect(getMessagesRequest.url().includes(getMessagesRequestPartialUrl)).toBe(true);
         expect(getMessagesResponse.status()).toBe(200);

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -280,6 +280,13 @@ export class ACSConversation {
 
         try {
             const listener = (event: TypingIndicatorReceivedEvent) => {
+                const {sender, recipient} = event;
+
+                // Ignore participant's own typing events
+                if ((sender as any).communicationUserId === (recipient as any).communicationUserId) { // eslint-disable-line @typescript-eslint/no-explicit-any
+                  return;
+                }
+
                 onTypingEventCallback(event);
             }
 


### PR DESCRIPTION
- Addressing #135 
- `onTypingEvent()` is not filtering user's own typing events