### PR TITLE
Chat SDK tests

### DIFF
--- a/playwright/integrations/authenticated-chat-with-attachments.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-attachments.spec.ts
@@ -1,0 +1,175 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchAuthUrl from '../utils/fetchAuthUrl';
+import { test, expect } from '@playwright/test';
+import ACSEndpoints from '../utils/ACSEndpoints';
+import AMSEndpoints from '../utils/AMSEndpoints';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithAttachments');
+const authUrl = fetchAuthUrl('AuthenticatedChatWithAttachments');
+
+test.describe('AuthenticatedChat @AuthenticatedChatWithAttachments', () => {
+    test('ChatSDK.uploadFileAttachment() should upload attachment to the attachment service & send a message with the metadata', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [uploadImageRequest, uploadImageResponse, sendMessageRequest, sendMessageResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(AMSEndpoints.rootDomain) && request.url().match(AMSEndpoints.uploadImagePattern)?.length >= 0;
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(AMSEndpoints.rootDomain) && response.url().match(AMSEndpoints.uploadImagePattern)?.length >= 0;
+            }),
+            page.waitForRequest(request => {
+                return request.url().match(ACSEndpoints.sendMessagePathPattern)?.length >= 0;
+            }),
+            page.waitForResponse(response => {
+                return response.url().match(ACSEndpoints.sendMessagePathPattern)?.length >= 0;
+            }),
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                    acsEndpoint: chatSDK.chatToken.acsEndpoint
+                };
+
+                try {
+                    const response = await fetch('./images/600x400.png');
+                    const blob = await response.blob();
+                    const file = new File([blob], '600x400.png', {
+                        type: "image/png"
+                    });
+
+                    runtimeContext.chatToken = chatSDK.chatToken;
+                    await chatSDK.uploadFileAttachment(file);
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                    runtimeContext.errorObject = `${err}`;
+                }
+
+                const messages = await chatSDK.getMessages();
+                runtimeContext.messages = messages;
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, authUrl })
+        ]);
+
+        const sendMessageRequestPostDataDataJson = sendMessageRequest.postDataJSON();
+        const { content: sendMessageRequestContent, metadata } = sendMessageRequestPostDataDataJson;
+
+        expect(uploadImageRequest.method()).toBe('PUT');
+        expect(uploadImageResponse.status()).toBe(201);
+        expect(sendMessageRequestContent).toBe("");
+        expect(metadata).toBeDefined();
+        expect(metadata.amsReferences).toBeDefined();
+        expect(metadata.amsreferences).toBeDefined();
+        expect(metadata.amsMetadata).toBeDefined();
+        expect(sendMessageResponse.status()).toBe(201);
+        expect(runtimeContext.errorMessage).not.toBeDefined();
+        expect(runtimeContext.errorObject).not.toBeDefined();
+    });
+
+    test('ChatSDK.downloadFileAttachment() should download an attachment', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [getImageViewStatusRequest, getImageViewStatusResponse, getImageViewRequest, getImageViewResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(AMSEndpoints.rootDomain) && request.url().match(AMSEndpoints.getImageViewStatusPattern)?.length >= 0;
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(AMSEndpoints.rootDomain) && response.url().match(AMSEndpoints.getImageViewStatusPattern)?.length >= 0;
+            }),
+            page.waitForRequest(request => {
+                return request.url().includes(AMSEndpoints.rootDomain) && request.url().match(AMSEndpoints.getImageViewPattern)?.length >= 0 && !request.url().endsWith("status");
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(AMSEndpoints.rootDomain) && response.url().match(AMSEndpoints.getImageViewPattern)?.length >= 0 && !response.url().endsWith("status");
+            }),
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId
+                };
+
+                try {
+                    const response = await fetch('./images/600x400.png');
+                    const blob = await response.blob();
+                    const uploadedBlobContent = await blob.text();
+                    const file = new File([blob], '600x400.png', {
+                        type: "image/png"
+                    });
+
+                    await chatSDK.uploadFileAttachment(file);
+
+                    runtimeContext.uploadedBlobContent = uploadedBlobContent;
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                    runtimeContext.errorObject = `${err}`;
+                }
+
+                const messages = await chatSDK.getMessages();
+                runtimeContext.messages = messages;
+
+                const attachmentMessageResult = messages.filter(message => message.fileMetadata !== undefined);
+                const attachmentMessage = attachmentMessageResult[0];
+
+                try {
+                    const blob = await chatSDK.downloadFileAttachment(attachmentMessage.fileMetadata);
+                    const downloadedBlobContent = await blob.text();
+                    runtimeContext.downloadedBlobContent = downloadedBlobContent;
+                } catch (err) {
+                    runtimeContext.errorMessage = `${err.message}`;
+                    runtimeContext.errorObject = `${err}`;
+                }
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, authUrl })
+        ]);
+
+        expect(getImageViewStatusRequest.method()).toBe('GET');
+        expect(getImageViewStatusResponse.status()).toBe(200);
+        expect(getImageViewRequest.method()).toBe('GET');
+        expect(getImageViewResponse.status()).toBe(200);
+        expect(runtimeContext.downloadedBlobContent).toBe(runtimeContext.uploadedBlobContent);
+    });
+});

--- a/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
@@ -46,6 +46,10 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
                     authToken
                 };
 
+                const chatReconnectContext = await chatSDK.getChatReconnectContext();
+
+                runtimeContext.reconnectId = chatReconnectContext.reconnectId;
+
                 await chatSDK.startChat();
 
                 await chatSDK.endChat();

--- a/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
@@ -10,7 +10,7 @@ const authUrl = fetchAuthUrl('AuthenticatedChatWithChatReconnect');
 
 test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
 
-    test.only('ChatSDK.getChatReconnectContext() should not return a reconnect id if theres no existing chat session', async ({ page }) => {
+    test('ChatSDK.getChatReconnectContext() should not return a reconnect id if theres no existing chat session', async ({ page }) => {
         await page.goto(testPage);
 
         const [reconnectableChatsRequest, reconnectableChatsRespense, runtimeContext] = await Promise.all([

--- a/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
@@ -1,0 +1,66 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchAuthUrl from '../utils/fetchAuthUrl';
+import { test, expect } from '@playwright/test';
+import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithChatReconnect');
+const authUrl = fetchAuthUrl('AuthenticatedChatWithChatReconnect');
+
+test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
+
+    test.only('ChatSDK.getChatReconnectContext() should not return a reconnect id if theres no existing chat session', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [reconnectableChatsRequest, reconnectableChatsRespense, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthReconnectableChats) && request.method() === 'GET';
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthReconnectableChats) && response.request().method() === 'GET';
+            }),
+            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken,
+                    chatReconnect: {
+                        disable: false,
+                    },
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                await chatSDK.initialize();
+
+                const runtimeContext = {
+                    requestId: chatSDK.requestId,
+                    authToken
+                };
+
+                await chatSDK.startChat();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, authUrl })
+        ]);
+
+        const { authToken } = runtimeContext;
+        const reconnectableChatsRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthReconnectableChats}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${omnichannelConfig.orgId}?channelId=lcw`;
+
+        const reconnectableChatsRequestHeaders = reconnectableChatsRequest.headers();
+
+        expect(reconnectableChatsRequest.url() === reconnectableChatsRequestUrl).toBe(true);
+        expect(reconnectableChatsRespense.status()).toBe(204);
+        expect(reconnectableChatsRequestHeaders['authenticatedusertoken']).toBe(authToken);
+    });
+});

--- a/playwright/test.config.sample.yml
+++ b/playwright/test.config.sample.yml
@@ -17,3 +17,4 @@ AuthenticatedChat:
   widgetId: ''
   authUrl: ''
 AuthenticatedChatWithTyping:
+AuthenticatedChatWithAttachments:

--- a/playwright/test.config.sample.yml
+++ b/playwright/test.config.sample.yml
@@ -18,3 +18,4 @@ AuthenticatedChat:
   authUrl: ''
 AuthenticatedChatWithTyping:
 AuthenticatedChatWithAttachments:
+AuthenticatedChatWithChatReconnect:

--- a/playwright/utils/OmnichannelEndpoints.ts
+++ b/playwright/utils/OmnichannelEndpoints.ts
@@ -14,4 +14,5 @@ export default class OmnichannelEndpoints {
     public static readonly LiveChatAuthLiveWorkItemDetailsPath = "livechatconnector/auth/getliveworkitemdetails";
     public static readonly LiveChatAuthChatMapRecord = "livechatconnector/auth/validateauthchatmaprecord";
     public static readonly LiveChatReConnect= "livechatconnector/reconnect";
+    public static readonly LiveChatAuthReconnectableChats= "livechatconnector/auth/reconnectablechats";
 }

--- a/playwright/utils/OmnichannelEndpoints.ts
+++ b/playwright/utils/OmnichannelEndpoints.ts
@@ -13,6 +13,6 @@ export default class OmnichannelEndpoints {
     public static readonly LiveChatv2GetChatTranscriptPath = "livechatconnector/v2/getchattranscripts";
     public static readonly LiveChatAuthLiveWorkItemDetailsPath = "livechatconnector/auth/getliveworkitemdetails";
     public static readonly LiveChatAuthChatMapRecord = "livechatconnector/auth/validateauthchatmaprecord";
-    public static readonly LiveChatReConnect= "livechatconnector/reconnect";
-    public static readonly LiveChatAuthReconnectableChats= "livechatconnector/auth/reconnectablechats";
+    public static readonly LiveChatReConnect = "livechatconnector/reconnect";
+    public static readonly LiveChatAuthReconnectableChats = "livechatconnector/auth/reconnectablechats";
 }


### PR DESCRIPTION
This PR includes the following authentication chat scenarios,

1. ChatSDK.uploadFileAttachment() should upload attachment to the attachment service & send a message with the metadata.
2. ChatSDK.downloadFileAttachment() should download an attachment.
3. ChatSDK.getChatReconnectContext() should not return a reconnect id if theres no existing chat session.