### PR TITLE
Add Async to Internal Live Chat Transcript Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Set `enableSenderDisplayNameInTypingNotification` to true to include display name on sending typing notification
+- Add `async` to `ChatSDK.getLiveChatTranscript()` internal call
 
 ## [1.4.3] - 2023-06-15
 

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -28,7 +28,7 @@ const config: PlaywrightTestConfig = {
     actionTimeout: 0,
     trace: 'on-first-retry',
     launchOptions: {
-      slowMo: 50
+      slowMo: parseInt(process.env.PLAYWRIGHT_SLOW_MO || 1000)
     }
   },
   projects: [

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1485,7 +1485,7 @@ class OmnichannelChatSDK {
                 getChatTranscriptOptionalParams.authenticatedUserToken = this.authenticatedUserToken;
             }
 
-            const transcriptResponse = this.OCClient.getChatTranscripts(
+            const transcriptResponse = await this.OCClient.getChatTranscripts(
                 requestId,
                 chatToken.chatId,
                 chatToken.token,


### PR DESCRIPTION
- Adding `async` to internal transcript call. Otherwise, it would only return the unfulfilled promise without the transcript response.