### PR TITLE
Get live chat transcripts with live chat context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Add ability to use `ChatSDK.getLiveChatTranscript()` to fetch live chat transcript from `liveChatContext`
+
 ### Changed
 - Update `ChatSDKErrors` to include standard ChatSDK errors to be more predictable
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -2374,6 +2374,54 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.OCClient.getChatTranscripts.mock.calls[0][3]).toMatchObject(getChatTranscriptOptionalParams);
         });
 
+        it("ChatSDK.getLiveChatTranscript() with liveChatContext should fetch transcript from liveChatContext", async () => {
+            const omnichannelConfig = {
+                orgUrl: '',
+                orgId: '',
+                widgetId: ''
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+
+            await chatSDK.initialize();
+
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            const chatToken = {
+                ChatId: 'ChatId',
+                Token: 'Token',
+                RegionGtms: '{}'
+            };
+
+            jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve(chatToken));
+            jest.spyOn(chatSDK.OCClient, 'sessionInit').mockResolvedValue(Promise.resolve());
+            jest.spyOn(chatSDK.OCClient, 'getChatTranscripts').mockResolvedValue(Promise.resolve());
+
+            await chatSDK.startChat();
+            await chatSDK.getLiveChatTranscript();
+
+            const liveChatContext = {
+                requestId: 'requestId',
+                chatToken: {
+                    chatId: 'chatId',
+                    token: 'token'
+                }
+            }
+
+            await chatSDK.getLiveChatTranscript({liveChatContext});
+
+            expect(chatSDK.OCClient.getChatTranscripts).toHaveBeenCalledTimes(2);
+            expect(chatSDK.OCClient.getChatTranscripts.mock.calls[1][0]).toBe(liveChatContext.requestId);
+            expect(chatSDK.OCClient.getChatTranscripts.mock.calls[1][1]).toBe(liveChatContext.chatToken.chatId);
+            expect(chatSDK.OCClient.getChatTranscripts.mock.calls[1][2]).toBe(liveChatContext.chatToken.token);
+            expect(chatSDK.OCClient.getChatTranscripts.mock.calls[1][0]).not.toBe(chatSDK.requestId);
+            expect(chatSDK.OCClient.getChatTranscripts.mock.calls[1][1]).not.toBe(chatToken.ChatId);
+            expect(chatSDK.OCClient.getChatTranscripts.mock.calls[1][2]).not.toBe(chatToken.Token);
+        });
+
         it('[LiveChatV1] ChatSDK.getIC3Client() should return IC3Core if platform is Node', async () => {
             const IC3SDKProvider = require('@microsoft/omnichannel-ic3core').SDKProvider;
             const platform = require('../src/utils/platform').default;

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -1270,6 +1270,30 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.OCClient.sessionInit.mock.calls[0][1]).toMatchObject(sessionInitOptionalParams);
         });
 
+        it("ChatSDK.startChat() with an unsupported locale should throw an exception", async () => {
+            const omnichannelConfig = {
+                orgUrl: '',
+                orgId: '',
+                widgetId: ''
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize();
+
+            const optionalParams = {
+                locale: 'unsupported-locale'
+            };
+
+            try {
+                await chatSDK.startChat(optionalParams);
+            } catch (e) {
+                expect(e.message).toBe("ConversationInitializationFailure");
+            }
+        });
+
         it('[LiveChatV1] ChatSDK.startChat() with customContext, browser, os, locale, device defined in sessionInitOptionalParams should pass it to OCClient.sessionInit() call\'s optional parameters', async() => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();

--- a/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
@@ -49,7 +49,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
         expect(response.status()).toBe(200);
     });
 
-    test('ChatSDK.getLiveChatTranscript() should not fail', async ({ page}) => {
+    test('ChatSDK.getLiveChatTranscript() should not fail', async ({ page }) => {
         await page.goto(testPage);
 
         const [request, response, runtimeContext] = await Promise.all([
@@ -77,6 +77,60 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 runtimeContext.transcript = transcript;
 
                 await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig })
+        ]);
+
+        const {requestId, token, chatId, transcript} = runtimeContext;
+        const requestUrl = `${omnichannelConfig.orgUrl}/${OmnichannelEndpoints.LiveChatv2GetChatTranscriptPath}/${chatId}/${requestId}?channelId=lcw`;
+        const requestHeaders = request.headers();
+
+        expect(request.url() === requestUrl).toBe(true);
+        expect(requestHeaders['authorization']).toBe(token);
+        expect(requestHeaders['organizationid']).toBe(omnichannelConfig.orgId);
+        expect(requestHeaders['widgetappid']).toBe(omnichannelConfig.widgetId);
+        expect(response.status()).toBe(200);
+        expect(Object.keys(transcript).includes('chatMessagesJson'));
+        expect(typeof transcript['chatMessagesJson']).toBe('string');
+    });
+
+    test('ChatSDK.getLiveChatTranscript() with liveChatContext should not fail', async ({ page }) => {
+        await page.goto(testPage);
+
+        page.on("console", (message) => {
+            if (message.type() === "error") {
+              console.log(message.text());
+            }
+        })
+
+        const [request, response, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatv2GetChatTranscriptPath);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatv2GetChatTranscriptPath);
+            }),
+            await page.evaluate(async ({ omnichannelConfig }) => {
+                const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const runtimeContext = {};
+
+                chatSDK.setDebug(true);
+                await chatSDK.initialize();
+
+                await chatSDK.startChat();
+
+                const liveChatContext = await chatSDK.getCurrentLiveChatContext();
+                runtimeContext.liveChatContext = liveChatContext;
+                runtimeContext.requestId = chatSDK.requestId;
+                runtimeContext.token = chatSDK.chatToken.token;
+                runtimeContext.chatId = chatSDK.chatToken.chatId;
+
+                await chatSDK.endChat();
+
+                const transcript = await chatSDK.getLiveChatTranscript({liveChatContext});
+                runtimeContext.transcript = transcript;
 
                 return runtimeContext;
             }, { omnichannelConfig })

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -706,12 +706,16 @@ class OmnichannelChatSDK {
 
             return liveWorkItemDetails;
         } catch (error) {
+            const exceptionDetails: ChatSDKExceptionDetails = {
+                response: ChatSDKErrors.ConversationDetailsRetrievalFailure,
+                errorObject: `${error}`
+            };
+
             this.scenarioMarker.failScenario(TelemetryEvent.GetConversationDetails, {
                 RequestId: this.requestId,
                 ChatId: this.chatToken.chatId as string || '',
+                ExceptionDetails: JSON.stringify(exceptionDetails)
             });
-
-            console.error(`OmnichannelChatSDK/getConversationDetails/error ${error}`);
         }
 
         return {} as LiveWorkItemDetails;

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -85,6 +85,7 @@ import { getLocationInfo } from "./utils/location";
 import {isCustomerMessage} from "./utils/utilities";
 import urlResolvers from "./utils/urlResolvers";
 import validateOmnichannelConfig from "./validators/OmnichannelConfigValidator";
+import GetLiveChatTranscriptOptionalParams from "./core/GetLiveChatTranscriptOptionalParams";
 
 class OmnichannelChatSDK {
     private debug: boolean;
@@ -1391,12 +1392,22 @@ class OmnichannelChatSDK {
         }
     }
 
-    public async getLiveChatTranscript(): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
+    public async getLiveChatTranscript(optionalParams: GetLiveChatTranscriptOptionalParams = {}): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
         const getChatTranscriptOptionalParams: IGetChatTranscriptsOptionalParams = {};
 
+        let requestId = this.requestId;
+        let chatToken = this.chatToken;
+        let chatId = chatToken.chatId as string;
+
+        if (optionalParams.liveChatContext) {
+            requestId = optionalParams.liveChatContext.requestId;
+            chatToken = optionalParams.liveChatContext.chatToken;
+            chatId = chatToken.chatId as string;
+        }
+
         this.scenarioMarker.startScenario(TelemetryEvent.GetLiveChatTranscript, {
-            RequestId: this.requestId,
-            ChatId: this.chatToken.chatId as string
+            RequestId: requestId,
+            ChatId: chatId
         });
 
         try {
@@ -1405,21 +1416,21 @@ class OmnichannelChatSDK {
             }
 
             const transcriptResponse = this.OCClient.getChatTranscripts(
-                this.requestId,
-                this.chatToken.chatId,
-                this.chatToken.token,
+                requestId,
+                chatToken.chatId,
+                chatToken.token,
                 getChatTranscriptOptionalParams);
 
             this.scenarioMarker.completeScenario(TelemetryEvent.GetLiveChatTranscript, {
-                RequestId: this.requestId,
-                ChatId: this.chatToken.chatId as string
+                RequestId: requestId,
+                ChatId: chatId
             });
 
             return transcriptResponse;
         } catch (error) {
             this.scenarioMarker.failScenario(TelemetryEvent.GetLiveChatTranscript, {
-                RequestId: this.requestId,
-                ChatId: this.chatToken.chatId as string
+                RequestId: requestId,
+                ChatId: chatId
             });
         }
     }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1428,10 +1428,12 @@ class OmnichannelChatSDK {
 
             return transcriptResponse;
         } catch (error) {
-            this.scenarioMarker.failScenario(TelemetryEvent.GetLiveChatTranscript, {
+            const telemetryData = {
                 RequestId: requestId,
                 ChatId: chatId
-            });
+            };
+
+            exceptionThrowers.throwLiveChatTranscriptRetrievalFailure(error, this.scenarioMarker, TelemetryEvent.GetLiveChatTranscript, telemetryData);
         }
     }
 

--- a/src/core/ChatSDKErrors.ts
+++ b/src/core/ChatSDKErrors.ts
@@ -42,6 +42,8 @@ enum ChatSDKErrors {
     MessagingClientInitializationFailure = "MessagingClientInitializationFailure",
     /** Failure in message/communication client joining the conversation */
     MessagingClientConversationJoinFailure = "MessagingClientConversationJoinFailure",
+    /** Failure on retrieving live chat transcript of a conversation */
+    LiveChatTranscriptRetrievalFailure = "LiveChatTranscriptRetrievalFailure"
 }
 
 export default ChatSDKErrors;

--- a/src/core/ChatSDKErrors.ts
+++ b/src/core/ChatSDKErrors.ts
@@ -43,7 +43,9 @@ enum ChatSDKErrors {
     /** Failure in message/communication client joining the conversation */
     MessagingClientConversationJoinFailure = "MessagingClientConversationJoinFailure",
     /** Failure on retrieving live chat transcript of a conversation */
-    LiveChatTranscriptRetrievalFailure = "LiveChatTranscriptRetrievalFailure"
+    LiveChatTranscriptRetrievalFailure = "LiveChatTranscriptRetrievalFailure",
+    /** Failure on retrieving conversation details */
+    ConversationDetailsRetrievalFailure = "ConversationDetailsRetrievalFailure",
 }
 
 export default ChatSDKErrors;

--- a/src/core/GetLiveChatTranscriptOptionalParams.ts
+++ b/src/core/GetLiveChatTranscriptOptionalParams.ts
@@ -1,0 +1,5 @@
+import LiveChatContext from "./LiveChatContext";
+
+export default interface GetLiveChatTranscriptOptionalParams {
+    liveChatContext?: LiveChatContext
+}

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -114,6 +114,10 @@ export const throwChatAdapterInitializationFailure = (e: unknown, scenarioMarker
     throwChatSDKError(ChatSDKErrors.ChatAdapterInitializationFailure, e, scenarioMarker, telemetryEvent);
 };
 
+export const throwLiveChatTranscriptRetrievalFailure = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string}): void => {
+    throwChatSDKError(ChatSDKErrors.LiveChatTranscriptRetrievalFailure, e, scenarioMarker, telemetryEvent, telemetryData);
+}
+
 export default {
     throwChatSDKError,
     throwScriptLoadFailure,
@@ -134,5 +138,6 @@ export default {
     throwConversationClosureFailure,
     throwMessagingClientInitializationFailure,
     throwMessagingClientConversationJoinFailure,
-    throwChatAdapterInitializationFailure
+    throwChatAdapterInitializationFailure,
+    throwLiveChatTranscriptRetrievalFailure
 }


### PR DESCRIPTION
- Add ability to fetch live chat transcripts via `liveChatContext`
- It would allow users to call `chatSDK.getLiveChatTranscript({liveChatContext});` after `chatSDK.endChat()` as long as `liveChatContext` is still valid