### PR TITLE
Attachment File Scan

### DIFF
--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -55,4 +55,27 @@ describe("AMSFileScanner", () => {
         expect(initialSize).toBe(0);
         expect(fileScanner.scanResults?.size === 1).toBe(true);
     });
+
+    it("AMSFileScanner.addOrUpdateFile() should update the scan result if existing", async () => {
+        (global as any).setTimeout = jest.fn();
+        const amsClient: any = {};
+        const fileScanner = new AMSFileScanner(amsClient);
+
+        fileScanner.scanFiles = jest.fn();
+
+        const sampleFileId = "fileId";
+        const sampleFileMetadata = {id: "id", type: "type"};
+        const sampleScanResponse = {status: "status"};
+        const newSampleScanResponse = {status: "new status"}
+
+        fileScanner.addOrUpdateFile(sampleFileId, sampleFileMetadata, sampleScanResponse);
+        const initialScanResult = fileScanner.scanResults?.get(sampleFileId);
+
+        fileScanner.addOrUpdateFile(sampleFileId, sampleFileMetadata, newSampleScanResponse);
+        const newScanResult = fileScanner.scanResults?.get(sampleFileId);
+
+        expect(fileScanner.scanResults?.size === 1).toBe(true);
+        expect(initialScanResult).toEqual({fileMetadata: sampleFileMetadata, scan: sampleScanResponse});
+        expect(newScanResult).toEqual({fileMetadata: sampleFileMetadata, scan: newSampleScanResponse});
+    });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -13,7 +13,7 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.queueScan() should call AMSFileScanner.scanFiles()", async () => {
         (global as any).setTimeout = jest.fn();
-        const amsClient: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
 
         fileScanner.scanFiles = jest.fn();
@@ -25,7 +25,7 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.retrieveFileScanResult() of an existing scan result should return the scan result", async () => {
         (global as any).setTimeout = jest.fn();
-        const amsClient: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
 
         fileScanner.scanFiles = jest.fn();
@@ -36,5 +36,23 @@ describe("AMSFileScanner", () => {
 
         const scanResult = fileScanner.retrieveFileScanResult(sampleFileId);
         expect(scanResult).toEqual(sampleScanResult);
+    });
+
+    it("AMSFileScanner.addOrUpdateFile() should add a new scan result if not existing", async () => {
+        (global as any).setTimeout = jest.fn();
+        const amsClient: any = {};
+        const fileScanner = new AMSFileScanner(amsClient);
+
+        fileScanner.scanFiles = jest.fn();
+
+        const sampleFileId = "fileId";
+        const sampleFileMetadata = {id: "id", type: "type"};
+        const sampleScanResponse = {status: "status"};
+        const initialSize = fileScanner.scanResults?.size;
+
+        fileScanner.addOrUpdateFile(sampleFileId, sampleFileMetadata, sampleScanResponse);
+
+        expect(initialSize).toBe(0);
+        expect(fileScanner.scanResults?.size === 1).toBe(true);
     });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -2,12 +2,24 @@ import AMSFileScanner from '../../../src/external/ACSAdapter/AMSFileScanner';
 
 describe("AMSFileScanner", () => {
 
-    it("AMSFileManager initialization should call setTimeout()", () => {
+    it("AMSFileScanner initialization should call setTimeout()", () => {
         (global as any).setTimeout = jest.fn();
 
         const amsClient: any = {};
         new AMSFileScanner(amsClient);
 
         expect((global as any).setTimeout).toHaveBeenCalled();
+    });
+
+    it("AMSFileScanner.queueScan() should call AMSFileScanner.scanFiles()", async () => {
+        (global as any).setTimeout = jest.fn();
+        const amsClient: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const fileScanner = new AMSFileScanner(amsClient);
+
+        fileScanner.scanFiles = jest.fn();
+        fileScanner.queueScan();
+
+        expect((global as any).setTimeout).toHaveBeenCalled();
+        expect(fileScanner.scanFiles).toHaveBeenCalledTimes(1);
     });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -200,4 +200,18 @@ describe("AMSFileScanner", () => {
         expect(sampleScanResult.activity.channelData.fileScan).toEqual(fileScan);
         expect(sampleScanResult.activity.channelData.fileScan[0].status).toEqual(sampleViewStatusResponse.scan.status);
     });
+
+    it("AMSFileScanner.end() should set internal attribute shouldQueueScan to false", () => {
+        (global as any).setTimeout = jest.fn();
+        const amsClient: any = {};
+        const fileScanner = new AMSFileScanner(amsClient);
+
+        const beforeValue = (fileScanner as any).shouldQueueScan;
+        fileScanner.end();
+
+        const afterValue = (fileScanner as any).shouldQueueScan;
+
+        expect(beforeValue).toBe(true);
+        expect(afterValue).toBe(false);
+    });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -1,0 +1,13 @@
+import AMSFileScanner from '../../../src/external/ACSAdapter/AMSFileScanner';
+
+describe("AMSFileScanner", () => {
+
+    it("AMSFileManager initialization should call setTimeout()", () => {
+        (global as any).setTimeout = jest.fn();
+
+        const amsClient: any = {};
+        new AMSFileScanner(amsClient);
+
+        expect((global as any).setTimeout).toHaveBeenCalled();
+    });
+});

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -22,4 +22,19 @@ describe("AMSFileScanner", () => {
         expect((global as any).setTimeout).toHaveBeenCalled();
         expect(fileScanner.scanFiles).toHaveBeenCalledTimes(1);
     });
+
+    it("AMSFileScanner.retrieveFileScanResult() of an existing scan result should return the scan result", async () => {
+        (global as any).setTimeout = jest.fn();
+        const amsClient: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const fileScanner = new AMSFileScanner(amsClient);
+
+        fileScanner.scanFiles = jest.fn();
+
+        const sampleFileId = "fileId";
+        const sampleScanResult = {fileMetadata: {id: "id", type: "type"}, scan: {status: "status"}};
+        fileScanner.scanResults?.set(sampleFileId, sampleScanResult);
+
+        const scanResult = fileScanner.retrieveFileScanResult(sampleFileId);
+        expect(scanResult).toEqual(sampleScanResult);
+    });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -128,12 +128,14 @@ describe("AMSFileScanner", () => {
         (global as any).setTimeout = jest.fn();
 
         const amsClient: any = {};
-        amsClient.getViewStatus = jest.fn(() => ({
+        const sampleViewStatusResponse = {
             view_location: "view_location",
             scan: {
                 status: "malware"
             }
-        }));
+        };
+
+        amsClient.getViewStatus = jest.fn(() => sampleViewStatusResponse);
 
         const fileScanner = new AMSFileScanner(amsClient);
 
@@ -153,7 +155,7 @@ describe("AMSFileScanner", () => {
 
         expect(sampleScanResult.next).toHaveBeenCalledWith(sampleScanResult.activity);
         expect(sampleScanResult.activity.channelData.fileScan).toEqual(fileScan);
-        expect(sampleScanResult.activity.channelData.fileScan[0].status).toEqual("malware");
+        expect(sampleScanResult.activity.channelData.fileScan[0].status).toEqual(sampleViewStatusResponse.scan.status);
     });
 
     it("AMSFileScanner.scanFileCallback() where file scan status returns 'passed' should update the activity via next(activity)", async () => {
@@ -196,6 +198,6 @@ describe("AMSFileScanner", () => {
         expect(amsClient.getView).toHaveBeenCalled();
         expect(sampleScanResult.next).toHaveBeenCalledWith(sampleScanResult.activity);
         expect(sampleScanResult.activity.channelData.fileScan).toEqual(fileScan);
-        expect(sampleScanResult.activity.channelData.fileScan[0].status).toEqual("passed");
+        expect(sampleScanResult.activity.channelData.fileScan[0].status).toEqual(sampleViewStatusResponse.scan.status);
     });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -78,4 +78,26 @@ describe("AMSFileScanner", () => {
         expect(initialScanResult).toEqual({fileMetadata: sampleFileMetadata, scan: sampleScanResponse});
         expect(newScanResult).toEqual({fileMetadata: sampleFileMetadata, scan: newSampleScanResponse});
     });
+
+    it("AMSFileScanner.addNext() should fill the next property of the scan result", async () => {
+        (global as any).setTimeout = jest.fn();
+        const amsClient: any = {};
+        const fileScanner = new AMSFileScanner(amsClient);
+
+        fileScanner.scanFiles = jest.fn();
+
+        const sampleFileId = "fileId";
+        const sampleScanResult = {fileMetadata: {id: "id", type: "type"}, scan: {status: "status"}};
+
+        fileScanner.scanResults?.set(sampleFileId, sampleScanResult);
+
+        const next = jest.fn();
+        fileScanner.addNext(sampleFileId, next);
+
+        const scanResult = fileScanner.scanResults?.get(sampleFileId);
+
+        expect(fileScanner.scanResults?.size === 1).toBe(true);
+        expect(scanResult).toEqual({...sampleScanResult, next});
+        expect(scanResult?.next).toEqual(next);
+    });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -1,33 +1,45 @@
 import AMSFileScanner from '../../../src/external/ACSAdapter/AMSFileScanner';
 import activityUtils from '../../../src/external/ACSAdapter/activityUtils';
+import WebUtils from '../../../src/utils/WebUtils';
 
 describe("AMSFileScanner", () => {
 
-    it("AMSFileScanner initialization should call setTimeout()", () => {
+    it("AMSFileScanner initialization should call AMSFileScanner.queueScan()", () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
+        jest.spyOn(AMSFileScanner.prototype, 'queueScan');
 
         const amsClient: any = {};
-        new AMSFileScanner(amsClient);
+        const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).shouldQueueScan = false;
 
-        expect((global as any).setTimeout).toHaveBeenCalled();
+        expect(AMSFileScanner.prototype.queueScan).toHaveBeenCalled();
     });
 
     it("AMSFileScanner.queueScan() should call AMSFileScanner.scanFiles()", async () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
+        jest.spyOn(AMSFileScanner.prototype, 'queueScan');
+
         const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         fileScanner.scanFiles = jest.fn();
-        fileScanner.queueScan();
+        await fileScanner.queueScan();
 
-        expect((global as any).setTimeout).toHaveBeenCalled();
         expect(fileScanner.scanFiles).toHaveBeenCalledTimes(1);
     });
 
     it("AMSFileScanner.retrieveFileScanResult() of an existing scan result should return the scan result", async () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
         const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         fileScanner.scanFiles = jest.fn();
 
@@ -41,8 +53,11 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.addOrUpdateFile() should add a new scan result if not existing", async () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
         const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         fileScanner.scanFiles = jest.fn();
 
@@ -59,8 +74,11 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.addOrUpdateFile() should update the scan result if existing", async () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
         const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         fileScanner.scanFiles = jest.fn();
 
@@ -82,8 +100,11 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.addNext() should fill the next property of the scan result", async () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
         const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         fileScanner.scanFiles = jest.fn();
 
@@ -104,8 +125,11 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.addActivity() should fill the activity property of the scan result", async () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
         const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         fileScanner.scanFiles = jest.fn();
 
@@ -126,6 +150,7 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.scanFileCallback() where file scan status returns 'malware' should update the activity via next(activity)", async () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
 
         const amsClient: any = {};
         const sampleViewStatusResponse = {
@@ -138,6 +163,7 @@ describe("AMSFileScanner", () => {
         amsClient.getViewStatus = jest.fn(() => sampleViewStatusResponse);
 
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         const fileMetadata = {id: "id", type: "type", name: "name", size: 0};
         const attachment = {contentType: fileMetadata.type, name: fileMetadata.name, thumbnailUrl: undefined};
@@ -161,6 +187,7 @@ describe("AMSFileScanner", () => {
     it("AMSFileScanner.scanFileCallback() where file scan status returns 'passed' should update the activity via next(activity)", async () => {
         (global as any).setTimeout = jest.fn();
         (global as any).File = jest.fn();
+        WebUtils.sleep = jest.fn();
 
         jest.spyOn(activityUtils, "getDataURL").mockResolvedValue(Promise.resolve(""));
         jest.spyOn(activityUtils, "getAttachments").mockResolvedValue(Promise.resolve([""]));
@@ -177,6 +204,8 @@ describe("AMSFileScanner", () => {
         amsClient.getView = jest.fn();
 
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
+
         jest.spyOn(fileScanner, "addOrUpdateFile");
 
         const fileMetadata = {id: "id", type: "type", name: "name", size: 0};
@@ -203,8 +232,11 @@ describe("AMSFileScanner", () => {
 
     it("AMSFileScanner.end() should set internal attribute shouldQueueScan to false", () => {
         (global as any).setTimeout = jest.fn();
+        WebUtils.sleep = jest.fn();
+
         const amsClient: any = {};
         const fileScanner = new AMSFileScanner(amsClient);
+        (fileScanner as any).test = true;
 
         const beforeValue = (fileScanner as any).shouldQueueScan;
         fileScanner.end();

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -100,4 +100,26 @@ describe("AMSFileScanner", () => {
         expect(scanResult).toEqual({...sampleScanResult, next});
         expect(scanResult?.next).toEqual(next);
     });
+
+    it("AMSFileScanner.addActivity() should fill the activity property of the scan result", async () => {
+        (global as any).setTimeout = jest.fn();
+        const amsClient: any = {};
+        const fileScanner = new AMSFileScanner(amsClient);
+
+        fileScanner.scanFiles = jest.fn();
+
+        const sampleFileId = "fileId";
+        const sampleScanResult = {fileMetadata: {id: "id", type: "type"}, scan: {status: "status"}};
+
+        fileScanner.scanResults?.set(sampleFileId, sampleScanResult);
+
+        const sampleActivity = {type: "message", attachments: [{contentType: "", name: "", thumbnailUrl: undefined}], channelData: {fileScan: [{status: "in progress"}]}};
+        fileScanner.addActivity(sampleFileId, sampleActivity);
+
+        const scanResult = fileScanner.scanResults?.get(sampleFileId);
+
+        expect(fileScanner.scanResults?.size === 1).toBe(true);
+        expect(scanResult).toEqual({...sampleScanResult, activity: sampleActivity});
+        expect(scanResult?.activity).toEqual(sampleActivity);
+    });
 });

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -185,12 +185,15 @@ describe("AMSFileScanner", () => {
     });
 
     it("AMSFileScanner.scanFileCallback() where file scan status returns 'passed' should update the activity via next(activity)", async () => {
+        const fileMetadata = {id: "id", type: "type", name: "name", size: 0};
+        const attachment = {contentType: fileMetadata.type, name: fileMetadata.name, thumbnailUrl: undefined};
+
         (global as any).setTimeout = jest.fn();
-        (global as any).File = jest.fn();
+        (global as any).File = jest.fn(() => fileMetadata);
         WebUtils.sleep = jest.fn();
 
         jest.spyOn(activityUtils, "getDataURL").mockResolvedValue(Promise.resolve(""));
-        jest.spyOn(activityUtils, "getAttachments").mockResolvedValue(Promise.resolve([""]));
+        jest.spyOn(activityUtils, "getAttachments").mockResolvedValue(Promise.resolve([attachment]));
 
         const amsClient: any = {};
         const sampleViewStatusResponse = {
@@ -208,8 +211,6 @@ describe("AMSFileScanner", () => {
 
         jest.spyOn(fileScanner, "addOrUpdateFile");
 
-        const fileMetadata = {id: "id", type: "type", name: "name", size: 0};
-        const attachment = {contentType: fileMetadata.type, name: fileMetadata.name, thumbnailUrl: undefined};
         const attachments = [attachment];
         const attachmentSizes = [fileMetadata.size];
         const scan = {status: "in progress"};

--- a/__tests__/external/ACSAdapter/createFileScanIngressMiddleware.spec.ts
+++ b/__tests__/external/ACSAdapter/createFileScanIngressMiddleware.spec.ts
@@ -1,0 +1,12 @@
+import createFileScanIngressMiddleware from "../../../src/external/ACSAdapter/createFileScanIngressMiddleware";
+
+describe('createFileScanIngressMiddleware', () => {
+    it('createFileScanIngressMiddleware should call next if activity has no attachments', () => {
+        const next = jest.fn();
+        const activity = {};
+
+        createFileScanIngressMiddleware()()(next)(activity);
+
+        expect(next).toHaveBeenCalledWith(activity);
+    });
+});

--- a/__tests__/external/ACSAdapter/createFileScanIngressMiddleware.spec.ts
+++ b/__tests__/external/ACSAdapter/createFileScanIngressMiddleware.spec.ts
@@ -9,4 +9,27 @@ describe('createFileScanIngressMiddleware', () => {
 
         expect(next).toHaveBeenCalledWith(activity);
     });
+
+    it("createFileScanIngressMiddleware should populate 'activity.channelData.metadata.amsreferences' from 'activity.channelData.metadata.amsReferences' if doesn't exist", () => {
+        const next = jest.fn();
+
+        const fileMetadata = {id: "id", type: "type", name: "name", size: 0};
+        const attachment = {contentType: fileMetadata.type, name: fileMetadata.name, thumbnailUrl: undefined};
+        const attachments = [attachment];
+        const amsReferences = [fileMetadata.id];
+        const activity = {
+            attachments,
+            channelData: {
+                metadata: {
+                    amsReferences: JSON.stringify(amsReferences)
+                }
+            }
+        };
+
+        createFileScanIngressMiddleware()()(next)(activity);
+
+        expect(next).toHaveBeenCalledWith(activity);
+        expect(Object.keys(activity.channelData.metadata).indexOf("amsreferences") >= 0).toBe(true);
+        expect((activity.channelData.metadata as any)["amsreferences"]).toBe(activity.channelData.metadata.amsReferences);
+    });
 });

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1508,7 +1508,11 @@ class OmnichannelChatSDK {
         if (protocol === ChatAdapterProtocols.DirectLine) {
             return createDirectLine(optionalParams, this.chatSDKConfig, this.liveChatVersion, ChatAdapterProtocols.DirectLine, this.telemetry as typeof AriaTelemetry, this.scenarioMarker);
         } else if (protocol === ChatAdapterProtocols.ACS || this.liveChatVersion === LiveChatVersion.V2) {
-            const fileManager = new AMSFileManager(this.AMSClient as FramedClient, this.acsAdapterLogger);
+            const options = {
+                fileScan: optionalParams.ACSAdapter?.fileScan
+            };
+
+            const fileManager = new AMSFileManager(this.AMSClient as FramedClient, this.acsAdapterLogger, options);
             return createACSAdapter(optionalParams, this.chatSDKConfig, this.liveChatVersion, ChatAdapterProtocols.ACS, this.telemetry as typeof AriaTelemetry, this.scenarioMarker, this.omnichannelConfig, this.chatToken, fileManager, this.ACSClient?.getChatClient() as ChatClient, this.acsAdapterLogger as ACSAdapterLogger);
         } else if (protocol === ChatAdapterProtocols.IC3 || this.liveChatVersion === LiveChatVersion.V1) {
             return createIC3Adapter(optionalParams, this.chatSDKConfig, this.liveChatVersion, ChatAdapterProtocols.IC3, this.telemetry as typeof AriaTelemetry, this.scenarioMarker, this.chatToken, this.IC3Client, this.ic3ClientLogger as IC3ClientLogger);

--- a/src/core/messaging/ChatAdapterOptionalParams.ts
+++ b/src/core/messaging/ChatAdapterOptionalParams.ts
@@ -8,7 +8,7 @@ interface ChatAdapterOptionalParams {
     ACSAdapter?: {
         fileScan?: {
             disabled?: boolean,
-            interval?: number
+            pollingInterval?: number
         },
         options?: {
             [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/core/messaging/ChatAdapterOptionalParams.ts
+++ b/src/core/messaging/ChatAdapterOptionalParams.ts
@@ -6,7 +6,7 @@ interface ChatAdapterOptionalParams {
         }
     };
     ACSAdapter?: {
-        fileScan: {
+        fileScan?: {
             disabled?: boolean,
             interval?: number
         },

--- a/src/core/messaging/ChatAdapterOptionalParams.ts
+++ b/src/core/messaging/ChatAdapterOptionalParams.ts
@@ -6,7 +6,10 @@ interface ChatAdapterOptionalParams {
         }
     };
     ACSAdapter?: {
-        fileScan?: boolean;
+        fileScan: {
+            disabled?: boolean,
+            interval?: number
+        },
         options?: {
             [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
         }

--- a/src/core/messaging/ChatAdapterOptionalParams.ts
+++ b/src/core/messaging/ChatAdapterOptionalParams.ts
@@ -6,6 +6,7 @@ interface ChatAdapterOptionalParams {
         }
     };
     ACSAdapter?: {
+        fileScan?: boolean;
         options?: {
             [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any
         }

--- a/src/core/messaging/ChatAdapterOptionalParams.ts
+++ b/src/core/messaging/ChatAdapterOptionalParams.ts
@@ -8,7 +8,8 @@ interface ChatAdapterOptionalParams {
     ACSAdapter?: {
         fileScan?: {
             disabled?: boolean,
-            pollingInterval?: number
+            pollingInterval?: number,
+            scanStatusRetrievalDelay?: number
         },
         options?: {
             [key: string]: any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -55,7 +55,7 @@ export enum AMSViewScanStatus {
     INPROGRESS = "in progress"
 }
 
-export const defaultScanInterval = 7 * 1000;
+export const defaultScanPollingInterval = 7 * 1000;
 
 class AMSFileManager {
     private logger: ACSAdapterLogger | null;
@@ -69,7 +69,7 @@ class AMSFileManager {
         this.options = options;
 
         if (this.options.fileScan?.disabled === false) {
-            this.fileScanner = new AMSFileScanner(this.amsClient, this.options.fileScan?.interval || defaultScanInterval);
+            this.fileScanner = new AMSFileScanner(this.amsClient, this.options.fileScan?.pollingInterval || defaultScanPollingInterval);
         }
     }
 

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -49,7 +49,7 @@ enum AMSFileManagerEvent {
     CreateFileMetadataProperty = 'CreateFileMetadataProperty'
 }
 
-export enum AMSDownloadStatus {
+export enum AMSViewScanStatus {
     PASSED = "passed",
     MALWARE = "malware",
     INPROGRESS = "in progress"
@@ -327,7 +327,7 @@ class AMSFileManager {
 
             const {view_location, scan} = response;
 
-            if (this.options.fileScan?.disabled === false && scan && scan?.status !== AMSDownloadStatus.PASSED) {
+            if (this.options.fileScan?.disabled === false && scan && scan?.status !== AMSViewScanStatus.PASSED) {
                 const file = new File([blob], uploadedFile.metadata.fileName, { type: uploadedFile.metadata.contentType });
 
                 const exceptionDetails = {

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -55,6 +55,8 @@ export enum AMSDownloadStatus {
     INPROGRESS = "in progress"
 }
 
+export const defaultScanInterval = 7 * 1000;
+
 class AMSFileManager {
     private logger: ACSAdapterLogger | null;
     private amsClient: FramedClient;
@@ -66,8 +68,8 @@ class AMSFileManager {
         this.amsClient = amsClient;
         this.options = options;
 
-        if (this.options.fileScan) {
-            this.fileScanner = new AMSFileScanner(this.amsClient);
+        if (this.options.fileScan?.disabled === false) {
+            this.fileScanner = new AMSFileScanner(this.amsClient, this.options.fileScan?.interval || defaultScanInterval);
         }
     }
 
@@ -325,7 +327,7 @@ class AMSFileManager {
 
             const {view_location, scan} = response;
 
-            if (this.options.fileScan && scan && scan.status !== AMSDownloadStatus.PASSED) {
+            if (this.options.fileScan?.disabled === false && scan && scan?.status !== AMSDownloadStatus.PASSED) {
                 const file = new File([blob], uploadedFile.metadata.fileName, { type: uploadedFile.metadata.contentType });
 
                 const exceptionDetails = {

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -55,8 +55,6 @@ export enum AMSViewScanStatus {
     INPROGRESS = "in progress"
 }
 
-export const defaultScanPollingInterval = 7 * 1000;
-
 class AMSFileManager {
     private logger: ACSAdapterLogger | null;
     private amsClient: FramedClient;
@@ -69,7 +67,8 @@ class AMSFileManager {
         this.options = options;
 
         if (this.options.fileScan?.disabled === false) {
-            this.fileScanner = new AMSFileScanner(this.amsClient, this.options.fileScan?.pollingInterval || defaultScanPollingInterval);
+            const options = {...this.options.fileScan};
+            this.fileScanner = new AMSFileScanner(this.amsClient, options);
         }
     }
 

--- a/src/external/ACSAdapter/AMSFileManager.ts
+++ b/src/external/ACSAdapter/AMSFileManager.ts
@@ -49,7 +49,7 @@ enum AMSFileManagerEvent {
     CreateFileMetadataProperty = 'CreateFileMetadataProperty'
 }
 
-enum AMSDownloadStatus {
+export enum AMSDownloadStatus {
     PASSED = "passed",
     MALWARE = "malware",
     INPROGRESS = "in progress"

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -1,7 +1,7 @@
 import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
 import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
 import sleep from "../../utils/sleep";
-import { AMSDownloadStatus } from "./AMSFileManager";
+import { AMSDownloadStatus, defaultScanInterval } from "./AMSFileManager";
 import activityUtils from "./activityUtils";
 
 interface FileScanResponse {
@@ -18,22 +18,22 @@ interface FileScanResult {
 class AMSFileScanner {
     public amsClient: FramedClient;
     public scanResults: Map<string, FileScanResult> | null = null;
+    public interval: number = defaultScanInterval;
 
-    constructor(amsClient: FramedClient) {
+    constructor(amsClient: FramedClient, interval: number = defaultScanInterval) {
         this.amsClient = amsClient;
         this.scanResults = new Map<string, FileScanResult>();
+        this.interval = interval;
         this.queueScan();
     }
 
     public async queueScan(): Promise<void> {
-        const interval = 7 * 1000;
-
         try {
             await this.scanFiles();
         } catch (e) {
             console.error(e);
         } finally {
-            await sleep(interval);
+            await sleep(this.interval);
             await this.queueScan();
         }
     }

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -95,7 +95,7 @@ class AMSFileScanner {
 
                         activity.attachments = attachmentData;
                         activity.channelData.attachmentSizes = attachmentSizes;
-                        next(activity);
+                        next(activity); // Send updated activity to webchat
                     }
 
                     if (scan.status === AMSDownloadStatus.MALWARE && next && activity) {

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -1,0 +1,136 @@
+import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
+import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
+
+interface FileScanResponse {
+    status: string;
+}
+
+interface FileScanResult {
+    fileMetadata: FileMetadata;
+    scan: FileScanResponse;
+    next?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    activity?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+enum AMSDownloadStatus {
+    PASSED = "passed",
+    MALWARE = "malware",
+    INPROGRESS = "in progress"
+}
+
+const getDataURL = (file: File): Promise<string | ArrayBuffer> => {
+    return new Promise((resolve) => {
+        const fileReader = new FileReader();
+        fileReader.onloadend = () => {
+            resolve((fileReader as any).result); // eslint-disable-line @typescript-eslint/no-explicit-any
+        };
+        fileReader.readAsDataURL(file);
+    });
+}
+
+const getAttachments = (files: File[]) => {
+    return Promise.all(
+        files.map(async (file: File) => {
+            if (file) {
+                const url = await getDataURL(file);
+                return {
+                    contentType: file.type,
+                    contentUrl: url,
+                    name: file.name,
+                    thumbnailUrl: file.type.match("(image|video|audio).*") ? url: undefined
+                }
+            }
+        })
+    )
+}
+
+const getAttachmentSizes = (files: File[]) => {
+    return files.map((file: File) => {
+        return file.size;
+    });
+}
+
+class AMSFileScanner {
+    public amsClient: FramedClient;
+    public scanResults: Map<string, FileScanResult> | null = null;
+
+    constructor(amsClient: FramedClient) {
+        this.amsClient = amsClient;
+        this.scanResults = new Map<string, FileScanResult>();
+        this.startScan();
+    }
+
+    public addOrUpdateFile(id: string, fileMetadata: FileMetadata, scan: FileScanResponse): void {
+        this.scanResults?.set(id, {
+            fileMetadata,
+            scan
+        });
+    }
+
+    public startScan(): void {
+        const interval = 7 * 1000;
+
+        const scan = async (scanResult: FileScanResult, id: string) => {
+            const {fileMetadata, next, activity} = scanResult;
+
+            if (scanResult?.scan?.status === AMSDownloadStatus.INPROGRESS) {
+                try {
+                    const response: any = await this.amsClient.getViewStatus(fileMetadata); // eslint-disable-line @typescript-eslint/no-explicit-any
+                    const {view_location, scan} = response;
+
+                    this.addOrUpdateFile(id, scanResult.fileMetadata, scan);
+                    activity.channelData.fileScan = scan;
+
+                    if (scan.status === AMSDownloadStatus.PASSED && next && activity) {
+                        let blob: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+                        try {
+                            blob = await this.amsClient.getView(fileMetadata, view_location); // eslint-disable-line @typescript-eslint/no-explicit-any
+                        } catch (error) {
+                            console.log(error);
+                        }
+
+                        const file = new File([blob], fileMetadata.name as string, { type: fileMetadata.type});
+                        const attachmentData = await getAttachments([file]);
+                        const attachmentSizes = await getAttachmentSizes([file]);
+
+                        activity.attachments = attachmentData;
+                        activity.channelData.attachmentSizes = attachmentSizes;
+                        next(activity);
+                    }
+
+                    if (scan.status === AMSDownloadStatus.MALWARE && next && activity) {
+                        next(activity);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+        }
+
+        const scanFiles = () => {
+            this.scanResults?.forEach(async (scanResult, id) => {await scan(scanResult, id)});
+        };
+
+        setInterval(scanFiles, interval);
+    }
+
+    public retrieveFileScanResult(id: string): FileScanResult | undefined {
+        return this.scanResults?.get(id);
+    }
+
+    public addNext(id: string, next: Function): void {
+        const scanResult = this.scanResults?.get(id);
+        if (scanResult) {
+            this.scanResults?.set(id, {...scanResult, next});
+        }
+    }
+
+    public addActivity(id: string, activity: any): void {  // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+        const scanResult = this.scanResults?.get(id);
+        if (scanResult) {
+            this.scanResults?.set(id, {...scanResult, activity});
+        }
+    }
+}
+
+export default AMSFileScanner;

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -116,6 +116,8 @@ class AMSFileScanner {
             } catch (e) {
                 console.error(e);
             }
+
+            await sleep(1000);
         }
     }
 
@@ -125,7 +127,6 @@ class AMSFileScanner {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve) => {
             this.scanResults?.forEach(async (scanResult, id) => {await this.scanFileCallback(scanResult, id)});
-            await sleep(1000);
             resolve();
         });
     }

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -83,13 +83,11 @@ class AMSFileScanner {
                 if (scan.status === AMSViewScanStatus.PASSED && next && activity) {
                     const blob = await this.retrieveFileBlob(fileMetadata, view_location);
                     const file = new File([blob], fileMetadata.name as string, { type: fileMetadata.type});
-                    const attachmentData = await activityUtils.getAttachments([file]);
-                    const attachmentSizes = await activityUtils.getAttachmentSizes([file]);
 
-                    const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
+                    await this.addAttachmentToActivity(activity, file);
+
+                    const index = activity.attachments.findIndex((attachment: any) => (attachment.name === file.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
                     activity.channelData.fileScan[index] = scan;
-                    activity.attachments[index] = attachmentData[0];
-                    activity.channelData.attachmentSizes[index] = attachmentSizes[0];
 
                     const hasMultipleAttachments = index > 0;
                     if (hasMultipleAttachments) {
@@ -140,6 +138,14 @@ class AMSFileScanner {
         }
 
         return blob;
+    }
+
+    private async addAttachmentToActivity(activity: any, file: File) { // eslint-disable-line @typescript-eslint/no-explicit-any
+        const attachmentData = await activityUtils.getAttachments([file]);
+        const attachmentSizes = await activityUtils.getAttachmentSizes([file]);
+        const index = activity.attachments.findIndex((attachment: any) => (attachment.name === file.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
+        activity.attachments[index] = attachmentData[0];
+        activity.channelData.attachmentSizes[index] = attachmentSizes[0];
     }
 }
 

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -2,6 +2,7 @@ import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
 import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
 import sleep from "../../utils/sleep";
 import { AMSDownloadStatus } from "./AMSFileManager";
+import activityUtils from "./activityUtils";
 
 interface FileScanResponse {
     status: string;
@@ -12,38 +13,6 @@ interface FileScanResult {
     scan: FileScanResponse;
     next?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     activity?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-}
-
-const getDataURL = (file: File): Promise<string | ArrayBuffer> => {
-    return new Promise((resolve) => {
-        const fileReader = new FileReader();
-        fileReader.onloadend = () => {
-            resolve((fileReader as any).result); // eslint-disable-line @typescript-eslint/no-explicit-any
-        };
-        fileReader.readAsDataURL(file);
-    });
-}
-
-const getAttachments = (files: File[]) => {
-    return Promise.all(
-        files.map(async (file: File) => {
-            if (file) {
-                const url = await getDataURL(file);
-                return {
-                    contentType: file.type,
-                    contentUrl: url,
-                    name: file.name,
-                    thumbnailUrl: file.type.match("(image|video|audio).*") ? url: undefined
-                }
-            }
-        })
-    )
-}
-
-const getAttachmentSizes = (files: File[]) => {
-    return files.map((file: File) => {
-        return file.size;
-    });
 }
 
 class AMSFileScanner {
@@ -114,8 +83,8 @@ class AMSFileScanner {
                         }
 
                         const file = new File([blob], fileMetadata.name as string, { type: fileMetadata.type});
-                        const attachmentData = await getAttachments([file]);
-                        const attachmentSizes = await getAttachmentSizes([file]);
+                        const attachmentData = await activityUtils.getAttachments([file]);
+                        const attachmentSizes = await activityUtils.getAttachmentSizes([file]);
 
                         const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
                         activity.channelData.fileScan[index] = scan;

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -43,7 +43,9 @@ class AMSFileScanner {
     }
 
     public addOrUpdateFile(id: string, fileMetadata: FileMetadata, scan: FileScanResponse): void {
+        const scanResult = this.retrieveFileScanResult(id);
         this.scanResults?.set(id, {
+            ...(scanResult || {}),
             fileMetadata,
             scan
         });

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -71,9 +71,9 @@ class AMSFileScanner {
     }
 
     public async scanFileCallback(scanResult: FileScanResult, id: string): Promise<void> {
-        const {fileMetadata, next, activity} = scanResult;
+        const {fileMetadata, next, activity, scan} = scanResult;
 
-        if (scanResult?.scan?.status === AMSViewScanStatus.INPROGRESS) {
+        if (scan?.status === AMSViewScanStatus.INPROGRESS) {
             try {
                 const response: any = await this.amsClient.getViewStatus(fileMetadata); // eslint-disable-line @typescript-eslint/no-explicit-any
                 const {view_location, scan} = response;

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -96,8 +96,6 @@ class AMSFileScanner {
     }
 
     public scanFiles(): Promise<void> {
-        this.scanResults?.forEach(async (scanResult, id) => {await this.scanFileCallback(scanResult, id)});
-
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve) => {
             this.scanResults?.forEach(async (scanResult, id) => {await this.scanFileCallback(scanResult, id)});

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -1,7 +1,7 @@
 import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
 import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
 import sleep from "../../utils/sleep";
-import { AMSViewScanStatus, defaultScanInterval } from "./AMSFileManager";
+import { AMSViewScanStatus, defaultScanPollingInterval } from "./AMSFileManager";
 import activityUtils from "./activityUtils";
 
 interface FileScanResponse {
@@ -18,13 +18,13 @@ interface FileScanResult {
 class AMSFileScanner {
     public amsClient: FramedClient;
     public scanResults: Map<string, FileScanResult> | null = null;
-    public interval: number = defaultScanInterval;
+    public scanPollingInterval: number = defaultScanPollingInterval;
     private shouldQueueScan: boolean;
 
-    constructor(amsClient: FramedClient, interval: number = defaultScanInterval) {
+    constructor(amsClient: FramedClient, scanPollingInterval: number = defaultScanPollingInterval) {
         this.amsClient = amsClient;
         this.scanResults = new Map<string, FileScanResult>();
-        this.interval = interval;
+        this.scanPollingInterval = scanPollingInterval;
         this.shouldQueueScan = false;
         this.queueScan();
     }
@@ -37,7 +37,7 @@ class AMSFileScanner {
         } catch (e) {
             console.error(e);
         } finally {
-            await sleep(this.interval);
+            await sleep(this.scanPollingInterval);
             this.shouldQueueScan && await this.queueScan();
         }
     }

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -63,62 +63,62 @@ class AMSFileScanner {
         }
     }
 
-    public scanFiles(): Promise<void> {
-        const scan = async (scanResult: FileScanResult, id: string) => {
-            const {fileMetadata, next, activity} = scanResult;
+    public async scanFileCallback(scanResult: FileScanResult, id: string): Promise<void> {
+        const {fileMetadata, next, activity} = scanResult;
 
-            if (scanResult?.scan?.status === AMSDownloadStatus.INPROGRESS) {
-                try {
-                    const response: any = await this.amsClient.getViewStatus(fileMetadata); // eslint-disable-line @typescript-eslint/no-explicit-any
-                    const {view_location, scan} = response;
+        if (scanResult?.scan?.status === AMSDownloadStatus.INPROGRESS) {
+            try {
+                const response: any = await this.amsClient.getViewStatus(fileMetadata); // eslint-disable-line @typescript-eslint/no-explicit-any
+                const {view_location, scan} = response;
 
-                    this.addOrUpdateFile(id, scanResult.fileMetadata, scan);
+                this.addOrUpdateFile(id, scanResult.fileMetadata, scan);
 
-                    if (scan.status === AMSDownloadStatus.PASSED && next && activity) {
-                        let blob: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-                        try {
-                            blob = await this.amsClient.getView(fileMetadata, view_location); // eslint-disable-line @typescript-eslint/no-explicit-any
-                        } catch (error) {
-                            console.error(error);
-                        }
-
-                        const file = new File([blob], fileMetadata.name as string, { type: fileMetadata.type});
-                        const attachmentData = await activityUtils.getAttachments([file]);
-                        const attachmentSizes = await activityUtils.getAttachmentSizes([file]);
-
-                        const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
-                        activity.channelData.fileScan[index] = scan;
-                        activity.attachments[index] = attachmentData[0];
-                        activity.channelData.attachmentSizes[index] = attachmentSizes[0];
-
-                        const hasMultipleAttachments = index > 0;
-                        if (hasMultipleAttachments) {
-                            const {metadata: {amsreferences}} = activity.channelData;
-                            const fileIds = JSON.parse(amsreferences);
-                            fileIds.forEach((fileId: string) => {
-                                this.addActivity(fileId, activity);
-                            });
-                        }
-
-                        next(activity); // Send updated activity to webchat
+                if (scan.status === AMSDownloadStatus.PASSED && next && activity) {
+                    let blob: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+                    try {
+                        blob = await this.amsClient.getView(fileMetadata, view_location); // eslint-disable-line @typescript-eslint/no-explicit-any
+                    } catch (error) {
+                        console.error(error);
                     }
 
-                    if (scan.status === AMSDownloadStatus.MALWARE && next && activity) {
-                        const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
-                        activity.channelData.fileScan[index] = scan;
-                        next(activity);
+                    const file = new File([blob], fileMetadata.name as string, { type: fileMetadata.type});
+                    const attachmentData = await activityUtils.getAttachments([file]);
+                    const attachmentSizes = await activityUtils.getAttachmentSizes([file]);
+
+                    const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
+                    activity.channelData.fileScan[index] = scan;
+                    activity.attachments[index] = attachmentData[0];
+                    activity.channelData.attachmentSizes[index] = attachmentSizes[0];
+
+                    const hasMultipleAttachments = index > 0;
+                    if (hasMultipleAttachments) {
+                        const {metadata: {amsreferences}} = activity.channelData;
+                        const fileIds = JSON.parse(amsreferences);
+                        fileIds.forEach((fileId: string) => {
+                            this.addActivity(fileId, activity);
+                        });
                     }
-                } catch (e) {
-                    console.error(e);
+
+                    next(activity); // Send updated activity to webchat
                 }
+
+                if (scan.status === AMSDownloadStatus.MALWARE && next && activity) {
+                    const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
+                    activity.channelData.fileScan[index] = scan;
+                    next(activity);
+                }
+            } catch (e) {
+                console.error(e);
             }
         }
+    }
 
-        this.scanResults?.forEach(async (scanResult, id) => {await scan(scanResult, id)});
+    public scanFiles(): Promise<void> {
+        this.scanResults?.forEach(async (scanResult, id) => {await this.scanFileCallback(scanResult, id)});
 
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve) => {
-            this.scanResults?.forEach(async (scanResult, id) => {await scan(scanResult, id)});
+            this.scanResults?.forEach(async (scanResult, id) => {await this.scanFileCallback(scanResult, id)});
             await sleep(1000);
             resolve();
         });

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -1,7 +1,7 @@
 import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
 import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
 import sleep from "../../utils/sleep";
-import { AMSDownloadStatus, defaultScanInterval } from "./AMSFileManager";
+import { AMSViewScanStatus, defaultScanInterval } from "./AMSFileManager";
 import activityUtils from "./activityUtils";
 
 interface FileScanResponse {
@@ -72,14 +72,14 @@ class AMSFileScanner {
     public async scanFileCallback(scanResult: FileScanResult, id: string): Promise<void> {
         const {fileMetadata, next, activity} = scanResult;
 
-        if (scanResult?.scan?.status === AMSDownloadStatus.INPROGRESS) {
+        if (scanResult?.scan?.status === AMSViewScanStatus.INPROGRESS) {
             try {
                 const response: any = await this.amsClient.getViewStatus(fileMetadata); // eslint-disable-line @typescript-eslint/no-explicit-any
                 const {view_location, scan} = response;
 
                 this.addOrUpdateFile(id, scanResult.fileMetadata, scan);
 
-                if (scan.status === AMSDownloadStatus.PASSED && next && activity) {
+                if (scan.status === AMSViewScanStatus.PASSED && next && activity) {
                     let blob: any; // eslint-disable-line @typescript-eslint/no-explicit-any
                     try {
                         blob = await this.amsClient.getView(fileMetadata, view_location); // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -108,7 +108,7 @@ class AMSFileScanner {
                     next(activity); // Send updated activity to webchat
                 }
 
-                if (scan.status === AMSDownloadStatus.MALWARE && next && activity) {
+                if (scan.status === AMSViewScanStatus.MALWARE && next && activity) {
                     const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
                     activity.channelData.fileScan[index] = scan;
                     next(activity);

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -80,13 +80,7 @@ class AMSFileScanner {
                 this.addOrUpdateFile(id, scanResult.fileMetadata, scan);
 
                 if (scan.status === AMSViewScanStatus.PASSED && next && activity) {
-                    let blob: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-                    try {
-                        blob = await this.amsClient.getView(fileMetadata, view_location); // eslint-disable-line @typescript-eslint/no-explicit-any
-                    } catch (error) {
-                        console.error(error);
-                    }
-
+                    const blob = await this.retrieveFileBlob(fileMetadata, view_location);
                     const file = new File([blob], fileMetadata.name as string, { type: fileMetadata.type});
                     const attachmentData = await activityUtils.getAttachments([file]);
                     const attachmentSizes = await activityUtils.getAttachmentSizes([file]);
@@ -116,8 +110,6 @@ class AMSFileScanner {
             } catch (e) {
                 console.error(e);
             }
-
-            await sleep(1000);
         }
     }
 
@@ -127,12 +119,25 @@ class AMSFileScanner {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve) => {
             this.scanResults?.forEach(async (scanResult, id) => {await this.scanFileCallback(scanResult, id)});
+            await sleep(1000);
             resolve();
         });
     }
 
     public end(): void {
         this.shouldQueueScan = false;
+    }
+
+    private async retrieveFileBlob(fileMetadata: FileMetadata, view_location: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+        let blob: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        try {
+            blob = await this.amsClient.getView(fileMetadata, view_location); // eslint-disable-line @typescript-eslint/no-explicit-any
+        } catch (error) {
+            console.error(error);
+        }
+
+        return blob;
     }
 }
 

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -19,22 +19,26 @@ class AMSFileScanner {
     public amsClient: FramedClient;
     public scanResults: Map<string, FileScanResult> | null = null;
     public interval: number = defaultScanInterval;
+    private shouldQueueScan: boolean;
 
     constructor(amsClient: FramedClient, interval: number = defaultScanInterval) {
         this.amsClient = amsClient;
         this.scanResults = new Map<string, FileScanResult>();
         this.interval = interval;
+        this.shouldQueueScan = false;
         this.queueScan();
     }
 
     public async queueScan(): Promise<void> {
+        this.shouldQueueScan = true;
+
         try {
             await this.scanFiles();
         } catch (e) {
             console.error(e);
         } finally {
             await sleep(this.interval);
-            await this.queueScan();
+            this.shouldQueueScan && await this.queueScan();
         }
     }
 
@@ -124,6 +128,10 @@ class AMSFileScanner {
             await sleep(1000);
             resolve();
         });
+    }
+
+    public end(): void {
+        this.shouldQueueScan = false;
     }
 }
 

--- a/src/external/ACSAdapter/AMSFileScanner.ts
+++ b/src/external/ACSAdapter/AMSFileScanner.ts
@@ -102,9 +102,7 @@ class AMSFileScanner {
                 }
 
                 if (scan.status === AMSViewScanStatus.MALWARE && next && activity) {
-                    const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
-                    activity.channelData.fileScan[index] = scan;
-                    next(activity);
+                    await this.renderMalwareActivity(scanResult);
                 }
             } catch (e) {
                 console.error(e);
@@ -146,6 +144,13 @@ class AMSFileScanner {
         const index = activity.attachments.findIndex((attachment: any) => (attachment.name === file.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
         activity.attachments[index] = attachmentData[0];
         activity.channelData.attachmentSizes[index] = attachmentSizes[0];
+    }
+
+    public async renderMalwareActivity(scanResult: FileScanResult): Promise<void> { // eslint-disable-line @typescript-eslint/no-explicit-any
+        const {fileMetadata, next, activity} = scanResult;
+        const index = activity.attachments.findIndex((attachment: any) => (attachment.name === fileMetadata.name)); // eslint-disable-line @typescript-eslint/no-explicit-any
+        activity.channelData.fileScan[index] = {status: AMSViewScanStatus.MALWARE};
+        next(activity);
     }
 }
 

--- a/src/external/ACSAdapter/activityUtils.ts
+++ b/src/external/ACSAdapter/activityUtils.ts
@@ -1,0 +1,33 @@
+export const getDataURL = async (file: File): Promise<string | ArrayBuffer> => {
+    return new Promise((resolve) => {
+        const fileReader = new FileReader();
+        fileReader.onloadend = () => {
+            resolve((fileReader as any).result); // eslint-disable-line @typescript-eslint/no-explicit-any
+        };
+        fileReader.readAsDataURL(file);
+    });
+}
+
+export const getAttachments = async (files: File[]): Promise<Array<any>> => { // eslint-disable-line @typescript-eslint/no-explicit-any
+    return Promise.all(
+        files.map(async (file: File) => {
+            if (file) {
+                const url = await getDataURL(file);
+                return {
+                    contentType: file.type,
+                    contentUrl: url,
+                    name: file.name,
+                    thumbnailUrl: file.type.match("(image|video|audio).*") ? url: undefined
+                }
+            }
+        })
+    )
+}
+
+export const getAttachmentSizes = (files: File[]): number[] => {
+    return files.map((file: File) => {
+        return file.size;
+    });
+}
+
+export default {getDataURL, getAttachments, getAttachmentSizes};

--- a/src/external/ACSAdapter/createFileScanIngressMiddleware.ts
+++ b/src/external/ACSAdapter/createFileScanIngressMiddleware.ts
@@ -7,7 +7,7 @@ const createFileScanIngressMiddleware = (): CallableFunction => {
 
         // Patch references
         if (!channelData?.metadata?.amsreferences && channelData?.metadata?.amsReferences) {
-            channelData.metadata.amsreferences = channelData.metadata.amsReferences;
+            activity.channelData.metadata.amsreferences = channelData.metadata.amsReferences;
         }
 
         const {metadata: {amsreferences}} = channelData;

--- a/src/external/ACSAdapter/createFileScanIngressMiddleware.ts
+++ b/src/external/ACSAdapter/createFileScanIngressMiddleware.ts
@@ -16,6 +16,11 @@ const createFileScanIngressMiddleware = (): CallableFunction => {
             try {
                 const fileId = JSON.parse(amsreferences)[0];
                 const { fileScanner } = (window as any).chatAdapter.fileManager;  // eslint-disable-line @typescript-eslint/no-explicit-any
+
+                if (!fileScanner) {
+                    return next(activity);
+                }
+
                 const scanResult = fileScanner.retrieveFileScanResult(fileId);
 
                 if (scanResult) {

--- a/src/external/ACSAdapter/createFileScanIngressMiddleware.ts
+++ b/src/external/ACSAdapter/createFileScanIngressMiddleware.ts
@@ -1,0 +1,39 @@
+const createFileScanIngressMiddleware = (): CallableFunction => {
+    const fileScanIngressMiddleware = () => (next: any) => async (activity: any) => {  // eslint-disable-line @typescript-eslint/no-explicit-any
+        const {attachments, channelData} = activity;
+        if (!attachments) {
+            return next(activity);
+        }
+
+        // Patch references
+        if (!channelData?.metadata?.amsreferences && channelData?.metadata?.amsReferences) {
+            channelData.metadata.amsreferences = channelData.metadata.amsReferences;
+        }
+
+        const {metadata: {amsreferences}} = channelData;
+
+        if (amsreferences) {
+            try {
+                const fileId = JSON.parse(amsreferences)[0];
+                const { fileScanner } = (window as any).chatAdapter.fileManager;  // eslint-disable-line @typescript-eslint/no-explicit-any
+                const scanResult = fileScanner.retrieveFileScanResult(fileId);
+
+                if (scanResult) {
+                    const {scan} = scanResult;
+                    activity.channelData.fileScan = scan;
+                }
+
+                fileScanner.addNext(fileId, next);
+                fileScanner.addActivity(fileId, activity);
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
+        return next(activity);
+    }
+
+    return fileScanIngressMiddleware;
+}
+
+export default createFileScanIngressMiddleware;

--- a/src/utils/WebUtils.ts
+++ b/src/utils/WebUtils.ts
@@ -50,10 +50,12 @@ const removeElementById = (id: string): void => {
 
 export default {
   loadScript,
-  removeElementById
+  removeElementById,
+  sleep
 }
 
 export {
   loadScript,
-  removeElementById
+  removeElementById,
+  sleep
 }

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -102,6 +102,14 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
         scenarioMarker.completeScenario(TelemetryEvent.CreateACSAdapter);
 
         if (optionalParams.ACSAdapter?.fileScan?.disabled === false) {
+            if (adapter.end) {
+                const {end} = adapter;
+                adapter.end = () => {
+                    adapter.fileManager.fileScanner.end()
+                    end();
+                }
+            }
+
             (window as any).chatAdapter = adapter;  // eslint-disable-line @typescript-eslint/no-explicit-any
         }
 

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -100,6 +100,11 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
         );
 
         scenarioMarker.completeScenario(TelemetryEvent.CreateACSAdapter);
+
+        if (optionalParams.ACSAdapter?.fileScan) {
+            (window as any).chatAdapter = adapter;  // eslint-disable-line @typescript-eslint/no-explicit-any
+        }
+
         return adapter;
     } catch (error) {
         exceptionThrowers.throwChatAdapterInitializationFailure(error, scenarioMarker, TelemetryEvent.CreateACSAdapter)

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -14,6 +14,7 @@ import ScenarioMarker from "../telemetry/ScenarioMarker";
 import TelemetryEvent from "../telemetry/TelemetryEvent";
 import WebUtils from "./WebUtils";
 import createChannelDataEgressMiddleware from "../external/ACSAdapter/createChannelDataEgressMiddleware";
+import createFileScanIngressMiddleware from "../external/ACSAdapter/createFileScanIngressMiddleware";
 import createFormatEgressTagsMiddleware from "../external/ACSAdapter/createFormatEgressTagsMiddleware";
 import createFormatIngressTagsMiddleware from "../external/ACSAdapter/createFormatIngressTagsMiddleware";
 import exceptionThrowers from "./exceptionThrowers";
@@ -55,7 +56,12 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
 
     // Tags formatting middlewares are required to be the last in the pipeline to ensure tags are converted to the right format
     const defaultEgressMiddlewares = [createChannelDataEgressMiddleware({widgetId: omnichannelConfig.widgetId}), createFormatEgressTagsMiddleware()];
-    const defaultIngressMiddlewares = [createFormatIngressTagsMiddleware()];
+    let defaultIngressMiddlewares = [createFormatIngressTagsMiddleware()];
+
+    if (optionalParams.ACSAdapter?.fileScan) {
+        defaultIngressMiddlewares = [createFileScanIngressMiddleware(), ...defaultIngressMiddlewares];
+    }
+
     const egressMiddleware = options?.egressMiddleware? [...options.egressMiddleware, ...defaultEgressMiddlewares]: [...defaultEgressMiddlewares];
     const ingressMiddleware = options?.ingressMiddleware? [...options.ingressMiddleware, ...defaultIngressMiddlewares]: [...defaultIngressMiddlewares];
     const featuresOption = {

--- a/src/utils/chatAdapterCreators.ts
+++ b/src/utils/chatAdapterCreators.ts
@@ -58,7 +58,7 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
     const defaultEgressMiddlewares = [createChannelDataEgressMiddleware({widgetId: omnichannelConfig.widgetId}), createFormatEgressTagsMiddleware()];
     let defaultIngressMiddlewares = [createFormatIngressTagsMiddleware()];
 
-    if (optionalParams.ACSAdapter?.fileScan) {
+    if (optionalParams.ACSAdapter?.fileScan?.disabled === false) {
         defaultIngressMiddlewares = [createFileScanIngressMiddleware(), ...defaultIngressMiddlewares];
     }
 
@@ -101,7 +101,7 @@ const createACSAdapter = async (optionalParams: ChatAdapterOptionalParams, chatS
 
         scenarioMarker.completeScenario(TelemetryEvent.CreateACSAdapter);
 
-        if (optionalParams.ACSAdapter?.fileScan) {
+        if (optionalParams.ACSAdapter?.fileScan?.disabled === false) {
             (window as any).chatAdapter = adapter;  // eslint-disable-line @typescript-eslint/no-explicit-any
         }
 


### PR DESCRIPTION
## Problem 

- Currently, attachment files with `in progress` or `malicious` states can be downloaded

## Solution 

- Any attachment files not with `passed` state won't be able to be downloaded. 
- The `File.content` of the attachment in `malicious` state be will removed. 
- Attachment files with `in progress` state would be added to the file scanning, its state would be periodically verified until we get a definite state (`passed` or `malicious`), then it would be handled accordingly

## Sample Code

```ts
const fileScan: any = {
  disabled: false, // disabled by default to ensure backward compability
  scanPollingInterval: 30 * 1000 // file scan polling interval (default: 7 seconds)
  scanStatusRetrievalDelay: 1000 // wait time between subsequent scan status retrieval API call (default: 1 second)
};

const chatAdapter: any = await chatSDK?.createChatAdapter({ACSAdapter: {fileScan}});

// ...

const attachmentMiddleware = () => (next: any) => (...args: any) => {
  const [card] = args;
  // ...

  if (card.activity.channelData && card.activity.channelData.fileScan) {
    const index = attachments.findIndex((attachment: any) => (attachment.name === card.attachment.name));
    const {activity: {channelData: {fileScan}}} = card;

    if (scanResult?.status === "in progress") {
     return <ScanInProgressAttachment/>
    } 

    if (scanResult?.status === "malware") {
     return <MaliciousAttachment/>
    } 
  }
}
```

## Test Scenarios
1. Upload single image attachment
   - Attachment should be ignored since `scan.status` only exists for file attachments and not image attachments
1. Upload single file attachment which takes time to retrieve the `scan.status` (.pdf, .pptx)
   - Attachment should go from `in progress` to `passed`
1. Upload malicious file attachment
   - It should be blocked
1. Upload image + file attachment
   - Multiple attachments should be uploaded accordingly
1. Upload multiple files attachment
   - Multiple attachments should be uploaded accordingly
