### PR TITLE
Add validation for present values in telemetry

### DIFF
--- a/__tests__/OmnichannelChatSDK.node.spec.ts
+++ b/__tests__/OmnichannelChatSDK.node.spec.ts
@@ -14,7 +14,7 @@ describe('Omnichannel Chat SDK (Node)', () => {
     AWTLogManager.initialize = jest.fn();
 
     const omnichannelConfig = {
-        orgUrl: '[data-org-uri]',
+        orgUrl: '[data-org-url]',
         orgId: '[data-org-id]',
         widgetId: '[data-app-id]'
     };

--- a/__tests__/OmnichannelChatSDK.node.spec.ts
+++ b/__tests__/OmnichannelChatSDK.node.spec.ts
@@ -14,9 +14,9 @@ describe('Omnichannel Chat SDK (Node)', () => {
     AWTLogManager.initialize = jest.fn();
 
     const omnichannelConfig = {
-        orgUrl: '',
-        orgId: '',
-        widgetId: ''
+        orgUrl: '[data-org-uri]',
+        orgId: '[data-org-id]',
+        widgetId: '[data-app-id]'
     };
 
     beforeEach(() => {

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -28,10 +28,38 @@ describe('Omnichannel Chat SDK', () => {
             }
         });
 
-        it('ChatSDK should throw an error if a required omnichannelConfig value is missing', () => {
+        it('ChatSDK should throw an error if a required omnichannelConfig property is missing', () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
                 orgId:'[data-org-id]'
+            };
+
+            try {
+                new OmnichannelChatSDK(omnichannelConfig);
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+            }
+        });
+
+        it('ChatSDK should throw an error if a required omnichannelConfig value is missing', () => {
+            const omnichannelConfig = {
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId:''
+            };
+
+            try {
+                new OmnichannelChatSDK(omnichannelConfig);
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+            }
+        });
+
+        it('ChatSDK should throw an error if a required omnichannelConfig value is a string with blank space', () => {
+            const omnichannelConfig = {
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId:' '
             };
 
             try {

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -35,12 +35,15 @@ describe('Omnichannel Chat SDK', () => {
                 orgId:'[data-org-id]'
             };
 
+            let flag = false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
-                fail();
+                flag= true;
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
             }
+
+            expect(flag).toBe(false);
         });
 
 
@@ -51,13 +54,15 @@ describe('Omnichannel Chat SDK', () => {
                 widgetId:'   '
             };
 
+            let flag = false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
-                fail();
+                flag= true;
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
             }
+            expect(flag).toBe(false);
         });
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is missing', () => {
@@ -67,13 +72,15 @@ describe('Omnichannel Chat SDK', () => {
                 widgetId:undefined
             };
 
+            let flag = false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
-                fail();
+                flag= true;
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
             }
+            expect(flag).toBe(false);
         });
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is declared as undefined', () => {
@@ -82,14 +89,15 @@ describe('Omnichannel Chat SDK', () => {
                 orgId:'[data-org-id]',
                 widgetId:undefined
             };
-
+            let flag = false;
             try {
-                new OmnichannelChatSDK(omnichannelConfig);
-                fail();
+             new OmnichannelChatSDK(omnichannelConfig);
+             flag= true;  
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
             }
+            expect(flag).toBe(false);
         });
 
         it('ChatSDK should not throw an error if a required omnichannelConfig value is not string', () => {
@@ -98,12 +106,8 @@ describe('Omnichannel Chat SDK', () => {
                 orgId:1234,
                 widgetId:true
             };
-
-            try {
-                new OmnichannelChatSDK(omnichannelConfig);
-            } catch (error) {
-             fail("Expected no error to be thrown but got: " + error.message);
-            }
+            const result = new OmnichannelChatSDK(omnichannelConfig);
+            expect(result).toBeInstanceOf(OmnichannelChatSDK);
         });
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is a string with blank space', () => {
@@ -113,11 +117,14 @@ describe('Omnichannel Chat SDK', () => {
                 widgetId:' '
             };
 
+            let flag=false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
+                flag=true;
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
             }
+            expect(flag).toBe(false);
         });
 
         it('ChatSDK should be able to pick custom ic3ClientVersion if set', async () => {

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -23,6 +23,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should require omnichannelConfig as parameter', () => {
             try {
                 new OmnichannelChatSDK();
+                fail();
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
             }
@@ -36,8 +37,26 @@ describe('Omnichannel Chat SDK', () => {
 
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
+                fail();
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
+            }
+        });
+
+
+        it('ChatSDK should throw an error if a required omnichannelConfig value is just blank spaces', () => {
+            const omnichannelConfig = {
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId:'   '
+            };
+
+            try {
+                new OmnichannelChatSDK(omnichannelConfig);
+                fail();
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+                expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
             }
         });
 
@@ -45,13 +64,45 @@ describe('Omnichannel Chat SDK', () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
                 orgId:'[data-org-id]',
-                widgetId:''
+                widgetId:undefined
+            };
+
+            try {
+                new OmnichannelChatSDK(omnichannelConfig);
+                fail();
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+                expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
+            }
+        });
+
+        it('ChatSDK should throw an error if a required omnichannelConfig value is declared as undefined', () => {
+            const omnichannelConfig = {
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId:undefined
+            };
+
+            try {
+                new OmnichannelChatSDK(omnichannelConfig);
+                fail();
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+                expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
+            }
+        });
+
+        it('ChatSDK should not throw an error if a required omnichannelConfig value is not string', () => {
+            const omnichannelConfig = {
+                orgUrl: '[data-org-url]',
+                orgId:1234,
+                widgetId:true
             };
 
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
             } catch (error) {
-                expect(error).toBeInstanceOf(Error);
+             fail("Expected no error to be thrown but got: " + error.message);
             }
         });
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -30,7 +30,7 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should throw an error if a required omnichannelConfig property is missing', () => {
             const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
+                orgUrl: '[data-org-url]',
                 orgId:'[data-org-id]'
             };
 
@@ -57,7 +57,7 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is a string with blank space', () => {
             const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
+                orgUrl: '[data-org-url]',
                 orgId:'[data-org-id]',
                 widgetId:' '
             };
@@ -303,9 +303,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('Telemetry should be disabled if set', () => {
             const omnichannelConfig = {
-                orgUrl: 'www.microsoft.com',
-                orgId: '1234',
-                widgetId: '5678'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -326,9 +326,9 @@ describe('Omnichannel Chat SDK', () => {
             jest.clearAllMocks();
 
             const omnichannelConfig = {
-                orgUrl: 'www.microsoft.com',
-                orgId: '1234',
-                widgetId: '5678'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             jest.spyOn(AriaTelemetry, 'disable');
@@ -341,9 +341,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up custom ariaTelemetryKey if set', () => {
             const omnichannelConfig = {
-                orgUrl: 'www.microsoft.com',
-                orgId: '1234',
-                widgetId: '56778'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -363,9 +363,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the default persistent chat config if not set', () => {
             const omnichannelConfig = {
-                orgUrl: 'www.microsoft.com',
-                orgId: '1234',
-                widgetId: '5678'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -376,9 +376,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the custom persistent chat config if set', () => {
             const omnichannelConfig = {
-                orgUrl: 'www.microsft.com',
-                orgId: '12345',
-                widgetId: '398709'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]]'
             };
 
             const chatSDKConfig = {
@@ -396,9 +396,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the default chat reconnect config if not set', () => {
             const omnichannelConfig = {
-                orgUrl: 'www.microsoft.com',
-                orgId: '1234',
-                widgetId: '5678'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -408,9 +408,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the custom chat reconnect config if set', () => {
             const omnichannelConfig = {
-                orgUrl: 'www.microsoft.com',
-                orgId: '1234',
-                widgetId: '5678'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -427,9 +427,9 @@ describe('Omnichannel Chat SDK', () => {
 
     describe('Functionalities', () => {
         const omnichannelConfig = {
-            orgUrl: 'www.microsoft.om',
-            orgId: '1234',
-            widgetId: '5678'
+            orgUrl: '[data-org-url]',
+            orgId: '[data-org-id]',
+            widgetId: '[data-app-id]'
         };
 
         beforeEach(() => {
@@ -1308,9 +1308,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it("ChatSDK.startChat() with an unsupported locale should throw an exception", async () => {
             const omnichannelConfig = {
-                orgUrl: 'microsofthealthcare.crm.dynamics.com',
-                orgId: '00000000-0000-0000-0000-000000000000',
-                widgetId: '12345678-1234-1234-1234-123456789012',
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]',
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -2498,9 +2498,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it("ChatSDK.getLiveChatTranscript() with liveChatContext should fetch transcript from liveChatContext", async () => {
             const omnichannelConfig = {
-                orgUrl: 'www.microsoft.com',
-                orgId: '1234',
-                widgetId: '5678'
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -19,6 +19,12 @@ import libraries from "../src/utils/libraries";
 describe('Omnichannel Chat SDK', () => {
     AWTLogManager.initialize = jest.fn();
 
+    const omnichannelConfigGlobal = {
+        orgUrl: '[data-org-uri]',
+        orgId: '[data-org-id]',
+        widgetId: '[data-app-id]'
+    };
+
     describe('Configurations', () => {
         it('ChatSDK should require omnichannelConfig as parameter', () => {
             try {
@@ -116,11 +122,6 @@ describe('Omnichannel Chat SDK', () => {
         });
 
         it('ChatSDK should be able to pick custom ic3ClientVersion if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 ic3Config: {
@@ -128,18 +129,13 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             const url = chatSDK.resolveIC3ClientUrl();
 
             expect(url).toBe(libraries.getIC3ClientCDNUrl(chatSDKConfig.ic3Config.ic3ClientVersion));
         });
 
         it('ChatSDK should be able to pick custom ic3ClientCDNUrl if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 ic3Config: {
@@ -148,31 +144,20 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             const url = chatSDK.resolveIC3ClientUrl();
 
             expect(url).toBe(chatSDKConfig.ic3Config.ic3ClientCDNUrl);
         });
 
         it('ChatSDK should pick the default ic3ClientCDNUrl if no ic3Config is set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
-
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
             const url = chatSDK.resolveIC3ClientUrl();
 
             expect(url).toBe(libraries.getIC3ClientCDNUrl());
         });
 
         it('[LiveChatV1] ChatSDK should be able to pick custom webChatIC3AdapterVersion if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 chatAdapterConfig: {
@@ -180,7 +165,7 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             chatSDK.liveChatVersion = LiveChatVersion.V1;
 
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.IC3);
@@ -189,11 +174,6 @@ describe('Omnichannel Chat SDK', () => {
         });
 
         it('[LiveChatV1] ChatSDK should be able to pick custom webChatIC3AdapterCDNUrl if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 chatAdapterConfig: {
@@ -202,7 +182,7 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             chatSDK.liveChatVersion = LiveChatVersion.V1;
 
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.IC3);
@@ -211,13 +191,8 @@ describe('Omnichannel Chat SDK', () => {
         });
 
         it('[LiveChatV1] ChatSDK should pick the default webChatIC3AdapterCDNUrl if no chatAdapterConfig is set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
             chatSDK.liveChatVersion = LiveChatVersion.V1;
 
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.IC3);
@@ -226,11 +201,6 @@ describe('Omnichannel Chat SDK', () => {
         });
 
         it('ChatSDK should be able to pick custom webChatACSAdapterVersion if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 chatAdapterConfig: {
@@ -238,18 +208,13 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.ACS);
 
             expect(url).toBe(libraries.getACSAdapterCDNUrl(chatSDKConfig.chatAdapterConfig.webChatACSAdapterVersion));
         });
 
         it('ChatSDK should be able to pick custom webChatACSAdapterCDNUrl if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 chatAdapterConfig: {
@@ -258,31 +223,21 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.ACS);
 
             expect(url).toBe(chatSDKConfig.chatAdapterConfig.webChatACSAdapterCDNUrl);
         });
 
         it('ChatSDK should pick the default webChatACSAdapterCDNUrl if no chatAdapterConfig is set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.ACS);
 
             expect(url).toBe(libraries.getACSAdapterCDNUrl());
         });
 
         it('ChatSDK should be able to pick custom webChatDirectLineVersion if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 chatAdapterConfig: {
@@ -290,18 +245,13 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.DirectLine);
 
             expect(url).toBe(libraries.getDirectLineCDNUrl(chatSDKConfig.chatAdapterConfig.webChatDirectLineVersion));
         });
 
         it('ChatSDK should be able to pick custom webChatDirectLineCDNUrl if set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 chatAdapterConfig: {
@@ -310,34 +260,23 @@ describe('Omnichannel Chat SDK', () => {
                 }
             };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.DirectLine);
 
             expect(url).toBe(chatSDKConfig.chatAdapterConfig.webChatDirectLineCDNUrl);
         });
 
         it('ChatSDK should pick the default webChatDirectLineCDNUrl if no chatAdapterConfig is set', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
             const url = chatSDK.resolveChatAdapterUrl(ChatAdapterProtocols.DirectLine);
 
             expect(url).toBe(libraries.getDirectLineCDNUrl());
         });
 
         it('ChatSDK should throw an error if ChatSDK.resolveChatAdapterUrl() is called with other protocol than supported protocols', async () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
-
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
             const protocol = "UnsupportedProtocol";
             try {
                 chatSDK.resolveChatAdapterUrl(protocol);
@@ -348,11 +287,6 @@ describe('Omnichannel Chat SDK', () => {
         });
 
         it('Telemetry should be disabled if set', () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-url]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
 
             const chatSDKConfig = {
                 telemetry: {
@@ -362,7 +296,7 @@ describe('Omnichannel Chat SDK', () => {
 
             jest.spyOn(AriaTelemetry, 'disable');
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
 
             expect(chatSDK.chatSDKConfig.telemetry.disable).toBe(true);
             expect(AriaTelemetry.disable).toHaveBeenCalledTimes(1);
@@ -371,27 +305,15 @@ describe('Omnichannel Chat SDK', () => {
         it('Telemetry should be enabled by default', () => {
             jest.clearAllMocks();
 
-            const omnichannelConfig = {
-                orgUrl: '[data-org-url]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
-
             jest.spyOn(AriaTelemetry, 'disable');
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
 
             expect(chatSDK.chatSDKConfig.telemetry.disable).toBe(false);
             expect(AriaTelemetry.disable).toHaveBeenCalledTimes(0);
         });
 
         it('ChatSDK should be able to pick up custom ariaTelemetryKey if set', () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-url]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
-
             const chatSDKConfig = {
                 telemetry: {
                     ariaTelemetryKey: 'custom'
@@ -400,7 +322,7 @@ describe('Omnichannel Chat SDK', () => {
 
             const fn = jest.spyOn(AriaTelemetry, 'initialize');
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
 
             expect(AriaTelemetry.initialize).toHaveBeenCalledTimes(1);
             expect(chatSDK.chatSDKConfig.telemetry.ariaTelemetryKey).toBe(chatSDKConfig.telemetry.ariaTelemetryKey);
@@ -408,24 +330,15 @@ describe('Omnichannel Chat SDK', () => {
         });
 
         it('ChatSDK should be able to pick up the default persistent chat config if not set', () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-url]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
-
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(chatSDK.chatSDKConfig.persistentChat.disable).toBe(defaultChatSDKConfig.persistentChat!.disable);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(chatSDK.chatSDKConfig.persistentChat.tokenUpdateTime).toBe(defaultChatSDKConfig.persistentChat!.tokenUpdateTime);
         });
 
         it('ChatSDK should be able to pick up the custom persistent chat config if set', () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-url]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]]'
-            };
 
             const chatSDKConfig = {
                 persistentChat: {
@@ -434,21 +347,16 @@ describe('Omnichannel Chat SDK', () => {
                 }
             }
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal, chatSDKConfig);
 
             expect(chatSDK.chatSDKConfig.persistentChat.disable).toBe(chatSDKConfig.persistentChat.disable);
             expect(chatSDK.chatSDKConfig.persistentChat.tokenUpdateTime).toBe(chatSDKConfig.persistentChat.tokenUpdateTime);
         });
 
         it('ChatSDK should be able to pick up the default chat reconnect config if not set', () => {
-            const omnichannelConfig = {
-                orgUrl: '[data-org-url]',
-                orgId: '[data-org-id]',
-                widgetId: '[data-app-id]'
-            };
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
 
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
-
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(chatSDK.chatSDKConfig.chatReconnect.disable).toBe(defaultChatSDKConfig.chatReconnect!.disable);
         });
 
@@ -989,6 +897,7 @@ describe('Omnichannel Chat SDK', () => {
                 RegionGtms: '{}'
             }));
 
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const axiosErrorObject: any = {};
             axiosErrorObject.isAxiosError = true;
             axiosErrorObject.response = {};
@@ -2099,6 +2008,7 @@ describe('Omnichannel Chat SDK', () => {
 
             await chatSDK.sendMessage(messageToSend);
             expect(chatSDK.conversation.sendMessage).toHaveBeenCalledTimes(1);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             expect((chatSDK.conversation.sendMessage.mock.calls[0][0] as any).timestamp).toEqual(messageToSend.timestamp);
         });
 
@@ -3510,7 +3420,7 @@ describe('Omnichannel Chat SDK', () => {
             jest.spyOn(console, 'error');
 
             try {
-                const postChatContext = await chatSDK.getPostChatSurveyContext();
+                await chatSDK.getPostChatSurveyContext();
                 throw("Should throw error.");
             } catch (ex) {
                 expect(chatSDK.getConversationDetails).not.toHaveBeenCalled();
@@ -3553,7 +3463,7 @@ describe('Omnichannel Chat SDK', () => {
             jest.spyOn(console, 'error');
 
             try {
-                const postChatContext = await chatSDK.getPostChatSurveyContext();
+                await chatSDK.getPostChatSurveyContext();
                 throw("Should throw error.");
             } catch (ex) {
                 expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);
@@ -3600,7 +3510,7 @@ describe('Omnichannel Chat SDK', () => {
             jest.spyOn(console, 'error');
 
             try {
-                const postChatContext = await chatSDK.getPostChatSurveyContext();
+                await chatSDK.getPostChatSurveyContext();
                 throw("Should throw error.");
             } catch (ex) {
                 expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -30,8 +30,8 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is missing', () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]'
             };
 
             try {
@@ -43,9 +43,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick custom ic3ClientVersion if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -62,9 +62,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick custom ic3ClientCDNUrl if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -82,9 +82,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should pick the default ic3ClientCDNUrl if no ic3Config is set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -95,9 +95,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('[LiveChatV1] ChatSDK should be able to pick custom webChatIC3AdapterVersion if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -116,9 +116,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('[LiveChatV1] ChatSDK should be able to pick custom webChatIC3AdapterCDNUrl if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -138,9 +138,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('[LiveChatV1] ChatSDK should pick the default webChatIC3AdapterCDNUrl if no chatAdapterConfig is set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -153,9 +153,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick custom webChatACSAdapterVersion if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -172,9 +172,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick custom webChatACSAdapterCDNUrl if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -192,9 +192,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should pick the default webChatACSAdapterCDNUrl if no chatAdapterConfig is set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -205,9 +205,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick custom webChatDirectLineVersion if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -224,9 +224,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick custom webChatDirectLineCDNUrl if set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDKConfig = {
@@ -244,9 +244,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should pick the default webChatDirectLineCDNUrl if no chatAdapterConfig is set', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -257,9 +257,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should throw an error if ChatSDK.resolveChatAdapterUrl() is called with other protocol than supported protocols', async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: '[data-org-uri]',
+                orgId:'[data-org-id]',
+                widgetId: '[data-app-id]'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -275,9 +275,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('Telemetry should be disabled if set', () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsoft.com',
+                orgId: '1234',
+                widgetId: '5678'
             };
 
             const chatSDKConfig = {
@@ -298,9 +298,9 @@ describe('Omnichannel Chat SDK', () => {
             jest.clearAllMocks();
 
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsoft.com',
+                orgId: '1234',
+                widgetId: '5678'
             };
 
             jest.spyOn(AriaTelemetry, 'disable');
@@ -313,9 +313,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up custom ariaTelemetryKey if set', () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsoft.com',
+                orgId: '1234',
+                widgetId: '56778'
             };
 
             const chatSDKConfig = {
@@ -335,9 +335,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the default persistent chat config if not set', () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsoft.com',
+                orgId: '1234',
+                widgetId: '5678'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -348,9 +348,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the custom persistent chat config if set', () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsft.com',
+                orgId: '12345',
+                widgetId: '398709'
             };
 
             const chatSDKConfig = {
@@ -368,9 +368,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the default chat reconnect config if not set', () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsoft.com',
+                orgId: '1234',
+                widgetId: '5678'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -380,9 +380,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should be able to pick up the custom chat reconnect config if set', () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsoft.com',
+                orgId: '1234',
+                widgetId: '5678'
             };
 
             const chatSDKConfig = {
@@ -399,9 +399,9 @@ describe('Omnichannel Chat SDK', () => {
 
     describe('Functionalities', () => {
         const omnichannelConfig = {
-            orgUrl: '',
-            orgId: '',
-            widgetId: ''
+            orgUrl: 'www.microsoft.om',
+            orgId: '1234',
+            widgetId: '5678'
         };
 
         beforeEach(() => {
@@ -1280,9 +1280,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it("ChatSDK.startChat() with an unsupported locale should throw an exception", async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'microsofthealthcare.crm.dynamics.com',
+                orgId: '00000000-0000-0000-0000-000000000000',
+                widgetId: '12345678-1234-1234-1234-123456789012',
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -2470,9 +2470,9 @@ describe('Omnichannel Chat SDK', () => {
 
         it("ChatSDK.getLiveChatTranscript() with liveChatContext should fetch transcript from liveChatContext", async () => {
             const omnichannelConfig = {
-                orgUrl: '',
-                orgId: '',
-                widgetId: ''
+                orgUrl: 'www.microsoft.com',
+                orgId: '1234',
+                widgetId: '5678'
             };
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -35,69 +35,59 @@ describe('Omnichannel Chat SDK', () => {
                 orgId:'[data-org-id]'
             };
 
-            let flag = false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
-                flag= true;
+                fail();
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
             }
-
-            expect(flag).toBe(false);
         });
-
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is just blank spaces', () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
-                widgetId:'   '
+                orgId: '[data-org-id]',
+                widgetId: '   '
             };
 
-            let flag = false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
-                flag= true;
+                fail();
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
             }
-            expect(flag).toBe(false);
         });
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is missing', () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
-                widgetId:undefined
+                orgId: '[data-org-id]',
+                widgetId: undefined
             };
 
-            let flag = false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
-                flag= true;
+                fail();
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
             }
-            expect(flag).toBe(false);
         });
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is declared as undefined', () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
-                widgetId:undefined
+                orgId: '[data-org-id]',
+                widgetId: undefined
             };
-            let flag = false;
             try {
-             new OmnichannelChatSDK(omnichannelConfig);
-             flag= true;  
+                new OmnichannelChatSDK(omnichannelConfig);
+                fail();
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe("Empty 'widgetId' in OmnichannelConfiguration");
             }
-            expect(flag).toBe(false);
         });
 
         it('ChatSDK should not throw an error if a required omnichannelConfig value is not string', () => {
@@ -113,24 +103,22 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should throw an error if a required omnichannelConfig value is a string with blank space', () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-url]',
-                orgId:'[data-org-id]',
-                widgetId:' '
+                orgId: '[data-org-id]',
+                widgetId: ' '
             };
 
-            let flag=false;
             try {
                 new OmnichannelChatSDK(omnichannelConfig);
-                flag=true;
+                fail();
             } catch (error) {
                 expect(error).toBeInstanceOf(Error);
             }
-            expect(flag).toBe(false);
         });
 
         it('ChatSDK should be able to pick custom ic3ClientVersion if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -149,7 +137,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should be able to pick custom ic3ClientCDNUrl if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -169,7 +157,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should pick the default ic3ClientCDNUrl if no ic3Config is set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -182,7 +170,7 @@ describe('Omnichannel Chat SDK', () => {
         it('[LiveChatV1] ChatSDK should be able to pick custom webChatIC3AdapterVersion if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -203,7 +191,7 @@ describe('Omnichannel Chat SDK', () => {
         it('[LiveChatV1] ChatSDK should be able to pick custom webChatIC3AdapterCDNUrl if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -225,7 +213,7 @@ describe('Omnichannel Chat SDK', () => {
         it('[LiveChatV1] ChatSDK should pick the default webChatIC3AdapterCDNUrl if no chatAdapterConfig is set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -240,7 +228,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should be able to pick custom webChatACSAdapterVersion if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -259,7 +247,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should be able to pick custom webChatACSAdapterCDNUrl if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -279,7 +267,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should pick the default webChatACSAdapterCDNUrl if no chatAdapterConfig is set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -292,7 +280,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should be able to pick custom webChatDirectLineVersion if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 
@@ -311,7 +299,7 @@ describe('Omnichannel Chat SDK', () => {
         it('ChatSDK should be able to pick custom webChatDirectLineCDNUrl if set', async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-uri]',
-                orgId:'[data-org-id]',
+                orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -20,7 +20,7 @@ describe('Omnichannel Chat SDK', () => {
     AWTLogManager.initialize = jest.fn();
 
     const omnichannelConfigGlobal = {
-        orgUrl: '[data-org-uri]',
+        orgUrl: '[data-org-url]',
         orgId: '[data-org-id]',
         widgetId: '[data-app-id]'
     };
@@ -51,7 +51,7 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is just blank spaces', () => {
             const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
+                orgUrl: '[data-org-url]',
                 orgId: '[data-org-id]',
                 widgetId: '   '
             };
@@ -67,7 +67,7 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is missing', () => {
             const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
+                orgUrl: '[data-org-url]',
                 orgId: '[data-org-id]',
                 widgetId: undefined
             };
@@ -83,7 +83,7 @@ describe('Omnichannel Chat SDK', () => {
 
         it('ChatSDK should throw an error if a required omnichannelConfig value is declared as undefined', () => {
             const omnichannelConfig = {
-                orgUrl: '[data-org-uri]',
+                orgUrl: '[data-org-url]',
                 orgId: '[data-org-id]',
                 widgetId: undefined
             };

--- a/__tests__/OmnichannelChatSDK.web.spec.ts
+++ b/__tests__/OmnichannelChatSDK.web.spec.ts
@@ -23,7 +23,7 @@ describe('Omnichannel Chat SDK (Web)', () => {
     AWTLogManager.initialize = jest.fn();
 
     const omnichannelConfig = {
-        orgUrl: '[data-org-uri]',
+        orgUrl: '[data-org-url]',
         orgId: '[data-org-id]',
         widgetId: '[data-app-id]'
     };

--- a/__tests__/OmnichannelChatSDK.web.spec.ts
+++ b/__tests__/OmnichannelChatSDK.web.spec.ts
@@ -23,9 +23,9 @@ describe('Omnichannel Chat SDK (Web)', () => {
     AWTLogManager.initialize = jest.fn();
 
     const omnichannelConfig = {
-        orgUrl: '',
-        orgId: '',
-        widgetId: ''
+        orgUrl: '[data-org-uri]',
+        orgId: '[data-org-id]',
+        widgetId: '[data-app-id]'
     };
 
     beforeEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.4.4-0",
+  "version": "1.3.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.3.1-0",
+  "version": "1.4.4-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/validators/OmnichannelConfigValidator.ts
+++ b/src/validators/OmnichannelConfigValidator.ts
@@ -7,14 +7,18 @@ const validateOmnichannelConfig = (omnichannelConfig: OmnichannelConfig): void =
       throw new Error(`OmnichannelConfiguration not found`);
     }
 
-    const mapEntries = new Map(Object.entries(omnichannelConfig));
-    let valueOfEntry;
-
     for (const key of requiredOmnichannelConfigParams) {
       //check for they key present in the map, if not present or value is undefined then throw error
-      valueOfEntry = mapEntries.get(key);
-      if (!valueOfEntry || valueOfEntry.trim() === "") {
+      const isPresent = Reflect.has(omnichannelConfig, key);
+
+      if (!isPresent) {
         throw new Error(`Missing '${key}' in OmnichannelConfiguration`);
+      }
+
+      const propertyValue = Reflect.get(omnichannelConfig, key);
+
+      if (propertyValue.length === 0) {
+        throw new Error(`Empty '${key}' in OmnichannelConfiguration`);
       }
     }
 }

--- a/src/validators/OmnichannelConfigValidator.ts
+++ b/src/validators/OmnichannelConfigValidator.ts
@@ -22,11 +22,9 @@ const validateOmnichannelConfig = (omnichannelConfig: OmnichannelConfig): void =
       */
       const propertyValue = Reflect.get(omnichannelConfig, key);
 
-      if (propertyValue) {
-        if ((typeof propertyValue === "string" && propertyValue?.trim().length === 0) || propertyValue.length === 0) {
-          throw new Error(`Empty '${key}' in OmnichannelConfiguration`);
-        }
-      } else {
+      if (!propertyValue || 
+        (typeof propertyValue === "string" && propertyValue.trim().length === 0) || 
+        propertyValue.length === 0) {
         throw new Error(`Empty '${key}' in OmnichannelConfiguration`);
       }
     }

--- a/src/validators/OmnichannelConfigValidator.ts
+++ b/src/validators/OmnichannelConfigValidator.ts
@@ -13,7 +13,7 @@ const validateOmnichannelConfig = (omnichannelConfig: OmnichannelConfig): void =
     for (const key of requiredOmnichannelConfigParams) {
       //check for they key present in the map, if not present or value is undefined then throw error
       valueOfEntry = mapEntries.get(key);
-      if (!valueOfEntry) {
+      if (!valueOfEntry || valueOfEntry.trim() === "") {
         throw new Error(`Missing '${key}' in OmnichannelConfiguration`);
       }
     }

--- a/src/validators/OmnichannelConfigValidator.ts
+++ b/src/validators/OmnichannelConfigValidator.ts
@@ -15,9 +15,14 @@ const validateOmnichannelConfig = (omnichannelConfig: OmnichannelConfig): void =
         throw new Error(`Missing '${key}' in OmnichannelConfiguration`);
       }
 
+      /**
+      * Since we know the keys that are required and we know those values are string, 
+      * there is no point in make a generic function to validate the object and different
+      * types of values based on its type. We can just check for the keys and check if the value is empty or not.
+      */
       const propertyValue = Reflect.get(omnichannelConfig, key);
 
-      if (propertyValue.length === 0) {
+      if (propertyValue?.trim().length === 0) {
         throw new Error(`Empty '${key}' in OmnichannelConfiguration`);
       }
     }

--- a/src/validators/OmnichannelConfigValidator.ts
+++ b/src/validators/OmnichannelConfigValidator.ts
@@ -22,7 +22,11 @@ const validateOmnichannelConfig = (omnichannelConfig: OmnichannelConfig): void =
       */
       const propertyValue = Reflect.get(omnichannelConfig, key);
 
-      if (propertyValue?.trim().length === 0) {
+      if (propertyValue) {
+        if ((typeof propertyValue === "string" && propertyValue?.trim().length === 0) || propertyValue.length === 0) {
+          throw new Error(`Empty '${key}' in OmnichannelConfiguration`);
+        }
+      } else {
         throw new Error(`Empty '${key}' in OmnichannelConfiguration`);
       }
     }

--- a/src/validators/OmnichannelConfigValidator.ts
+++ b/src/validators/OmnichannelConfigValidator.ts
@@ -7,9 +7,13 @@ const validateOmnichannelConfig = (omnichannelConfig: OmnichannelConfig): void =
       throw new Error(`OmnichannelConfiguration not found`);
     }
 
-    const currentOmnichannelConfigParams = Object.keys(omnichannelConfig);
+    const mapEntries = new Map(Object.entries(omnichannelConfig));
+    let valueOfEntry;
+
     for (const key of requiredOmnichannelConfigParams) {
-      if (!currentOmnichannelConfigParams.includes(key)) {
+      //check for they key present in the map, if not present or value is undefined then throw error
+      valueOfEntry = mapEntries.get(key);
+      if (!valueOfEntry) {
         throw new Error(`Missing '${key}' in OmnichannelConfiguration`);
       }
     }


### PR DESCRIPTION
we have detected in telemetry several entries without values for OrgId, WidgetId and OrgUrl.

in chat-sdk is only validated the presence of the property, but no the presence of the value, 

in this PR I'm addressing that issue

- add validation for values of the required properties
- fix tests
- additional tests for empty string and string with blank space