### PR TITLE
Chat SDK Performance - Added code to send performance data to Db through API call

### DIFF
--- a/playwright/performance/Initialize.spec.ts
+++ b/playwright/performance/Initialize.spec.ts
@@ -6,8 +6,8 @@ import { PerformanceTestResult } from '../utils/PerformanceTests';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
-let performanceDataTest: PerformanceData;
-let performanceDataTestCol: PerformanceData[] = [];
+let performanceDataTest: performanceData;
+let performanceDataTestCol: performanceData[] = [];
 test.afterEach(() => {
     performanceDataTestCol.push(performanceDataTest);
 });
@@ -19,8 +19,8 @@ test.afterAll(async () => {
 test.describe('Performance @Performance ', () => {
     test('ChatSDK.initialize()', async ({ page }) => {
         await page.goto(testPage);
-        
-        let [response, runtimeContext ] = await Promise.all([
+
+        let [response, runtimeContext] = await Promise.all([
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatConfigPath);
             }),
@@ -37,7 +37,7 @@ test.describe('Performance @Performance ', () => {
                     requestId: chatSDK.requestId,
                     timeTaken: timeTaken
                 };
-                
+
                 return runtimeContext;
             }, { omnichannelConfig }),
         ]);
@@ -46,12 +46,12 @@ test.describe('Performance @Performance ', () => {
         expect(response.status()).toBe(200);
 
         // Explicitly define the type of the 'data' variable
-        const data: PerformanceData = {
+        const data: performanceData = {
             "Scenario": "chatSDK.initialize()",
             "DateofRun": `${new Date()}`,
             "Threshold": 300,
             "ExecutionTime": runtimeContext.timeTaken
         };
-        performanceDataTest = data;     
+        performanceDataTest = data;
     });
 });

--- a/playwright/performance/Initialize.spec.ts
+++ b/playwright/performance/Initialize.spec.ts
@@ -2,7 +2,7 @@ import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
-import { PerformanceTestResult } from '../utils/PerformanceTests';
+import { createPerformanceData, PerformanceTestResult, performanceData } from '../utils/PerformanceTests';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
@@ -17,6 +17,7 @@ test.afterAll(async () => {
 });
 
 test.describe('Performance @Performance ', () => {
+    const threshold = 2000;
     test('ChatSDK.initialize()', async ({ page }) => {
         await page.goto(testPage);
 
@@ -45,13 +46,8 @@ test.describe('Performance @Performance ', () => {
         console.log("chatSDK.initialize(): " + runtimeContext.timeTaken);
         expect(response.status()).toBe(200);
 
-        // Explicitly define the type of the 'data' variable
-        const data: performanceData = {
-            "Scenario": "chatSDK.initialize()",
-            "DateofRun": `${new Date()}`,
-            "Threshold": 300,
-            "ExecutionTime": runtimeContext.timeTaken
-        };
-        performanceDataTest = data;
+        const executionTime = runtimeContext.timeTaken;
+        const data: PerformanceData = createPerformanceData("chatSDK.initialize()", executionTime, threshold);
+        performanceDataTest = data; 
     });
 });

--- a/playwright/performance/Initialize.spec.ts
+++ b/playwright/performance/Initialize.spec.ts
@@ -2,9 +2,19 @@ import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
+import { PerformanceTestResult } from '../utils/PerformanceTests';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
+let performanceDataTest: PerformanceData;
+let performanceDataTestCol: PerformanceData[] = [];
+test.afterEach(() => {
+    performanceDataTestCol.push(performanceDataTest);
+});
+
+test.afterAll(async () => {
+    await PerformanceTestResult(performanceDataTestCol);
+});
 
 test.describe('Performance @Performance ', () => {
     test('ChatSDK.initialize()', async ({ page }) => {
@@ -34,5 +44,14 @@ test.describe('Performance @Performance ', () => {
 
         console.log("chatSDK.initialize(): " + runtimeContext.timeTaken);
         expect(response.status()).toBe(200);
+
+        // Explicitly define the type of the 'data' variable
+        const data: PerformanceData = {
+            "Scenario": "chatSDK.initialize()",
+            "DateofRun": `${new Date()}`,
+            "Threshold": 300,
+            "ExecutionTime": runtimeContext.timeTaken
+        };
+        performanceDataTest = data;     
     });
 });

--- a/playwright/performance/StartChat.spec.ts
+++ b/playwright/performance/StartChat.spec.ts
@@ -6,8 +6,8 @@ import { PerformanceTestResult } from '../utils/PerformanceTests';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
-let performanceDataTest: PerformanceData;
-let performanceDataTestCol: PerformanceData[] = [];
+let performanceDataTest: performanceData;
+let performanceDataTestCol: performanceData[] = [];
 test.afterEach(() => {
     performanceDataTestCol.push(performanceDataTest);
 });
@@ -51,12 +51,12 @@ test.describe('Performance @Performance', () => {
         expect(chatTokenResponse.status()).toBe(200);
 
         // Explicitly define the type of the 'data' variable
-        const data: PerformanceData = {
+        const data: performanceData = {
             "Scenario": "chatSDK.startChat()",
             "DateofRun": `${new Date()}`,
             "Threshold": 300,
             "ExecutionTime": runtimeContext.timeTaken
         };
-        performanceDataTest = data;     
+        performanceDataTest = data;
     });
 });

--- a/playwright/performance/StartChat.spec.ts
+++ b/playwright/performance/StartChat.spec.ts
@@ -2,7 +2,8 @@ import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import { test, expect } from '@playwright/test';
-import { PerformanceTestResult } from '../utils/PerformanceTests';
+import { createPerformanceData, PerformanceTestResult, performanceData } from '../utils/PerformanceTests';
+
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
@@ -18,6 +19,7 @@ test.afterAll(async () => {
 
 test.describe('Performance @Performance', () => {
     test('ChatSDK.startChat()', async ({ page }) => {
+        const threshold = 2000;
         await page.goto(testPage);
 
         const [chatTokenResponse, runtimeContext] = await Promise.all([
@@ -50,13 +52,11 @@ test.describe('Performance @Performance', () => {
 
         expect(chatTokenResponse.status()).toBe(200);
 
-        // Explicitly define the type of the 'data' variable
-        const data: performanceData = {
-            "Scenario": "chatSDK.startChat()",
-            "DateofRun": `${new Date()}`,
-            "Threshold": 300,
-            "ExecutionTime": runtimeContext.timeTaken
-        };
-        performanceDataTest = data;
+        console.log("chatSDK.startChat(): " + runtimeContext.timeTaken);
+        expect(chatTokenResponse.status()).toBe(200);
+
+        const executionTime = runtimeContext.timeTaken;
+        const data: PerformanceData = createPerformanceData("chatSDK.startChat()", executionTime, threshold);
+        performanceDataTest = data; 
     });
 });

--- a/playwright/performance/StartChat.spec.ts
+++ b/playwright/performance/StartChat.spec.ts
@@ -2,9 +2,19 @@ import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import { test, expect } from '@playwright/test';
+import { PerformanceTestResult } from '../utils/PerformanceTests';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
+let performanceDataTest: PerformanceData;
+let performanceDataTestCol: PerformanceData[] = [];
+test.afterEach(() => {
+    performanceDataTestCol.push(performanceDataTest);
+});
+
+test.afterAll(async () => {
+    await PerformanceTestResult(performanceDataTestCol);
+});
 
 test.describe('Performance @Performance', () => {
     test('ChatSDK.startChat()', async ({ page }) => {
@@ -39,5 +49,14 @@ test.describe('Performance @Performance', () => {
         console.log("chatSDK.startChat(): " + timeTaken);
 
         expect(chatTokenResponse.status()).toBe(200);
+
+        // Explicitly define the type of the 'data' variable
+        const data: PerformanceData = {
+            "Scenario": "chatSDK.startChat()",
+            "DateofRun": `${new Date()}`,
+            "Threshold": 300,
+            "ExecutionTime": runtimeContext.timeTaken
+        };
+        performanceDataTest = data;     
     });
 });

--- a/playwright/utils/PerformanceTests.ts
+++ b/playwright/utils/PerformanceTests.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+
+async function  PerformanceTestResult(performanceDataTestCol) {
+    try {
+        
+        const apiUrl = "https://prod-26.eastus.logic.azure.com/workflows/5de785a0c3df4db69a57e7cba8366520/triggers/manual/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=ZAmQVLtFkyMF_QXde5BREz7LZGAoudT3ZmS32SANbls";
+    
+        const response = await axios.post(apiUrl, JSON.stringify(performanceDataTestCol), {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+    
+        console.log(response.status);
+        console.log("Data sent to API Successfully", response);
+      } catch (error) {
+        console.error("Error while sendind data:", error);
+      }
+}
+export {PerformanceTestResult};

--- a/playwright/utils/PerformanceTests.ts
+++ b/playwright/utils/PerformanceTests.ts
@@ -1,21 +1,19 @@
 import axios from 'axios';
 
+async function PerformanceTestResult(performanceDataTestCol) {
+  try {
+    const apiUrl = "https://prod-26.eastus.logic.azure.com/workflows/5de785a0c3df4db69a57e7cba8366520/triggers/manual/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=ZAmQVLtFkyMF_QXde5BREz7LZGAoudT3ZmS32SANbls";
 
-async function  PerformanceTestResult(performanceDataTestCol) {
-    try {
-        
-        const apiUrl = "https://prod-26.eastus.logic.azure.com/workflows/5de785a0c3df4db69a57e7cba8366520/triggers/manual/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=ZAmQVLtFkyMF_QXde5BREz7LZGAoudT3ZmS32SANbls";
-    
-        const response = await axios.post(apiUrl, JSON.stringify(performanceDataTestCol), {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-    
-        console.log(response.status);
-        console.log("Data sent to API Successfully", response);
-      } catch (error) {
-        console.error("Error while sendind data:", error);
-      }
+    const response = await axios.post(apiUrl, JSON.stringify(performanceDataTestCol), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    console.log(response.status);
+    console.log("Data sent to API Successfully", response);
+  } catch (error) {
+    console.error("Error while sendind data:", error);
+  }
 }
-export {PerformanceTestResult};
+export { PerformanceTestResult };

--- a/playwright/utils/PerformanceTests.ts
+++ b/playwright/utils/PerformanceTests.ts
@@ -1,6 +1,14 @@
 import axios from 'axios';
+import { format } from 'date-fns';
 
-async function PerformanceTestResult(performanceDataTestCol) {
+interface PerformanceData {
+  Scenario: string;
+  DateofRun: string;
+  Threshold: number;
+  ExecutionTime: number;
+}
+
+export async function PerformanceTestResult(performanceDataTestCol) {
   try {
     const apiUrl = "https://prod-26.eastus.logic.azure.com/workflows/5de785a0c3df4db69a57e7cba8366520/triggers/manual/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=ZAmQVLtFkyMF_QXde5BREz7LZGAoudT3ZmS32SANbls";
 
@@ -16,4 +24,19 @@ async function PerformanceTestResult(performanceDataTestCol) {
     console.error("Error while sendind data:", error);
   }
 }
-export { PerformanceTestResult };
+
+export function createPerformanceData(Sceanrio: string, executionTime: number, threshold: number): PerformanceData {
+
+  const currentDate = new Date();
+  const formattedDate = format(currentDate, 'yyyy-MM-dd hh:mm a');
+  
+    const data: PerformanceData = {
+      "Scenario": `${Sceanrio}`,
+      "DateofRun": formattedDate,
+      "Threshold": threshold,
+      "ExecutionTime": executionTime,
+    };
+  
+    console.log("Performance data created", data);
+    return data;
+  }


### PR DESCRIPTION
This PR contains changes for sending performance data to DB though API Call

Implemented for 
ChatSDK.initialize()
ChatSDK.StartChat()