### PR TITLE
Token Refresher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add `tokenRefresher` mechanism to retrieve chat token on expiry
+
 ## [1.4.2] - 2023-05-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add `tokenRefresher` mechanism to retrieve chat token on expiry
 
+### Changed
+- Add `ocSDKConfiguration` to reduce `chatToken` retries to 2
+
+### Fixed
+- Set `enableSenderDisplayNameInTypingNotification` to true to include display name on sending typing notification
+
 ## [1.4.2] - 2023-05-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Add `ocSDKConfiguration` to reduce `chatToken` retries to 2
+- Uptake [@microsoft/ocsdk@0.4.0](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.0)
 
 ### Fixed
 - Set `enableSenderDisplayNameInTypingNotification` to true to include display name on sending typing notification

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -2119,7 +2119,7 @@ describe('Omnichannel Chat SDK', () => {
             try {
                 await chatSDK.sendTypingEvent();
             } catch (error) {
-                expect(console.error).toHaveBeenCalled();
+                expect(error).toBeDefined();
             }
 
             expect(chatSDK.conversation.indicateTypingStatus).toHaveBeenCalledTimes(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.3.1-0",
+  "version": "1.4.4-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -767,9 +767,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -1094,9 +1094,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.3.4.tgz",
-      "integrity": "sha512-Ei417ceQBPoRG0bsMj/GKlMTRBbPm0osFJCP+qs1hgjMWt64H3sthKWo+bMgCaW4NoASwqJ57v1Pm7SwzgJqEA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.0.tgz",
+      "integrity": "sha512-8VvbXxyUs+8OfbJRv/IW0VF3lRso0UeaL6NabaBz7+VsXe+qXTGqYv0SfSOzMjG9h6GFFxxM8fYfYCGSu6sIqQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@azure/communication-chat": "1.1.1",
     "@azure/communication-common": "1.1.0",
-    "@microsoft/ocsdk": "^0.3.4",
+    "@microsoft/ocsdk": "^0.4.0",
     "@microsoft/omnichannel-amsclient": "^0.1.4",
     "@microsoft/omnichannel-ic3core": "^0.1.2"
   }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -124,7 +124,6 @@ class OmnichannelChatSDK {
     private isChatReconnect = false;
     private reconnectId: null | string = null;
     private refreshTokenTimer: number | null = null;
-    private chatTokenRefreshTimer: number | null = null;
 
     constructor(omnichannelConfig: OmnichannelConfig, chatSDKConfig: ChatSDKConfig = defaultChatSDKConfig) {
         this.debug = false;

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -472,35 +472,9 @@ class OmnichannelChatSDK {
                 pollingInterval: 30000
             };
 
-            // TODO: Find atob() platform-agnostic alternative
-            if (!platform.isNode() && !platform.isReactNative()) {
-                const refreshChatToken = async () => {
-                    const {token} = this.chatToken;
-                    const payload = (token as string).split(".")[1];
-                    const decodedPayload = JSON.parse(atob(payload));
-                    const {expiry} = decodedPayload;
-                    const currentTime = new Date().getTime();
-                    const tokenExpired = currentTime >= expiry;
-                    const tokenExpiringSoon = currentTime >= expiry - (30 * 1000);
-                    const ttl = (expiry - currentTime);
-                    const nextInterval = tokenExpired? 0: ttl * 0.5;
-
-                    if (tokenExpiringSoon) {
-                        clearTimeout(this.chatTokenRefreshTimer as number);
-                        await this.getChatToken(false);
-                        chatAdapterConfig.token = this.chatToken.token; // Update token
-                    }
-
-                    this.chatTokenRefreshTimer = setTimeout(async () => {
-                        refreshChatToken();
-                    }, nextInterval) as unknown as number;
-                }
-
-                refreshChatToken();
-            }
-
             const tokenRefresher = async (): Promise<string> => {
-                return chatAdapterConfig.token as string;
+                await this.getChatToken(false);
+                return this.chatToken.token as string;
             };
 
             try {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1341,9 +1341,9 @@ class OmnichannelChatSDK {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string
                 });
-
-                return error;
             }
+
+            return {} as OmnichannelMessage;
         }
     }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -81,6 +81,7 @@ import createTelemetry from "./utils/createTelemetry";
 import createVoiceVideoCalling from "./api/createVoiceVideoCalling";
 import { defaultMessageTags } from "./core/messaging/MessageTags";
 import exceptionThrowers from "./utils/exceptionThrowers";
+import exceptionSuppressors from "./utils/exceptionSuppressors";
 import { getLocationInfo } from "./utils/location";
 import {isCustomerMessage} from "./utils/utilities";
 import urlResolvers from "./utils/urlResolvers";
@@ -726,16 +727,12 @@ class OmnichannelChatSDK {
 
             return liveWorkItemDetails;
         } catch (error) {
-            const exceptionDetails: ChatSDKExceptionDetails = {
-                response: ChatSDKErrors.ConversationDetailsRetrievalFailure,
-                errorObject: `${error}`
-            };
-
-            this.scenarioMarker.failScenario(TelemetryEvent.GetConversationDetails, {
+            const telemetryData = {
                 RequestId: requestId,
                 ChatId: chatId || '',
-                ExceptionDetails: JSON.stringify(exceptionDetails)
-            });
+            };
+
+            exceptionSuppressors.suppressConversationDetailsRetrievalFailure(error, this.scenarioMarker, TelemetryEvent.GetConversationDetails, telemetryData);
         }
 
         return {} as LiveWorkItemDetails;

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1926,8 +1926,6 @@ class OmnichannelChatSDK {
                 ChatId: this.chatToken.chatId as string,
                 ExceptionDetails: JSON.stringify(exceptionDetails)
             });
-
-            console.error(`OmnichannelChatSDK/updateChatToken/error ${error}`);
         }
     }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -207,9 +207,15 @@ class OmnichannelChatSDK {
             return this.liveChatConfig;
         }
 
+        const ocSDKConfiguration = {
+            getChatTokenRetryCount: 2,
+            getChatTokenTimeBetweenRetriesOnFailure: 2000,
+            getChatTokenRetryOn429: false,
+        };
+
         try {
             this.OCSDKProvider = OCSDKProvider;
-            this.OCClient = await OCSDKProvider.getSDK(this.omnichannelConfig as IOmnichannelConfiguration, {} as ISDKConfiguration, this.ocSdkLogger as OCSDKLogger);
+            this.OCClient = await OCSDKProvider.getSDK(this.omnichannelConfig as IOmnichannelConfiguration, ocSDKConfiguration as ISDKConfiguration, this.ocSdkLogger as OCSDKLogger);
         } catch (e) {
             exceptionThrowers.throwOmnichannelClientInitializationFailure(e, this.scenarioMarker, TelemetryEvent.InitializeChatSDK);
         }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -471,10 +471,15 @@ class OmnichannelChatSDK {
                 pollingInterval: 30000
             };
 
+            const tokenRefresher = async (): Promise<string> => {
+                return chatAdapterConfig.token as string;
+            };
+
             try {
                 await this.ACSClient?.initialize({
                     token: chatAdapterConfig.token as string,
-                    environmentUrl: chatAdapterConfig.environmentUrl
+                    environmentUrl: chatAdapterConfig.environmentUrl,
+                    tokenRefresher
                 });
             } catch (error) {
                 const telemetryData = {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1902,13 +1902,13 @@ class OmnichannelChatSDK {
         })
 
         try {
-            const sessionInfo: IInitializationInfo = {
-                token: newToken,
-                regionGtms: newRegionGTMS,
-                visitor: true
-            }
-
             if (this.liveChatVersion === LiveChatVersion.V1) {
+                const sessionInfo: IInitializationInfo = {
+                    token: newToken,
+                    regionGtms: newRegionGTMS,
+                    visitor: true
+                };
+
                 await this.IC3Client.initialize(sessionInfo);
             }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1109,7 +1109,7 @@ class OmnichannelChatSDK {
                     ChatId: this.chatToken.chatId as string
                 });
 
-                throw new Error('OCClientSendTypingFailed');
+                throw new Error('SendTypingFailure');
             }
         } else {
             const typingPayload = `{isTyping: 0}`;
@@ -1125,13 +1125,12 @@ class OmnichannelChatSDK {
                     ChatId: this.chatToken.chatId as string
                 });
             } catch (error) {
-                console.error("OmnichannelChatSDK/sendTypingEvent/error");
-
                 this.scenarioMarker.failScenario(TelemetryEvent.SendTypingEvent, {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string
                 });
-                return error;
+
+                throw new Error('SendTypingFailure');
             }
         }
     }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -481,9 +481,11 @@ class OmnichannelChatSDK {
                     const {expiry} = decodedPayload;
                     const currentTime = new Date().getTime();
                     const tokenExpired = currentTime >= expiry;
-                    const nextInterval = tokenExpired? 0: (expiry - currentTime) * 0.5;
+                    const tokenExpiringSoon = currentTime >= expiry - (30 * 1000);
+                    const ttl = (expiry - currentTime);
+                    const nextInterval = tokenExpired? 0: ttl * 0.5;
 
-                    if (tokenExpired) {
+                    if (tokenExpiringSoon) {
                         clearTimeout(this.chatTokenRefreshTimer as number);
                         await this.getChatToken(false);
                         chatAdapterConfig.token = this.chatToken.token; // Update token

--- a/src/api/createVoiceVideoCalling.ts
+++ b/src/api/createVoiceVideoCalling.ts
@@ -239,7 +239,6 @@ export class VoiceVideoCallingProxy {
             });
 
             console.error(`[VoiceVideoCallingProxy][rejectCall][makeSecondaryChannelEventRequest] Failure ${e}`);
-            return e;
         }
     }
 

--- a/src/core/GetChatTokenOptionalParams.ts
+++ b/src/core/GetChatTokenOptionalParams.ts
@@ -1,0 +1,3 @@
+export default interface GetChatTokenOptionalParams {
+    refreshToken?: boolean;
+}

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -4,7 +4,7 @@ import { ACSClientLogger } from "../../utils/loggers";
 import ACSParticipantDisplayName from "./ACSParticipantDisplayName";
 import ACSSessionInfo from "./ACSSessionInfo";
 import { ChatClient, ChatParticipant, ChatThreadClient, ChatMessage } from "@azure/communication-chat";
-import { AzureCommunicationTokenCredential, CommunicationTokenRefreshOptions, CommunicationUserIdentifier } from "@azure/communication-common";
+import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from "@azure/communication-common";
 import { ChatMessageReceivedEvent, ParticipantsRemovedEvent, TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
 import ChatSDKMessage from "./ChatSDKMessage";
 import createOmnichannelMessage from "../../utils/createOmnichannelMessage";

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -419,7 +419,8 @@ class ACSClient {
         try {
             this.tokenCredential = new AzureCommunicationTokenCredential({
                 token: acsClientConfig.token,
-                tokenRefresher
+                tokenRefresher, // tokenRefresher is executed when token found to be expired on performing HTTP calls
+                refreshProactively: true // Flag to whether refresh token 10 mins it expires
             });
         } catch (error) {
             const exceptionDetails = {

--- a/src/core/messaging/ACSClientConfig.ts
+++ b/src/core/messaging/ACSClientConfig.ts
@@ -1,4 +1,5 @@
 export default interface ACSClientConfig {
     token: string;
     environmentUrl: string;
+    tokenRefresher?: () => Promise<string>;
 }

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -61,6 +61,7 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
         enableAdaptiveCards: true, // Whether to enable adaptive card payload in adapter (payload in JSON string)
         enableThreadMemberUpdateNotification: true, // Whether to enable chat thread member join/leave notification
         enableLeaveThreadOnWindowClosed: false, // Whether to remove user on browser close event
+        enableSenderDisplayNameInTypingNotification: true, // Whether to send sender display name in typing notification
         ...options, // overrides
         ingressMiddleware,
         egressMiddleware

--- a/src/utils/exceptionSuppressors.ts
+++ b/src/utils/exceptionSuppressors.ts
@@ -1,0 +1,45 @@
+/**
+ * Utilities to suppress exception on failures in ChatSDK.
+ *
+ * It should catch an exception, then silently fail. Not every exception thrown should be known by the user.
+ *
+ * An exception details object would be logged in telemetry with ChatSDK standard errors as response with the exception object if any.
+ *
+ * If a longer message needs to displayed to the user, a console.error() would be preferred.
+ *
+ * Stack trace should only be logged and not printed.
+ */
+
+import ChatSDKErrors from "../core/ChatSDKErrors";
+import ChatSDKExceptionDetails from "../core/ChatSDKExceptionDetails";
+import ScenarioMarker from "../telemetry/ScenarioMarker";
+import TelemetryEvent from "../telemetry/TelemetryEvent";
+
+export const suppressChatSDKError = (chatSDKError: ChatSDKErrors, e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string} = {}, message = ""): void => {
+    const exceptionDetails: ChatSDKExceptionDetails = {
+        response: chatSDKError
+    };
+
+    if (e) {
+        exceptionDetails.errorObject = `${e}`;
+    }
+
+    scenarioMarker.failScenario(telemetryEvent, {
+        ...telemetryData,
+        ExceptionDetails: JSON.stringify(exceptionDetails)
+    });
+
+    if (message) {
+        exceptionDetails.message = message;
+        console.error(message);
+    }
+}
+
+export const suppressConversationDetailsRetrievalFailure = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string} = {}): void => {
+    suppressChatSDKError(ChatSDKErrors.ConversationDetailsRetrievalFailure, e, scenarioMarker, telemetryEvent, telemetryData);
+}
+
+export default {
+    suppressChatSDKError,
+    suppressConversationDetailsRetrievalFailure
+}

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -1,7 +1,9 @@
 /**
  * Utilities to throw exception on failures in ChatSDK.
  *
- * It should throw ChatSDK standard errors as response with the exception object if any.
+ * It should throw ChatSDK standard errors.
+ *
+ * An exception details object would be logged in telemetry with ChatSDK standard errors as response with the exception object if any.
  *
  * The error thrown should have a short message in CamelCase to allow the exception to be caught easily programmatically.
  *


### PR DESCRIPTION
- Pass `tokenRefresher` to fetch `chatToken` when getting closer to expiry
- Reduce `chatToken` call retries to 2
- Include user display name on sending typing notification