### PR TITLE
Integrated Chat SDK tests

### DIFF
--- a/playwright/integrations/authenticated-chat-with-typing.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-typing.spec.ts
@@ -1,0 +1,109 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchAuthUrl from '../utils/fetchAuthUrl';
+import { test, expect } from '@playwright/test';
+import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithTyping');
+const authUrl = fetchAuthUrl('AuthenticatedChatWithTyping');
+
+test.describe('AuthenticatedChat @AuthenticatedChatWithTyping', () => {
+    test('ChatSDK.sendTyping() should not fail', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [request, response, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.SendTypingIndicatorPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.SendTypingIndicatorPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+                const runtimeContext = {};
+
+                chatSDK.setDebug(true);
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                runtimeContext.requestId = chatSDK.requestId;
+
+                await chatSDK.sendTypingEvent();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, authUrl })
+        ]);
+
+        const { requestId } = runtimeContext;
+        const requestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.SendTypingIndicatorPath}/${requestId}`;
+
+        expect(request.url() === requestUrl).toBe(true);
+        expect(response.status()).toBe(200);
+    });
+
+    test('ChatSDK.onTypingEvent() should not fail', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                    chatId: chatSDK.chatToken.chatId,
+                    acsEndpoint: chatSDK.chatToken.acsEndpoint,
+                };
+
+                try {
+                    chatSDK.onTypingEvent(() => {
+                        console.log("Agent is typing...");
+                    })
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                    runtimeContext.errorObject = `${err}`;
+                }
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, authUrl })
+        ]);
+
+        expect(runtimeContext?.errorMessage).not.toBeDefined();
+        expect(runtimeContext?.errorObject).not.toBeDefined();
+    });
+});

--- a/playwright/integrations/authenticated-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat.spec.ts
@@ -70,4 +70,160 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
         expect(sessionInitRequestHeaders['authenticatedusertoken']).toBe(authToken);
         expect(sessionInitResponse.status()).toBe(200);
     });
+
+    test('ChatSDK.startChat() with liveChatContext should not perform session init & validate the live work item details & validate auth map record', async ({ page }) => {
+        await page.goto(testPage);
+
+        const requestUrls = [];
+        page.on('request', (request) => {
+            if (request.url().includes("livechatconnector")) {
+                requestUrls.push(request.url());
+            }
+        });
+
+        const [_, liveWorkItemDetailsRequest, liveWorkItemDetailsResponse, liveChatMapRecordRequest, liveChatMapRecordResponse, runtimeContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const liveChatContext = await chatSDK.getCurrentLiveChatContext();
+
+                const runtimeContext = {
+                    runtimeIdFirstSession: chatSDK.runtimeId,
+                    requestIdFirstSession: chatSDK.requestId,
+                    liveChatContext,
+                };
+
+                (window as any).runtimeContext = runtimeContext;
+            }, { omnichannelConfig, authUrl }),
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
+            }),
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthChatMapRecord);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthChatMapRecord);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK, runtimeContext } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                runtimeContext.runtimeIdSecondSession = chatSDK.runtimeId;
+                runtimeContext.requestIdSecondSession = chatSDK.requestId;
+                runtimeContext.authToken= authToken;
+
+                try {
+                    await chatSDK.startChat({ liveChatContext: runtimeContext.liveChatContext });
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                }
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, authUrl })
+        ]);
+
+        const { requestIdFirstSession: requestId, authToken } = runtimeContext;
+        const liveWorkItemDetailsRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+        const authChatMapRecordRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthChatMapRecord}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}`;
+        const liveWorkItemDetailsResponseDataJson = await liveWorkItemDetailsResponse.json();
+        const sessionInitCalls = requestUrls.filter((url) => url.includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath));
+
+        const liveWorkItemDetailsRequestHeaders = liveWorkItemDetailsRequest.headers();
+        const liveChatMapRecordRequestHeaders = liveChatMapRecordRequest.headers();
+
+        expect(liveWorkItemDetailsRequest.url() === liveWorkItemDetailsRequestUrl).toBe(true);
+        expect(liveWorkItemDetailsResponse.status()).toBe(200);
+        expect(liveChatMapRecordRequest.url()).toContain(authChatMapRecordRequestUrl);
+        expect(liveChatMapRecordResponse.status()).toBe(200);
+        expect(liveWorkItemDetailsResponseDataJson.State).not.toBe('Closed');
+        expect(sessionInitCalls.length).toBe(1);
+        expect(liveWorkItemDetailsRequestHeaders['authenticatedusertoken']).toBe(authToken);
+        expect(liveChatMapRecordRequestHeaders['authenticatedusertoken']).toBe(authToken);
+    });
+
+    test('ChatSDK.endChat() should perform session close', async ({page}) => {
+        await page.goto(testPage);
+
+        const [sessionCloseRequest, sessionCloseResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthSessionClosePath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionClosePath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
+                
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                    authToken
+                };
+
+                await chatSDK.startChat();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, authUrl })
+        ]);
+
+        const {requestId, authToken} = runtimeContext;
+        const sessionCloseRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthSessionClosePath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+        const sessionCloseRequestHeaders = sessionCloseRequest.headers();
+
+        expect(sessionCloseRequest.url() === sessionCloseRequestUrl).toBe(true);
+        expect(sessionCloseResponse.status()).toBe(200);
+        expect(sessionCloseRequestHeaders['authenticatedusertoken']).toBe(authToken);
+    });
 });

--- a/playwright/test.config.sample.yml
+++ b/playwright/test.config.sample.yml
@@ -12,3 +12,4 @@ AuthenticatedChat:
   orgUrl: ''
   widgetId: ''
   authUrl: ''
+AuthenticatedChatWithTyping:

--- a/playwright/utils/OmnichannelEndpoints.ts
+++ b/playwright/utils/OmnichannelEndpoints.ts
@@ -13,6 +13,6 @@ export default class OmnichannelEndpoints {
     public static readonly LiveChatv2GetChatTranscriptPath = "livechatconnector/v2/getchattranscripts";
     public static readonly LiveChatAuthLiveWorkItemDetailsPath = "livechatconnector/auth/getliveworkitemdetails";
     public static readonly LiveChatAuthChatMapRecord = "livechatconnector/auth/validateauthchatmaprecord";
-    public static readonly LiveChatAuthSessionClosePath= "livechatconnector/auth/sessionclose"
-    public static readonly LiveChatReConnect= "livechatconnector/reconnect";
+    public static readonly LiveChatAuthSessionClosePath = "livechatconnector/auth/sessionclose"
+    public static readonly LiveChatReConnect = "livechatconnector/reconnect";
 }

--- a/playwright/utils/OmnichannelEndpoints.ts
+++ b/playwright/utils/OmnichannelEndpoints.ts
@@ -11,4 +11,7 @@ export default class OmnichannelEndpoints {
     public static readonly LiveChatTranscriptEmailRequestPath = "livechatconnector/createemailrequest";
     public static readonly LiveChatLiveWorkItemDetailsPath = "livechatconnector/getliveworkitemdetails";
     public static readonly LiveChatv2GetChatTranscriptPath = "livechatconnector/v2/getchattranscripts";
+    public static readonly LiveChatAuthLiveWorkItemDetailsPath = "livechatconnector/auth/getliveworkitemdetails";
+    public static readonly LiveChatAuthChatMapRecord = "livechatconnector/auth/validateauthchatmaprecord";
+    public static readonly LiveChatAuthSessionClosePath= "livechatconnector/auth/sessionclose"
 }


### PR DESCRIPTION
This PR includes the following authenticated chat scenarios,

1.ChatSDK.sendTyping() should not fail.
2. ChatSDK.onTypingEvent() should not fail. 
3. ChatSDK.startChat() with liveChatContext should not perform session init & validate the live work item details & validate auth map record.
4. ChatSDK.endChat() should perform session close.