### PR TITLE
Fix tokenRefresher mechanism with attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-
+### Fixed
+- Fix `tokenRefresher` to update `chatToken` properly on expiry through reinitialization of AMSClient
+  
 ## [1.4.5] - 2023-08-02
 
 ### Changed

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -486,11 +486,7 @@ class OmnichannelChatSDK {
 
                 const tokenRefresher = async (): Promise<string> => {
                     await this.getChatToken(false, {refreshToken: true});
-
-                    if (!platform.isNode() && !platform.isReactNative()) {
-                        await this.AMSClient?.initialize({ chatToken: this.chatToken as OmnichannelChatToken });
-                    }
-
+                    await this.AMSClient?.initialize({ chatToken: this.chatToken as OmnichannelChatToken });
                     return this.chatToken.token as string;
                 };
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -488,16 +488,7 @@ class OmnichannelChatSDK {
                     await this.getChatToken(false, {refreshToken: true});
 
                     if (!platform.isNode() && !platform.isReactNative()) {
-                        (this.AMSClient as FramedClient).dispose();
-
-                        this.AMSClient = await createAMSClient({
-                            framedMode: isBrowser(),
-                            multiClient: true,
-                            debug: false,
-                            logger: this.amsClientLogger as PluggableLogger
-                        });
-
-                        await this.AMSClient?.initialize({ chatToken: this.chatToken as OmnichannelChatToken });
+                        (this.AMSClient as any).chatToken = this.chatToken; // eslint-disable-line @typescript-eslint/no-explicit-any
                     }
 
                     return this.chatToken.token as string;

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -488,7 +488,7 @@ class OmnichannelChatSDK {
                     await this.getChatToken(false, {refreshToken: true});
 
                     if (!platform.isNode() && !platform.isReactNative()) {
-                        (this.AMSClient as any).chatToken = this.chatToken; // eslint-disable-line @typescript-eslint/no-explicit-any
+                        await this.AMSClient?.initialize({ chatToken: this.chatToken as OmnichannelChatToken });
                     }
 
                     return this.chatToken.token as string;


### PR DESCRIPTION
- Fix token refresher mechanism not updating chat token on AMS Client

### Scenarios Tested
- AMSClient should have the new chat token updated on expiry
- Attachment uploads/downloads should work after a chat token has been refreshed