### PR TITLE
Adding redirect for oauth reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
 - Modify `getChatReconnectContext` to return redirection URL when reconnection ID is not longer Valid for Auth Chats.
 
 ## [1.5.0] - 2023-09-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Modify `getChatReconnectContext` to return redirection URL when reconnection ID is not longer Valid for Auth Chats.
 
 ## [1.5.0] - 2023-09-29
 ### Added

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3306,7 +3306,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(context.redirectURL).toBe(mockedResponseAvailability.reconnectRedirectionURL);
         });
         
-        it('ChatSDK.getChatReconnectContext() with authenticatedUserToken should call OCClient.getReconnectableChats() & return redirectURL empty and return valid session', async () => {
+        it('ChatSDK.getChatReconnectContext() with authenticatedUserToken should call OCClient.getReconnectableChats(), return redirectURL empty and return valid session', async () => {
             const chatSDKConfig = {
                 telemetry: {
                     disable: true

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3292,6 +3292,46 @@ describe('Omnichannel Chat SDK', () => {
 
             const mockedResponseAvailability = {
                 reconnectid: null,
+                reconnectRedirectionURL: null
+            };
+
+            jest.spyOn(chatSDK.OCClient, 'getReconnectAvailability').mockResolvedValue(Promise.resolve(mockedResponseAvailability));
+            jest.spyOn(chatSDK.OCClient, 'getReconnectableChats').mockResolvedValue(Promise.resolve(mockedResponse));
+
+            const context = await chatSDK.getChatReconnectContext(params);
+
+            expect(chatSDK.OCClient.getReconnectAvailability).toHaveBeenCalledTimes(1);
+            expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(1);
+            expect(context.reconnectId).toBe(mockedResponse.reconnectid);
+            expect(context.redirectURL).toBe(mockedResponseAvailability.reconnectRedirectionURL);
+        });
+        
+        it('ChatSDK.getChatReconnectContext() with authenticatedUserToken should call OCClient.getReconnectableChats() & return redirectURL empty and return valid session', async () => {
+            const chatSDKConfig = {
+                telemetry: {
+                    disable: true
+                },
+                chatReconnect: {
+                    disable: false,
+                }
+            };
+            const params = {
+                reconnectId: 'reconnectId'
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.isChatReconnect = true;
+            chatSDK.authenticatedUserToken = 'token';
+
+            await chatSDK.initialize();
+  
+            const mockedResponse = {
+                reconnectid: 'reconnectid'
+            };
+
+            const mockedResponseAvailability = {
+                reconnectid: null,
                 reconnectRedirectionURL: "http://microsoft.com"
             };
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3331,8 +3331,8 @@ describe('Omnichannel Chat SDK', () => {
             };
 
             const mockedResponseAvailability = {
-                reconnectid: null,
-                reconnectRedirectionURL: "http://microsoft.com"
+                reconnectid: "12345",
+
             };
 
             jest.spyOn(chatSDK.OCClient, 'getReconnectAvailability').mockResolvedValue(Promise.resolve(mockedResponseAvailability));
@@ -3343,7 +3343,6 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.OCClient.getReconnectAvailability).toHaveBeenCalledTimes(1);
             expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(1);
             expect(context.reconnectId).toBe(mockedResponse.reconnectid);
-            expect(context.redirectURL).toBe(mockedResponseAvailability.reconnectRedirectionURL);
         });
         
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3258,15 +3258,17 @@ describe('Omnichannel Chat SDK', () => {
             };
 
             jest.spyOn(chatSDK.OCClient, 'getReconnectableChats').mockResolvedValue(Promise.resolve(mockedResponse));
+            jest.spyOn(chatSDK.OCClient, 'getReconnectAvailability').mockResolvedValue(Promise.resolve());
 
             const context = await chatSDK.getChatReconnectContext();
 
             expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(1);
+            expect(chatSDK.OCClient.getReconnectAvailability).toHaveBeenCalledTimes(0);
             expect(context.reconnectId).toBe(mockedResponse.reconnectid);
         });
 
 
-        it('ChatSDK.getChatReconnectContext() with authenticatedUserToken should call OCClient.getReconnectableChats() & return redirectURL due to expired token', async () => {
+        it('ChatSDK.getChatReconnectContext() with authenticatedUserToken should not call OCClient.getReconnectableChats() & return redirectURL due to expired token', async () => {
             const chatSDKConfig = {
                 telemetry: {
                     disable: true
@@ -3292,7 +3294,8 @@ describe('Omnichannel Chat SDK', () => {
 
             const mockedResponseAvailability = {
                 reconnectid: null,
-                reconnectRedirectionURL: null
+                reconnectRedirectionURL: "www.microsoft.com",
+                isReconnectAvailable: false
             };
 
             jest.spyOn(chatSDK.OCClient, 'getReconnectAvailability').mockResolvedValue(Promise.resolve(mockedResponseAvailability));
@@ -3301,8 +3304,8 @@ describe('Omnichannel Chat SDK', () => {
             const context = await chatSDK.getChatReconnectContext(params);
 
             expect(chatSDK.OCClient.getReconnectAvailability).toHaveBeenCalledTimes(1);
-            expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(1);
-            expect(context.reconnectId).toBe(mockedResponse.reconnectid);
+            expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(0);
+            expect(context.reconnectId).toBe(mockedResponseAvailability.reconnectid);
             expect(context.redirectURL).toBe(mockedResponseAvailability.reconnectRedirectionURL);
         });
         

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -255,7 +255,7 @@ class OmnichannelChatSDK {
     }
 
 
-    public async getChatReconnectContextForAuth(): Promise<ChatReconnectContext> {
+    private async getChatReconnectContextForAuth(): Promise<ChatReconnectContext> {
 
         this.scenarioMarker.startScenario(TelemetryEvent.GetReconnectableChatContext, {
             RequestId: this.requestId,
@@ -303,7 +303,7 @@ class OmnichannelChatSDK {
         return context;
     }
 
-    public async getChatReconnectContextAvailability(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
+    private async getChatReconnectContextAvailability(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
 
         this.scenarioMarker.startScenario(TelemetryEvent.GetReconnectAvailabilityContext, {
             RequestId: this.requestId,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -3,13 +3,13 @@
 import { ACSAdapterLogger, ACSClientLogger, AMSClientLogger, CallingSDKLogger, IC3ClientLogger, OCSDKLogger, createACSAdapterLogger, createACSClientLogger, createAMSClientLogger, createCallingSDKLogger, createIC3ClientLogger, createOCSDKLogger } from "./utils/loggers";
 import ACSClient, { ACSConversation } from "./core/messaging/ACSClient";
 import { ChatMessageReceivedEvent, ParticipantsRemovedEvent } from '@azure/communication-signaling';
-import {SDKProvider as OCSDKProvider, uuidv4} from "@microsoft/ocsdk";
+import { SDKProvider as OCSDKProvider, uuidv4 } from "@microsoft/ocsdk";
 import { createACSAdapter, createDirectLine, createIC3Adapter } from "./utils/chatAdapterCreators";
 import { defaultLocaleId, getLocaleStringFromId } from "./utils/locale";
-import {isClientIdNotFoundErrorMessage, isCustomerMessage} from "./utils/utilities";
+import { isClientIdNotFoundErrorMessage, isCustomerMessage } from "./utils/utilities";
 import { loadScript, removeElementById } from "./utils/WebUtils";
 import platform, { isBrowser } from "./utils/platform";
-import validateSDKConfig, {defaultChatSDKConfig} from "./validators/SDKConfigValidators";
+import validateSDKConfig, { defaultChatSDKConfig } from "./validators/SDKConfigValidators";
 import ACSParticipantDisplayName from "./core/messaging/ACSParticipantDisplayName";
 import AMSFileManager from "./external/ACSAdapter/AMSFileManager";
 import AriaTelemetry from "./telemetry/AriaTelemetry";
@@ -37,7 +37,7 @@ import GetConversationDetailsOptionalParams from "./core/GetConversationDetailsO
 import GetLiveChatConfigOptionalParams from "./core/GetLiveChatConfigOptionalParams";
 import GetLiveChatTranscriptOptionalParams from "./core/GetLiveChatTranscriptOptionalParams";
 import HostType from "@microsoft/omnichannel-ic3core/lib/interfaces/HostType";
-import {SDKProvider as IC3SDKProvider} from '@microsoft/omnichannel-ic3core';
+import { SDKProvider as IC3SDKProvider } from '@microsoft/omnichannel-ic3core';
 import IChatToken from "./external/IC3Adapter/IChatToken";
 import IConversation from "@microsoft/omnichannel-ic3core/lib/model/IConversation";
 import IEmailTranscriptOptionalParams from "@microsoft/ocsdk/lib/Interfaces/IEmailTranscriptOptionalParams";
@@ -221,7 +221,7 @@ class OmnichannelChatSDK {
         }
 
         try {
-            const {getLiveChatConfigOptionalParams} = optionalParams;
+            const { getLiveChatConfigOptionalParams } = optionalParams;
             await this.getChatConfig(getLiveChatConfigOptionalParams || {});
         } catch (e) {
             exceptionThrowers.throwChatConfigRetrievalFailure(e, this.scenarioMarker, TelemetryEvent.InitializeChatSDK);
@@ -254,27 +254,68 @@ class OmnichannelChatSDK {
         return this.liveChatConfig;
     }
 
-    public async getChatReconnectContext(optionalParams: ChatReconnectOptionalParams = {}):  Promise<ChatReconnectContext> {
-        this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContext, {
-            RequestId: this.requestId,
-            ChatId: this.chatToken.chatId as string
-        })
+
+    public async getChatReconnectContextForAuth(): Promise<ChatReconnectContext> {
 
         const context: ChatReconnectContext = {
             reconnectId: null,
             redirectURL: null
         }
 
-        if (this.authenticatedUserToken) {
+        try {
+
+            const reconnectableChatsParams: IReconnectableChatsParams = {
+                authenticatedUserToken: this.authenticatedUserToken as string
+            }
+
+            const reconnectableChatsResponse = await this.OCClient.getReconnectableChats(reconnectableChatsParams);
+
+            if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) {
+                context.reconnectId = reconnectableChatsResponse.reconnectid as string
+            }
+
+            this.scenarioMarker.completeScenario(TelemetryEvent.GetChatReconnectContext, {
+                RequestId: this.requestId,
+                ChatId: this.chatToken.chatId as string
+            })
+        } catch (error) {
+            const exceptionDetails = {
+                response: "OCClientGetReconnectableChatsFailed"
+            }
+            const telemetryData = {
+                RequestId: this.requestId,
+                ChatId: this.chatToken.chatId as string,
+                ExceptionDetails: JSON.stringify(exceptionDetails)
+            }
+            if (isClientIdNotFoundErrorMessage(error)) {
+                exceptionThrowers.throwAuthContactIdNotFoundFailure(error, this.scenarioMarker, TelemetryEvent.GetChatReconnectContext, telemetryData);
+            }
+
+            this.scenarioMarker.failScenario(TelemetryEvent.GetChatReconnectContext, telemetryData);
+            console.error(`OmnichannelChatSDK/GetChatReconnectContext/error ${error}`);
+        }
+
+        return context;
+
+    }
+
+    public async getChatReconnectContextAvailability(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
+
+        const context: ChatReconnectContext = {
+            reconnectId: null,
+            redirectURL: null
+        }
+
+        if (optionalParams.reconnectId) {
             try {
-                const reconnectableChatsParams: IReconnectableChatsParams = {
-                    authenticatedUserToken: this.authenticatedUserToken as string
-                }
+                const reconnectAvailabilityResponse = await this.OCClient.getReconnectAvailability(optionalParams.reconnectId);
 
-                const reconnectableChatsResponse = await this.OCClient.getReconnectableChats(reconnectableChatsParams);
-
-                if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) {
-                    context.reconnectId = reconnectableChatsResponse.reconnectid as string
+                if (reconnectAvailabilityResponse && !reconnectAvailabilityResponse.isReconnectAvailable) {
+                    if (reconnectAvailabilityResponse.reconnectRedirectionURL) {
+                        context.redirectURL = reconnectAvailabilityResponse.reconnectRedirectionURL as string;
+                    }
+                } else {
+                    context.reconnectId = optionalParams.reconnectId as string;
                 }
 
                 this.scenarioMarker.completeScenario(TelemetryEvent.GetChatReconnectContext, {
@@ -283,54 +324,50 @@ class OmnichannelChatSDK {
                 })
             } catch (error) {
                 const exceptionDetails = {
-                    response: "OCClientGetReconnectableChatsFailed"
+                    response: "OCClientGetReconnectAvailabilityFailed"
                 }
-                const telemetryData = {
+
+                this.scenarioMarker.failScenario(TelemetryEvent.GetChatReconnectContext, {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string,
                     ExceptionDetails: JSON.stringify(exceptionDetails)
-                }
-                if (isClientIdNotFoundErrorMessage(error)) {
-                    exceptionThrowers.throwAuthContactIdNotFoundFailure(error, this.scenarioMarker, TelemetryEvent.GetChatReconnectContext, telemetryData);
-                }
+                });
 
-                this.scenarioMarker.failScenario(TelemetryEvent.GetChatReconnectContext, telemetryData);
                 console.error(`OmnichannelChatSDK/GetChatReconnectContext/error ${error}`);
-            }
-        } else {
-            if (optionalParams.reconnectId) {
-                try {
-                    const reconnectAvailabilityResponse = await this.OCClient.getReconnectAvailability(optionalParams.reconnectId);
-
-                    if (reconnectAvailabilityResponse && !reconnectAvailabilityResponse.isReconnectAvailable) {
-                        if (reconnectAvailabilityResponse.reconnectRedirectionURL) {
-                            context.redirectURL = reconnectAvailabilityResponse.reconnectRedirectionURL as string;
-                        }
-                    } else {
-                        context.reconnectId = optionalParams.reconnectId as string;
-                    }
-
-                    this.scenarioMarker.completeScenario(TelemetryEvent.GetChatReconnectContext, {
-                        RequestId: this.requestId,
-                        ChatId: this.chatToken.chatId as string
-                    })
-                } catch (error) {
-                    const exceptionDetails = {
-                        response: "OCClientGetReconnectAvailabilityFailed"
-                    }
-
-                    this.scenarioMarker.failScenario(TelemetryEvent.GetChatReconnectContext, {
-                        RequestId: this.requestId,
-                        ChatId: this.chatToken.chatId as string,
-                        ExceptionDetails: JSON.stringify(exceptionDetails)
-                    });
-
-                    console.error(`OmnichannelChatSDK/GetChatReconnectContext/error ${error}`);
-                }
             }
         }
 
-        return context
+        return context;
+
+    }
+
+    public async getChatReconnectContext(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
+        this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContext, {
+            RequestId: this.requestId,
+            ChatId: this.chatToken.chatId as string
+        })
+
+        let avialbilityContext : ChatReconnectContext = {
+            reconnectId: null,
+            redirectURL: null
+        }
+
+        avialbilityContext = await this.getChatReconnectContextAvailability(optionalParams);
+
+        console.log("ELOPEZANAYA : SDK : context availability : ", JSON.stringify(avialbilityContext));
+
+        if ( this.authenticatedUserToken) {
+            const result = await this.getChatReconnectContextForAuth();
+            console.log("ELOPEZANAYA : SDK : redirectURL : ", JSON.stringify(result));
+            if (result.redirectURL == null ){
+                result.redirectURL = avialbilityContext.redirectURL;
+            }
+            return result;
+        } 
+
+        console.log("ELOPEZANAYA :: SDK : return context : ", JSON.stringify(avialbilityContext));
+        return avialbilityContext;
+
     }
 
     public async startChat(optionalParams: StartChatOptionalParams = {}): Promise<void> {
@@ -485,7 +522,7 @@ class OmnichannelChatSDK {
                 };
 
                 const tokenRefresher = async (): Promise<string> => {
-                    await this.getChatToken(false, {refreshToken: true});
+                    await this.getChatToken(false, { refreshToken: true });
                     await this.AMSClient?.initialize({ chatToken: this.chatToken as OmnichannelChatToken });
                     return this.chatToken.token as string;
                 };
@@ -576,8 +613,8 @@ class OmnichannelChatSDK {
 
         if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
             this.refreshTokenTimer = setInterval(async () => {
-               await this.getChatToken(false);
-               this.updateChatToken(this.chatToken.token as string, this.chatToken.regionGTMS);
+                await this.getChatToken(false);
+                this.updateChatToken(this.chatToken.token as string, this.chatToken.regionGTMS);
             }, this.chatSDKConfig.persistentChat?.tokenUpdateTime);
         }
     }
@@ -591,15 +628,15 @@ class OmnichannelChatSDK {
         const sessionCloseOptionalParams: ISessionCloseOptionalParams = {};
 
         if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
-            const isReconnectChat = this.reconnectId !== null? true: false;
+            const isReconnectChat = this.reconnectId !== null ? true : false;
 
             sessionCloseOptionalParams.isPersistentChat = this.isPersistentChat;
             sessionCloseOptionalParams.isReconnectChat = isReconnectChat;
         }
 
         if (this.isChatReconnect && !this.chatSDKConfig.chatReconnect?.disable && !this.isPersistentChat) {
-            const isChatReconnect = this.reconnectId !== null? true: false;
-            this.requestId = isChatReconnect? (this.reconnectId as string): this.requestId; // Chat Reconnect session to close
+            const isChatReconnect = this.reconnectId !== null ? true : false;
+            this.requestId = isChatReconnect ? (this.reconnectId as string) : this.requestId; // Chat Reconnect session to close
             sessionCloseOptionalParams.isReconnectChat = isChatReconnect;
         }
 
@@ -661,7 +698,7 @@ class OmnichannelChatSDK {
 
     public async getCurrentLiveChatContext(): Promise<LiveChatContext | {}> {
         const chatToken = await this.getChatToken();
-        const {requestId} = this;
+        const { requestId } = this;
 
         this.scenarioMarker.startScenario(TelemetryEvent.GetCurrentLiveChatContext, {
             RequestId: requestId,
@@ -710,7 +747,7 @@ class OmnichannelChatSDK {
             ChatId: chatId || '',
         });
 
-        const getLWIDetailsOptionalParams: IGetLWIDetailsOptionalParams  = {};
+        const getLWIDetailsOptionalParams: IGetLWIDetailsOptionalParams = {};
 
         if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable && reconnectId) {
             getLWIDetailsOptionalParams.reconnectId = reconnectId as string;
@@ -726,7 +763,7 @@ class OmnichannelChatSDK {
 
         try {
             const lwiDetails = await this.OCClient.getLWIDetails(requestId, getLWIDetailsOptionalParams);
-            const {State: state, ConversationId: conversationId, AgentAcceptedOn: agentAcceptedOn, CanRenderPostChat: canRenderPostChat, ParticipantType: participantType} = lwiDetails;
+            const { State: state, ConversationId: conversationId, AgentAcceptedOn: agentAcceptedOn, CanRenderPostChat: canRenderPostChat, ParticipantType: participantType } = lwiDetails;
 
             const liveWorkItemDetails: LiveWorkItemDetails = {
                 state,
@@ -774,7 +811,7 @@ class OmnichannelChatSDK {
     public async getPreChatSurvey(parse = true): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
         this.scenarioMarker.startScenario(TelemetryEvent.GetPreChatSurvey);
         try {
-            const result = parse? JSON.parse(this.preChatSurvey): this.preChatSurvey;
+            const result = parse ? JSON.parse(this.preChatSurvey) : this.preChatSurvey;
             this.scenarioMarker.completeScenario(TelemetryEvent.GetPreChatSurvey);
             return result;
         } catch {
@@ -787,7 +824,7 @@ class OmnichannelChatSDK {
             return this.liveChatConfig;
         }
 
-        return this.getChatConfig({sendCacheHeaders: optionalParams?.sendCacheHeaders || false});
+        return this.getChatConfig({ sendCacheHeaders: optionalParams?.sendCacheHeaders || false });
     }
 
     public async getChatToken(cached = true, optionalParams?: GetChatTokenOptionalParams): Promise<IChatToken> {
@@ -815,7 +852,7 @@ class OmnichannelChatSDK {
                 }
 
                 const chatToken = await this.OCClient.getChatToken(this.requestId, getChatTokenOptionalParams);
-                const {ChatId: chatId, Token: token, RegionGtms: regionGtms, ExpiresIn: expiresIn, VisitorId: visitorId, VoiceVideoCallToken: voiceVideoCallToken, ACSEndpoint: acsEndpoint, AttachmentConfiguration: attachmentConfiguration} = chatToken;
+                const { ChatId: chatId, Token: token, RegionGtms: regionGtms, ExpiresIn: expiresIn, VisitorId: visitorId, VoiceVideoCallToken: voiceVideoCallToken, ACSEndpoint: acsEndpoint, AttachmentConfiguration: attachmentConfiguration } = chatToken;
                 this.chatToken = {
                     chatId,
                     regionGTMS: JSON.parse(regionGtms),
@@ -906,9 +943,9 @@ class OmnichannelChatSDK {
             ChatId: this.chatToken.chatId as string
         });
 
-        const {disable, maskingCharacter} = this.chatSDKConfig.dataMasking!;
+        const { disable, maskingCharacter } = this.chatSDKConfig.dataMasking!;
 
-        let {content} = message;
+        let { content } = message;
         if (Object.keys(this.dataMaskingRules).length > 0 && !disable) {
             for (const maskingRule of Object.values(this.dataMaskingRules)) {
                 const regex = new RegExp(maskingRule as string, 'g');
@@ -933,7 +970,7 @@ class OmnichannelChatSDK {
             }
 
             if (message.metadata) {
-                sendMessageRequest.metadata = {...sendMessageRequest.metadata, ...message.metadata};
+                sendMessageRequest.metadata = { ...sendMessageRequest.metadata, ...message.metadata };
             }
 
             try {
@@ -961,9 +998,9 @@ class OmnichannelChatSDK {
                 properties: undefined,
                 tags: [...defaultMessageTags],
                 sender: {
-                    displayName : "Customer",
-                    id : "customer",
-                    type : PersonType.User
+                    displayName: "Customer",
+                    id: "customer",
+                    type: PersonType.User
                 }
             };
 
@@ -1006,9 +1043,9 @@ class OmnichannelChatSDK {
                 this.debug && console.log('[OmnichannelChatSDK][onNewMessage] rehydrate');
                 const messages = await this.getMessages() as OmnichannelMessage[];
                 for (const message of messages.reverse()) {
-                    const {id} = message;
+                    const { id } = message;
                     if (postedMessages.has(id)) {
-                      continue;
+                        continue;
                     }
 
                     postedMessages.add(id);
@@ -1018,7 +1055,7 @@ class OmnichannelChatSDK {
 
             try {
                 (this.conversation as ACSConversation)?.registerOnNewMessage((event: ChatMessageReceivedEvent) => {
-                    const {id} = event;
+                    const { id } = event;
 
                     const omnichannelMessage = createOmnichannelMessage(event, {
                         liveChatVersion: this.liveChatVersion,
@@ -1049,7 +1086,7 @@ class OmnichannelChatSDK {
                 const messages = await this.getMessages() as IRawMessage[];
                 if (messages) {
                     for (const message of messages.reverse()) {
-                        const {clientmessageid} = message;
+                        const { clientmessageid } = message;
 
                         if (postedMessages.has(clientmessageid)) {
                             continue;
@@ -1069,7 +1106,7 @@ class OmnichannelChatSDK {
 
             try {
                 this.conversation?.registerOnNewMessage((message: IRawMessage) => {
-                    const {clientmessageid, messageType} = message;
+                    const { clientmessageid, messageType } = message;
 
                     // Filter out customer messages
                     if (isCustomerMessage(message)) {
@@ -1137,7 +1174,7 @@ class OmnichannelChatSDK {
                 await (this.conversation as IConversation)!.indicateTypingStatus(0);
                 const members: IPerson[] = await (this.conversation as IConversation)!.getMembers();
                 const botMembers = members.filter((member: IPerson) => member.type === PersonType.Bot);
-                await (this.conversation as IConversation)!.sendMessageToBot(botMembers[0].id, {payload: typingPayload});
+                await (this.conversation as IConversation)!.sendMessageToBot(botMembers[0].id, { payload: typingPayload });
 
                 this.scenarioMarker.completeScenario(TelemetryEvent.SendTypingEvent, {
                     RequestId: this.requestId,
@@ -1177,7 +1214,7 @@ class OmnichannelChatSDK {
         } else {
             try {
                 this.conversation?.registerOnNewMessage((message: IRawMessage) => {
-                    const {messageType} = message;
+                    const { messageType } = message;
 
                     // Filter out customer messages
                     if (isCustomerMessage(message)) {
@@ -1227,7 +1264,7 @@ class OmnichannelChatSDK {
         } else {
             try {
                 this.conversation?.registerOnThreadUpdate((message: IRawThread) => {
-                    const {members} = message;
+                    const { members } = message;
 
                     // Agent ending conversation would have 1 member left in the chat thread
                     if (members.length === 1) {
@@ -1278,7 +1315,7 @@ class OmnichannelChatSDK {
 
             const sendMessageRequest = {
                 content: '',
-                metadata:  {
+                metadata: {
                     widgetId: this.omnichannelConfig.widgetId,
                     clientMessageId: Date.now().toString(),
                     ...fileIdsProperty,
@@ -1375,7 +1412,7 @@ class OmnichannelChatSDK {
         if (this.liveChatVersion === LiveChatVersion.V2) {
             try {
                 const response: any = await this.AMSClient?.getViewStatus(fileMetadata);  // eslint-disable-line @typescript-eslint/no-explicit-any
-                const {view_location} = response;
+                const { view_location } = response;
                 const viewResponse: any = await this.AMSClient?.getView(fileMetadata, view_location);  // eslint-disable-line @typescript-eslint/no-explicit-any
                 this.scenarioMarker.completeScenario(TelemetryEvent.DownloadFileAttachment, {
                     RequestId: this.requestId,
@@ -1499,7 +1536,7 @@ class OmnichannelChatSDK {
             return Promise.reject('ChatAdapter is only supported on browser');
         }
 
-        const {protocol} = optionalParams;
+        const { protocol } = optionalParams;
         const supportedChatAdapterProtocols = [ChatAdapterProtocols.ACS, ChatAdapterProtocols.IC3, ChatAdapterProtocols.DirectLine];
         if (protocol && !supportedChatAdapterProtocols.includes(protocol as string)) {
             return Promise.reject(`ChatAdapter for protocol ${protocol} currently not supported`);
@@ -1535,14 +1572,14 @@ class OmnichannelChatSDK {
         }
 
         const chatConfig = await this.getChatConfig();
-        const {LiveWSAndLiveChatEngJoin: liveWSAndLiveChatEngJoin} = chatConfig;
-        const {msdyn_widgetsnippet} = liveWSAndLiveChatEngJoin;
+        const { LiveWSAndLiveChatEngJoin: liveWSAndLiveChatEngJoin } = chatConfig;
+        const { msdyn_widgetsnippet } = liveWSAndLiveChatEngJoin;
 
         // Find src attribute with its url in code snippet
         const widgetSnippetSourceRegex = new RegExp(`src="(https:\\/\\/[\\w-.]+)[\\w-.\\/]+"`);
         const result = msdyn_widgetsnippet.match(widgetSnippetSourceRegex);
         if (result && result.length) {
-            return new Promise (async (resolve) => { // eslint-disable-line no-async-promise-executor
+            return new Promise(async (resolve) => { // eslint-disable-line no-async-promise-executor
                 const LiveChatWidgetLibCDNUrl = `${result[1]}/livechatwidget/WebChatControl/lib/CallingBundle.js`;
 
                 this.telemetry?.setCDNPackages({
@@ -1555,7 +1592,7 @@ class OmnichannelChatSDK {
 
                 await loadScript(LiveChatWidgetLibCDNUrl, async () => {
                     this.debug && console.debug(`${LiveChatWidgetLibCDNUrl} loaded!`);
-                    const VoiceVideoCalling = await createVoiceVideoCalling({...params, ...defaultParams});
+                    const VoiceVideoCalling = await createVoiceVideoCalling({ ...params, ...defaultParams });
 
                     this.scenarioMarker.completeScenario(TelemetryEvent.GetVoiceVideoCalling);
 
@@ -1586,8 +1623,8 @@ class OmnichannelChatSDK {
 
         try {
             const chatConfig: ChatConfig = this.liveChatConfig;
-            const {LiveWSAndLiveChatEngJoin: liveWSAndLiveChatEngJoin} = chatConfig;
-            const {msdyn_postconversationsurveyenable, msfp_sourcesurveyidentifier, msfp_botsourcesurveyidentifier, postConversationSurveyOwnerId, postConversationBotSurveyOwnerId} = liveWSAndLiveChatEngJoin;
+            const { LiveWSAndLiveChatEngJoin: liveWSAndLiveChatEngJoin } = chatConfig;
+            const { msdyn_postconversationsurveyenable, msfp_sourcesurveyidentifier, msfp_botsourcesurveyidentifier, postConversationSurveyOwnerId, postConversationBotSurveyOwnerId } = liveWSAndLiveChatEngJoin;
 
             if (msdyn_postconversationsurveyenable === "true") {
                 const liveWorkItemDetails = await this.getConversationDetails();
@@ -1814,7 +1851,7 @@ class OmnichannelChatSDK {
             /* istanbul ignore next */
             this.debug && console.debug('IC3Client');
             // Use IC3Client if browser is detected
-            return new Promise (async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
+            return new Promise(async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
                 const ic3ClientCDNUrl = this.resolveIC3ClientUrl();
 
                 this.telemetry?.setCDNPackages({
@@ -1837,8 +1874,8 @@ class OmnichannelChatSDK {
                     // Use FramedBridge from IC3Client
                     /* istanbul ignore next */
                     this.debug && console.debug('ic3:sdk:load');
-                    const {SDK: ic3sdk} = window.Microsoft.CRM.Omnichannel.IC3Client;
-                    const {SDKProvider: IC3SDKProvider} = ic3sdk;
+                    const { SDK: ic3sdk } = window.Microsoft.CRM.Omnichannel.IC3Client;
+                    const { SDKProvider: IC3SDKProvider } = ic3sdk;
                     this.IC3SDKProvider = IC3SDKProvider;
                     const IC3Client = await IC3SDKProvider.getSDK({
                         hostType: HostType.IFrame,
@@ -1870,7 +1907,7 @@ class OmnichannelChatSDK {
     }
 
     private async getChatConfig(optionalParams: GetLiveChatConfigOptionalParams = {}): Promise<ChatConfig> {
-        const {sendCacheHeaders} = optionalParams;
+        const { sendCacheHeaders } = optionalParams;
         const bypassCache = sendCacheHeaders === true;
         const liveChatConfig = await this.OCClient.getChatConfig(this.requestId, bypassCache);
         const {
@@ -1881,7 +1918,7 @@ class OmnichannelChatSDK {
             ChatWidgetLanguage: chatWidgetLanguage
         } = liveChatConfig;
 
-        const {msdyn_localeid} = chatWidgetLanguage;
+        const { msdyn_localeid } = chatWidgetLanguage;
 
         this.localeId = msdyn_localeid || defaultLocaleId;
         this.liveChatVersion = liveChatVersion || LiveChatVersion.V2;
@@ -1889,7 +1926,7 @@ class OmnichannelChatSDK {
         /* istanbul ignore next */
         this.debug && console.log(`[OmnichannelChatSDK][getChatConfig][liveChatVersion] ${this.liveChatVersion}`);
 
-        const {setting} = dataMaskingConfig;
+        const { setting } = dataMaskingConfig;
         if (setting.msdyn_maskforcustomer) {
             this.dataMaskingRules = dataMaskingConfig.dataMaskingRules;
         }
@@ -1898,7 +1935,7 @@ class OmnichannelChatSDK {
             this.authSettings = authSettings;
         }
 
-        const {PreChatSurvey: preChatSurvey, msdyn_prechatenabled, msdyn_callingoptions, msdyn_conversationmode, msdyn_enablechatreconnect} = liveWSAndLiveChatEngJoin;
+        const { PreChatSurvey: preChatSurvey, msdyn_prechatenabled, msdyn_callingoptions, msdyn_conversationmode, msdyn_enablechatreconnect } = liveWSAndLiveChatEngJoin;
         const isPreChatEnabled = msdyn_prechatenabled === true || msdyn_prechatenabled == "true";
         const isChatReconnectEnabled = msdyn_enablechatreconnect === true || msdyn_enablechatreconnect == "true";
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -255,20 +255,24 @@ class OmnichannelChatSDK {
     }
 
 
-    public async getChatReconnectContextForAuth(): Promise<ChatReconnectContext> {
+    public async getChatReconnectContextForAuth(redirectUrl?:string|null): Promise<ChatReconnectContext> {
 
         const context: ChatReconnectContext = {
             reconnectId: null,
-            redirectURL: null
+            redirectURL: redirectUrl? redirectUrl : null
         }
 
         try {
+
+            console.log("ELOPEZANAYA :: SDK :: redirectURL ::"+ redirectUrl);
+            console.log("ELOPEZANAYA :: SDK :: context.redirectURL ::"+ context?.redirectURL);
 
             const reconnectableChatsParams: IReconnectableChatsParams = {
                 authenticatedUserToken: this.authenticatedUserToken as string
             }
 
             const reconnectableChatsResponse = await this.OCClient.getReconnectableChats(reconnectableChatsParams);
+            console.log("ELOPEZANAYA : SDK : reconnectableChatsResponse : ", JSON.stringify(reconnectableChatsResponse));
 
             if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) {
                 context.reconnectId = reconnectableChatsResponse.reconnectid as string
@@ -310,10 +314,18 @@ class OmnichannelChatSDK {
             try {
                 const reconnectAvailabilityResponse = await this.OCClient.getReconnectAvailability(optionalParams.reconnectId);
 
+                console.log("ELOPEZANAYA : SDK : reconnectAvailabilityResponse : ", JSON.stringify(reconnectAvailabilityResponse)); 
                 if (reconnectAvailabilityResponse && !reconnectAvailabilityResponse.isReconnectAvailable) {
+                   console.log("ELOPEZANAYA :: business time");
                     if (reconnectAvailabilityResponse.reconnectRedirectionURL) {
+                        console.log("ELOPEZANAYA :: SDK :: redirectURL :   "+ reconnectAvailabilityResponse.reconnectRedirectionURL);
                         context.redirectURL = reconnectAvailabilityResponse.reconnectRedirectionURL as string;
+                        console.log("ELOPEZANAYA context =>" + context.redirectURL);
+                    }else{
+                        console.log("WHAAAAT");
                     }
+
+
                 } else {
                     context.reconnectId = optionalParams.reconnectId as string;
                 }
@@ -337,6 +349,7 @@ class OmnichannelChatSDK {
             }
         }
 
+        console.log("ELOPEZANAYA :: return :"+ context.redirectURL);
         return context;
 
     }
@@ -347,26 +360,24 @@ class OmnichannelChatSDK {
             ChatId: this.chatToken.chatId as string
         })
 
-        let avialbilityContext : ChatReconnectContext = {
+        let availabilityContext : ChatReconnectContext = {
             reconnectId: null,
             redirectURL: null
         }
 
-        avialbilityContext = await this.getChatReconnectContextAvailability(optionalParams);
+        availabilityContext = await this.getChatReconnectContextAvailability(optionalParams);
 
-        console.log("ELOPEZANAYA : SDK : context availability : ", JSON.stringify(avialbilityContext));
+        console.log("ELOPEZANAYA : SDK : context availability : ", JSON.stringify(availabilityContext));
 
         if ( this.authenticatedUserToken) {
-            const result = await this.getChatReconnectContextForAuth();
+            console.log("ELOPEZANAYA :: SDK :: redirect passing ::"+ availabilityContext.redirectURL);
+            const result = await this.getChatReconnectContextForAuth(availabilityContext.redirectURL);
             console.log("ELOPEZANAYA : SDK : redirectURL : ", JSON.stringify(result));
-            if (result.redirectURL == null ){
-                result.redirectURL = avialbilityContext.redirectURL;
-            }
             return result;
         } 
 
-        console.log("ELOPEZANAYA :: SDK : return context : ", JSON.stringify(avialbilityContext));
-        return avialbilityContext;
+        console.log("ELOPEZANAYA :: SDK : return context : ", JSON.stringify(availabilityContext));
+        return availabilityContext;
 
     }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -255,9 +255,9 @@ class OmnichannelChatSDK {
     }
 
 
-    private async getChatReconnectContextForAuth(): Promise<ChatReconnectContext> {
+    private async getChatReconnectContextWithAuthToken(): Promise<ChatReconnectContext> {
 
-        this.scenarioMarker.startScenario(TelemetryEvent.GetReconnectableChatContext, {
+        this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContextWithAuthToken, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
         })
@@ -278,7 +278,7 @@ class OmnichannelChatSDK {
                 context.reconnectId = reconnectableChatsResponse.reconnectid as string
             }
 
-            this.scenarioMarker.completeScenario(TelemetryEvent.GetReconnectableChatContext, {
+            this.scenarioMarker.completeScenario(TelemetryEvent.GetChatReconnectContextWithAuthToken, {
                 RequestId: this.requestId,
                 ChatId: this.chatToken.chatId as string
             })
@@ -293,19 +293,19 @@ class OmnichannelChatSDK {
                 ExceptionDetails: JSON.stringify(exceptionDetails)
             }
             if (isClientIdNotFoundErrorMessage(error)) {
-                exceptionThrowers.throwAuthContactIdNotFoundFailure(error, this.scenarioMarker, TelemetryEvent.GetReconnectableChatContext, telemetryData);
+                exceptionThrowers.throwAuthContactIdNotFoundFailure(error, this.scenarioMarker, TelemetryEvent.GetChatReconnectContextWithAuthToken, telemetryData);
             }
 
-            this.scenarioMarker.failScenario(TelemetryEvent.GetReconnectableChatContext, telemetryData);
-            console.error(`OmnichannelChatSDK/GetReconnectableChatContext/error ${error}`);
+            this.scenarioMarker.failScenario(TelemetryEvent.GetChatReconnectContextWithAuthToken, telemetryData);
+            console.error(`OmnichannelChatSDK/GetChatReconnectContextWithAuthToken/error ${error}`);
         }
 
         return context;
     }
 
-    private async getChatReconnectContextAvailability(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
+    private async getChatReconnectContextWithReconnectId(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
 
-        this.scenarioMarker.startScenario(TelemetryEvent.GetReconnectAvailabilityContext, {
+        this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContextWithReconnectId, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
         })
@@ -327,7 +327,7 @@ class OmnichannelChatSDK {
                     context.reconnectId = optionalParams.reconnectId as string;
                 }
 
-                this.scenarioMarker.completeScenario(TelemetryEvent.GetReconnectAvailabilityContext, {
+                this.scenarioMarker.completeScenario(TelemetryEvent.GetChatReconnectContextWithReconnectId, {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string
                 })
@@ -336,13 +336,13 @@ class OmnichannelChatSDK {
                     response: "OCClientGetReconnectAvailabilityFailed"
                 }
 
-                this.scenarioMarker.failScenario(TelemetryEvent.GetReconnectAvailabilityContext, {
+                this.scenarioMarker.failScenario(TelemetryEvent.GetChatReconnectContextWithReconnectId, {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string,
                     ExceptionDetails: JSON.stringify(exceptionDetails)
                 });
 
-                console.error(`OmnichannelChatSDK/GetReconnectAvailabilityContext/error ${error}`);
+                console.error(`OmnichannelChatSDK/GetChatReconnectContextWithReconnectId/error ${error}`);
             }
         }
         //here the context contains recconnectionId if valid, or redirectionURL if not valid
@@ -350,19 +350,19 @@ class OmnichannelChatSDK {
     }
 
     public async getChatReconnectContext(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
-       
+
         this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContext, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
         })
 
-        let context : ChatReconnectContext = {
+        let context: ChatReconnectContext = {
             reconnectId: null,
             redirectURL: null
         }
 
         // if necessary to make this call, to validate if the token is valid.
-        context = await this.getChatReconnectContextAvailability(optionalParams);
+        context = await this.getChatReconnectContextWithReconnectId(optionalParams);
 
         // if redirectURL is present, it means the token is not longer valid.
         if (context.redirectURL && context.redirectURL.length > 0) {
@@ -371,8 +371,8 @@ class OmnichannelChatSDK {
 
         // at this point the token is valid and we can check for active session for auth sessions
         if (this.authenticatedUserToken) {
-            context = await this.getChatReconnectContextForAuth();
-        } 
+            context = await this.getChatReconnectContextWithAuthToken();
+        }
 
         this.scenarioMarker.completeScenario(TelemetryEvent.GetChatReconnectContext, {
             RequestId: this.requestId,
@@ -380,7 +380,7 @@ class OmnichannelChatSDK {
         })
 
         return context;
-}
+    }
 
     public async startChat(optionalParams: StartChatOptionalParams = {}): Promise<void> {
         this.scenarioMarker.startScenario(TelemetryEvent.StartChat, {

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -36,8 +36,8 @@ enum TelemetryEvent {
     GetPostChatSurveyContext = "GetPostChatSurveyContext",
     GetAgentAvailability = "GetAgentAvailability",
     GetGeolocation = "GetGeolocation",
-    GetReconnectAvailabilityContext = "GetReconnectAvailabilityContext",
-    GetReconnectableChatContext = "GetReconnectableChatContext"
+    GetChatReconnectContextWithReconnectId = "GetChatReconnectContextWithReconnectId",
+    GetChatReconnectContextWithAuthToken = "GetChatReconnectContextWithAuthToken"
 
 }
 

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -35,7 +35,10 @@ enum TelemetryEvent {
     GetChatReconnectContext = "GetChatReconnectContext",
     GetPostChatSurveyContext = "GetPostChatSurveyContext",
     GetAgentAvailability = "GetAgentAvailability",
-    GetGeolocation = "GetGeolocation"
+    GetGeolocation = "GetGeolocation",
+    GetReconnectAvailabilityContext = "GetReconnectAvailabilityContext",
+    GetReconnectableChatContext = "GetReconnectableChatContext"
+
 }
 
 export default TelemetryEvent;


### PR DESCRIPTION
## Description

For Auth chats with invalid reconnection id , is missing the redirection URL as part of the response 

Solution

Obtain the redirection URL when checking for connection availability, this call returns  : 
- isRecconnectable (true if session is valid)
- reconnectionId
- redirect URL

__if reconnectable is false, then there is no point in checking for oauth reconnectable chats__, so we will break the flow at this point and return the redirection URL

## Tests

### No Auth
- refresh
- connecting to the chat using the reconnection URL
-  connecting to the chat using a reconnection URL in a different browser
- refresh with the reconnection URL defined in the browser
- try to reconnect using URL, but being redirected due to an expired token

### pop-out
- reconnection and redirection using URL with an expired token
- reconnection using URL

### Auth
- reconnect to the chat using the reconnection URL
- reconnect to the chat using a reconnection URL in a different browser
- tried to reconnect using the URL, but I was redirected due to an expired token

#### pop-out
- reconnection using url
- close chat and reopen to same session
#### when reconnection url is present in the window browser
- when closing and launching the widget, takes to the same user
- 

## No redirect config
### guess
- chat starts , and using reconnection within the time, no issue
- chat starts, and using reconnection with an expired token starts a new chat

### auth
- chat starts , and using reconnection within the time, no issue
- chat starts, and using reconnection with an expired token starts a new chat

##### when no reconnection url in the browser
- can close and restart a new chat session (options present in the popout)


