### PR TITLE
Fixed an issue where startChat failed due to optionalParam being null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Add missing `PACS` URL for `EUDomainNames`
+- Fixed an issue where startChat failed due to optionalParam being null
 
 ## [1.5.4] - 2023-10-20
 ### Fixed

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1783,9 +1783,9 @@ class OmnichannelChatSDK {
     private populateInitChatOptionalParam = (requestOptionalParams: ISessionInitOptionalParams | IGetQueueAvailabilityOptionalParams, optionalParams: StartChatOptionalParams | GetAgentAvailabilityOptionalParams, telemetryEvent: TelemetryEvent) => {
         requestOptionalParams.initContext!.locale = getLocaleStringFromId(this.localeId);
 
-        if (optionalParams.customContext) {
+        if (optionalParams?.customContext) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const context: any = optionalParams.customContext;
+            const context: any = optionalParams?.customContext;
             if (typeof context === "object") {
                 for (const key in context) {
                     if (context[key].value === null || context[key].value === undefined || context[key].value === "") {
@@ -1793,7 +1793,7 @@ class OmnichannelChatSDK {
                     }
                 }
             }
-            (requestOptionalParams.initContext! as any).customContextData = optionalParams.customContext; // eslint-disable-line @typescript-eslint/no-explicit-any
+            (requestOptionalParams.initContext! as any).customContextData = optionalParams?.customContext; // eslint-disable-line @typescript-eslint/no-explicit-any
         }
 
         if (optionalParams.browser) {


### PR DESCRIPTION
[Task 3656723](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3656723): investigate : : Cannot read properties of undefined (reading 'customContext'