### PR TITLE
Integrated Chat SDK Pre chat tests

### DIFF
--- a/playwright/integrations/authenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-prechat.spec.ts
@@ -1,0 +1,74 @@
+import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
+import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchAuthUrl from '../utils/fetchAuthUrl';
+import { test, expect } from '@playwright/test';
+import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
+
+const testPage = fetchTestPageUrl();
+const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithPrechat');
+const authUrl = fetchAuthUrl('AuthenticatedChatWithPrechat');
+
+test.describe('AuthenticatedChat @AuthenticatedChatWithPrechat', () => {
+    test('ChatSDK.startChat() with preChatResponse should be part of session init payload', async ({ page }) => {
+        await page.goto(testPage);
+
+        const optionalParams = {
+            preChatResponse: {
+                'Type': "InputSubmit",
+                'Survey': '{"Name":"OmnichannelSurvey","IsOption":false,"Order":1,"IsRequired":false,"QuestionText":"OmnichannelSurvey"}'
+            }
+        };
+
+        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, optionalParams, authUrl }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+                const payload = {
+                    method: "POST"
+                };
+
+                const response = await fetch(authUrl, payload);
+                const authToken = await response.text();
+
+                const chatSDKConfig = {
+                    getAuthToken: () => authToken
+                };
+
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
+
+                const runtimeContext = {};
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat(optionalParams);
+
+                runtimeContext.requestId = chatSDK.requestId;
+
+                const preChatSurveyRes = await chatSDK.getPreChatSurvey();
+
+                runtimeContext.preChatSurvey = preChatSurveyRes;
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, optionalParams, authUrl })
+        ]);
+
+        const { requestId } = runtimeContext;
+        const sessionInitRequestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatAuthSessionInitPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
+        const prechatSurveyBody = JSON.parse(optionalParams.preChatResponse.Survey);
+        expect(prechatSurveyBody.Name).toEqual('OmnichannelSurvey');
+        const requestPostData = sessionInitRequest.postDataJSON();
+
+        expect(sessionInitRequest.url() === sessionInitRequestUrl).toBe(true);
+        expect(sessionInitResponse.status()).toBe(200);
+        const { preChatResponse: preChatResponseData } = requestPostData;
+        expect(optionalParams.preChatResponse).toEqual(preChatResponseData);
+    });
+});

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -57,4 +57,142 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
         const { preChatResponse: preChatResponseData } = requestPostData;
         expect(optionalParams.preChatResponse).toEqual(preChatResponseData);
     });
+
+    test('ChatSDK.getPreChatSurvey() should return the survey in JSON format', async ({ page }) => {
+
+        await page.goto(testPage);
+
+        const optionalParams = {
+            preChatResponse: {
+                'Type': "InputSubmit",
+                'Survey': '{"Name":"OmnichannelSurvey","IsOption":false,"Order":1,"IsRequired":false,"QuestionText":"OmnichannelSurvey"}'
+            }
+        };
+
+        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const runtimeContext = {};
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat(optionalParams);
+
+                runtimeContext.requestId = chatSDK.requestId;
+
+                const preChatSurveyRes = await chatSDK.getPreChatSurvey();
+
+                runtimeContext.preChatSurvey = preChatSurveyRes;
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, optionalParams })
+        ]);
+
+        const { preChatSurvey } = runtimeContext;
+        const prechatSurveyBody = JSON.parse(preChatSurvey.body[2].id);
+        const prechatSurveyResponseBody = JSON.parse(optionalParams.preChatResponse.Survey);
+        expect(prechatSurveyBody.Name).toEqual(prechatSurveyResponseBody.Name);
+    });
+
+    test('ChatSDK.getPreChatSurvey() with parseToJSON set to true should return the survey as JSON format', async ({ page }) => {
+
+        await page.goto(testPage);
+
+        const optionalParams = {
+            preChatResponse: {
+                'Type': "InputSubmit",
+                'Survey': '{"Name":"OmnichannelSurvey","IsOption":false,"Order":1,"IsRequired":false,"QuestionText":"OmnichannelSurvey"}'
+            }
+        };
+
+        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const runtimeContext = {};
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat(optionalParams);
+
+                runtimeContext.requestId = chatSDK.requestId;
+
+                const parseToJSON = true;
+
+                const preChatSurveyRes = await chatSDK.getPreChatSurvey(parseToJSON);
+
+                runtimeContext.preChatSurvey = preChatSurveyRes;
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, optionalParams })
+        ]);
+
+        const { preChatSurvey } = runtimeContext;
+        const prechatSurveyBody = JSON.parse(preChatSurvey.body[2].id);
+        const prechatSurveyResponseBody = JSON.parse(optionalParams.preChatResponse.Survey);
+        expect(prechatSurveyBody.Name).toEqual(prechatSurveyResponseBody.Name);
+    });
+
+    test('ChatSDK.getPreChatSurvey() with parseToJSON set to false should return the survey as string format', async ({ page }) => {
+
+        await page.goto(testPage);
+
+        const optionalParams = {
+            preChatResponse: {
+                'Type': "InputSubmit",
+                'Survey': '{"Name":"OmnichannelSurvey","IsOption":false,"Order":1,"IsRequired":false,"QuestionText":"OmnichannelSurvey"}'
+            }
+        };
+
+        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const runtimeContext = {};
+
+                await chatSDK.initialize();
+
+                await chatSDK.startChat(optionalParams);
+
+                runtimeContext.requestId = chatSDK.requestId;
+
+                const parseToJSON = false;
+
+                const preChatSurveyRes = await chatSDK.getPreChatSurvey(parseToJSON);
+
+                runtimeContext.preChatSurvey = preChatSurveyRes;
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig, optionalParams })
+        ]);
+
+        const { preChatSurvey } = runtimeContext;
+        const prechatSurveyResponseBody = JSON.parse(optionalParams.preChatResponse.Survey);
+        expect(preChatSurvey).toContain(prechatSurveyResponseBody.Name);
+    });
 });

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -8,7 +8,6 @@ const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithPrechat
 
 test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
     test('ChatSDK.startChat() with preChatResponse should be part of session init payload', async ({ page }) => {
-
         await page.goto(testPage);
 
         const optionalParams = {
@@ -59,78 +58,38 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
     });
 
     test('ChatSDK.getPreChatSurvey() should return the survey in JSON format', async ({ page }) => {
-
         await page.goto(testPage);
 
-        const optionalParams = {
-            preChatResponse: {
-                'Type': "InputSubmit",
-                'Survey': '{"Name":"OmnichannelSurvey","IsOption":false,"Order":1,"IsRequired":false,"QuestionText":"OmnichannelSurvey"}'
-            }
-        };
-
-        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
-            page.waitForRequest(request => {
-                return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
-            }),
-            page.waitForResponse(response => {
-                return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
-            }),
-            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
 
                 await chatSDK.initialize();
-
-                await chatSDK.startChat(optionalParams);
-
-                runtimeContext.requestId = chatSDK.requestId;
 
                 const preChatSurveyRes = await chatSDK.getPreChatSurvey();
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
 
-                await chatSDK.endChat();
-
                 return runtimeContext;
-            }, { omnichannelConfig, optionalParams })
+            }, { omnichannelConfig })
         ]);
 
         const { preChatSurvey } = runtimeContext;
-        const prechatSurveyBody = JSON.parse(preChatSurvey.body[2].id);
-        const prechatSurveyResponseBody = JSON.parse(optionalParams.preChatResponse.Survey);
-        expect(prechatSurveyBody.Name).toEqual(prechatSurveyResponseBody.Name);
+        expect(typeof (preChatSurvey) === 'object').toBe(true);
     });
 
     test('ChatSDK.getPreChatSurvey() with parseToJSON set to true should return the survey as JSON format', async ({ page }) => {
-
         await page.goto(testPage);
 
-        const optionalParams = {
-            preChatResponse: {
-                'Type': "InputSubmit",
-                'Survey': '{"Name":"OmnichannelSurvey","IsOption":false,"Order":1,"IsRequired":false,"QuestionText":"OmnichannelSurvey"}'
-            }
-        };
-
-        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
-            page.waitForRequest(request => {
-                return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
-            }),
-            page.waitForResponse(response => {
-                return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
-            }),
-            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
 
                 await chatSDK.initialize();
-
-                await chatSDK.startChat(optionalParams);
-
-                runtimeContext.requestId = chatSDK.requestId;
 
                 const parseToJSON = true;
 
@@ -138,46 +97,24 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
 
-                await chatSDK.endChat();
-
                 return runtimeContext;
-            }, { omnichannelConfig, optionalParams })
+            }, { omnichannelConfig })
         ]);
 
         const { preChatSurvey } = runtimeContext;
-        const prechatSurveyBody = JSON.parse(preChatSurvey.body[2].id);
-        const prechatSurveyResponseBody = JSON.parse(optionalParams.preChatResponse.Survey);
-        expect(prechatSurveyBody.Name).toEqual(prechatSurveyResponseBody.Name);
+        expect(typeof (preChatSurvey) === 'object').toBe(true);
     });
 
     test('ChatSDK.getPreChatSurvey() with parseToJSON set to false should return the survey as string format', async ({ page }) => {
-
         await page.goto(testPage);
 
-        const optionalParams = {
-            preChatResponse: {
-                'Type': "InputSubmit",
-                'Survey': '{"Name":"OmnichannelSurvey","IsOption":false,"Order":1,"IsRequired":false,"QuestionText":"OmnichannelSurvey"}'
-            }
-        };
-
-        const [sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
-            page.waitForRequest(request => {
-                return request.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
-            }),
-            page.waitForResponse(response => {
-                return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
-            }),
-            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+        const [runtimeContext] = await Promise.all([
+            await page.evaluate(async ({ omnichannelConfig }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
 
                 await chatSDK.initialize();
-
-                await chatSDK.startChat(optionalParams);
-
-                runtimeContext.requestId = chatSDK.requestId;
 
                 const parseToJSON = false;
 
@@ -185,14 +122,11 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
 
-                await chatSDK.endChat();
-
                 return runtimeContext;
-            }, { omnichannelConfig, optionalParams })
+            }, { omnichannelConfig })
         ]);
 
         const { preChatSurvey } = runtimeContext;
-        const prechatSurveyResponseBody = JSON.parse(optionalParams.preChatResponse.Survey);
-        expect(preChatSurvey).toContain(prechatSurveyResponseBody.Name);
+        expect(typeof (preChatSurvey) === 'string').toBe(true);
     });
 });

--- a/playwright/test.config.sample.yml
+++ b/playwright/test.config.sample.yml
@@ -17,3 +17,4 @@ AuthenticatedChat:
   widgetId: ''
   authUrl: ''
 AuthenticatedChatWithTyping:
+AuthenticatedChatWithPrechat:


### PR DESCRIPTION
This PR includes the following chat scenarios,

1. ChatSDK.startChat() with preChatResponse should be part of session init payload (authenticated chat).
2. ChatSDK.getPreChatSurvey() should return the survey in JSON format.
3. ChatSDK.getPreChatSurvey() with parseToJSON set to true should return the survey as JSON format.
4. ChatSDK.getPreChatSurvey() with parseToJSON set to false should return the survey as string format.