### PR TITLE
Skipped empty string or null context variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Skipped empty string or null context variables (parity with v1)
+
 ## [1.4.0] - 2023-05-02
 ### Added
 - Add ability to use `ChatSDK.getLiveChatTranscript()` to fetch live chat transcript from `liveChatContext`

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1710,6 +1710,15 @@ class OmnichannelChatSDK {
         requestOptionalParams.initContext!.locale = getLocaleStringFromId(this.localeId);
 
         if (optionalParams.customContext) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const context: any = optionalParams.customContext;
+            if (typeof context === "object") {
+                for (const key in context) {
+                    if (context[key].value === null || context[key].value === undefined || context[key].value === "") {
+                        delete context[key];
+                    }
+                }
+            }
             (requestOptionalParams.initContext! as any).customContextData = optionalParams.customContext; // eslint-disable-line @typescript-eslint/no-explicit-any
         }
 


### PR DESCRIPTION
[Bug 3365987](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3365987): [LCW V2]: Custom context with empty or null is not excluded in V2

![image](https://user-images.githubusercontent.com/14852927/236584888-a6524041-31b7-4a6c-b6e9-3271d7d3fd27.png)
