### PR TITLE
Add `InvalidAuthentication` to `ExceptionThrower`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 ## Unreleased
+
+### Added
 - Add `InvalidAuthentication` to `ExceptionThrower`
 
 ## [1.5.6]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
-- Add `InvalidAuthentication` to `ExceptionThrower`
+- Throw `InvalidAuthentication` if `OCClient.getChatToken()` fails with `401` status
 
 ## [1.5.7] - 2023-11-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Add `RequestPayload`, `RequestPath`, `RequestMethod`, `ResponseStatusCode` telemetry base property to `OCSDKContract`
+- Add `InvalidAuthentication` to `ExceptionThrower`
 
 ### Changed
 - Use `parseLowerCaseString()` on chat config properties to protect text case change

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -898,7 +898,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.OCClient.sessionInit).toHaveBeenCalledTimes(0);
         });
 
-        it('ChatSDK.startChat() should not call OCClient.sessionInit() if OCClient.getChatToken() fails with 401 InvalidAuthentication', async () => {
+        it('ChatSDK.startChat() should fail with "InvalidAuthentication" if OCClient.getChatToken() fails with 401', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -898,6 +898,30 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.OCClient.sessionInit).toHaveBeenCalledTimes(0);
         });
 
+        it('ChatSDK.startChat() should not call OCClient.sessionInit() if OCClient.getChatToken() fails with 401 InvalidAuthentication', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+
+            await chatSDK.initialize();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const axiosErrorObject: any = {};
+            axiosErrorObject.isAxiosError = true;
+            axiosErrorObject.response = {};
+            axiosErrorObject.response.status = 401;
+
+            jest.spyOn(chatSDK.OCClient, 'getChatToken').mockRejectedValue(axiosErrorObject);
+            jest.spyOn(chatSDK.OCClient, 'sessionInit').mockRejectedValue(Promise.resolve());
+
+            try {
+                await chatSDK.startChat();
+            } catch (e) {
+                expect(e.message).toBe("InvalidAuthentication");
+            }
+
+            expect(chatSDK.OCClient.sessionInit).toHaveBeenCalledTimes(0);
+        });
+
         it('ChatSDK.startChat() should throw a \'WidgetUseOutsideOperatingHour\' error if OCClient.sessionInit() fails with \'705\' error code', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();

--- a/__tests__/utils/utilities.spec.ts
+++ b/__tests__/utils/utilities.spec.ts
@@ -101,4 +101,30 @@ describe('Utilities', () => {
 
         expect(utilities.isClientIdNotFoundErrorMessage(error)).toBe(false);
     });
+
+    it('utilities.isInvalidAuthentication() should return true if error has 401 status code', () => {
+        const error = {
+            response: {
+                status: 401,
+                headers: {
+                    message: "test"
+                }
+            }
+        }
+
+        expect(utilities.isInvalidAuthentication(error)).toBe(true);
+    });
+
+    it('utilities.isInvalidAuthentication() should return false if error has other error code', () => {
+        const error = {
+            response: {
+                status: 403,
+                headers: {
+                    message: "test"
+                }
+            }
+        }
+
+        expect(utilities.isInvalidAuthentication(error)).toBe(false);
+    });
 });

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -900,11 +900,6 @@ class OmnichannelChatSDK {
                     ChatId: this.chatToken?.chatId as string,
                 };
 
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                if ((error as any)?.isAxiosError && (error as any).response?.headers?.errorcode?.toString() === OmnichannelErrorCodes.WidgetUseOutsideOperatingHour.toString()) {
-                    exceptionThrowers.throwWidgetUseOutsideOperatingHour(error, this.scenarioMarker, TelemetryEvent.StartChat, telemetryData);
-                }
-
                 if (isClientIdNotFoundErrorMessage(error)) {
                     exceptionThrowers.throwAuthContactIdNotFoundFailure(error, this.scenarioMarker, TelemetryEvent.GetChatToken, telemetryData);
                 } else if (isInvalidAuthentication(error)) {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -902,7 +902,7 @@ class OmnichannelChatSDK {
 
                 if (isClientIdNotFoundErrorMessage(error)) {
                     exceptionThrowers.throwAuthContactIdNotFoundFailure(error, this.scenarioMarker, TelemetryEvent.GetChatToken, telemetryData);
-                } else if (isInvalidAuthentication(error)) {
+                } else if ((error as any)?.isAxiosError && isInvalidAuthentication(error)) {
                     exceptionThrowers.throwInvalidAuthentication(error, this.scenarioMarker, TelemetryEvent.GetChatToken, telemetryData);
                 } else {
                     exceptionThrowers.throwChatTokenRetrievalFailure(error, this.scenarioMarker, TelemetryEvent.GetChatToken, telemetryData);

--- a/src/core/ChatSDKErrors.ts
+++ b/src/core/ChatSDKErrors.ts
@@ -48,7 +48,7 @@ enum ChatSDKErrors {
     ConversationDetailsRetrievalFailure = "ConversationDetailsRetrievalFailure",
     /** Failure on finding the contact id related to the auth code */
     AuthContactIdNotFoundFailure = "AuthContactIdNotFoundFailure",
-    /** Failure from getChatToken returning 401 */
+    /** Failure in authentication with the service */
     InvalidAuthentication = "InvalidAuthentication"
 }
 

--- a/src/core/ChatSDKErrors.ts
+++ b/src/core/ChatSDKErrors.ts
@@ -47,7 +47,9 @@ enum ChatSDKErrors {
     /** Failure on retrieving conversation details */
     ConversationDetailsRetrievalFailure = "ConversationDetailsRetrievalFailure",
     /** Failure on finding the contact id related to the auth code */
-    AuthContactIdNotFoundFailure = "AuthContactIdNotFoundFailure"
+    AuthContactIdNotFoundFailure = "AuthContactIdNotFoundFailure",
+    /** Failure from getChatToken returning 401 */
+    InvalidAuthentication = "InvalidAuthentication"
 }
 
 export default ChatSDKErrors;

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -125,6 +125,10 @@ export const throwAuthContactIdNotFoundFailure = (e: unknown, scenarioMarker: Sc
     throwChatSDKError(ChatSDKErrors.AuthContactIdNotFoundFailure, e, scenarioMarker, telemetryEvent, telemetryData);
 }
 
+export const throwInvalidAuthentication = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string}): void => {
+    throwChatSDKError(ChatSDKErrors.InvalidAuthentication, e, scenarioMarker, telemetryEvent, telemetryData);
+}
+
 export default {
     throwChatSDKError,
     throwScriptLoadFailure,
@@ -147,5 +151,6 @@ export default {
     throwMessagingClientConversationJoinFailure,
     throwChatAdapterInitializationFailure,
     throwLiveChatTranscriptRetrievalFailure,
-    throwAuthContactIdNotFoundFailure
+    throwAuthContactIdNotFoundFailure,
+    throwInvalidAuthentication
 }

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -27,3 +27,7 @@ export const isClientIdNotFoundErrorMessage = (e: any): boolean => {
     return e?.response?.status === 401
         && e?.response?.headers?.message === "UserId not found";
 }
+
+export const isInvalidAuthentication = (e: any): boolean => {
+    return e?.response?.status === 401;
+}


### PR DESCRIPTION
Add `InvalidAuthentication` to `ExceptionThrower` when getChatToken returns 401, to make the original getChatToken error of `ChatTokenRetrievalFailure` have more granular cases.