### PR TITLE
Add `httpResponseStatusCode` into the thrown error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Changed
-- Added "status" attribute in the error object thrown
+- Added "httpResponseStatusCode" attribute in the error object thrown
 
 ## [1.5.7] - 2023-11-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 ## Unreleased
+### Changed
+- Added "status" attribute in the error object thrown
 
 ## [1.5.7] - 2023-11-20
 ### Changed

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -18,6 +18,20 @@ import ChatSDKExceptionDetails from "../core/ChatSDKExceptionDetails";
 import ScenarioMarker from "../telemetry/ScenarioMarker";
 import TelemetryEvent from "../telemetry/TelemetryEvent";
 
+class CustomChatSDKError {
+    public message: string;
+    public httpResponseStatusCode: number | undefined;
+
+    constructor(message: string, httpResponseStatusCode?: number) {
+        this.message = message;
+        this.httpResponseStatusCode = httpResponseStatusCode;
+    }
+
+    toString(): string {
+        return this.message;
+    }
+}
+
 export const throwChatSDKError = (chatSDKError: ChatSDKErrors, e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string} = {}, message = ""): void => {
     const exceptionDetails: ChatSDKExceptionDetails = {
         response: chatSDKError
@@ -37,15 +51,10 @@ export const throwChatSDKError = (chatSDKError: ChatSDKErrors, e: unknown, scena
         console.error(message);
     }
 
-    const errorObject = {
-        message: exceptionDetails.response
-    };
-    
-    if ((e as any)?.isAxiosError && (e as any)?.response?.status) {
-        (errorObject as any).httpResponseStatusCode = (e as any).response.status;
-    }
-
-    throw errorObject;
+    throw new CustomChatSDKError(
+        exceptionDetails.response,
+        ((e as any)?.isAxiosError && (e as any)?.response?.status) ? (e as any)?.response?.status : undefined
+    );
 }
 
 export const throwScriptLoadFailure = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent): void => {

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -41,8 +41,8 @@ export const throwChatSDKError = (chatSDKError: ChatSDKErrors, e: unknown, scena
         message: exceptionDetails.response
     };
     
-    if ((e as any)?.response?.status) {
-        (errorObject as any).status = (e as any).response.status;
+    if ((e as any)?.isAxiosError && (e as any)?.response?.status) {
+        (errorObject as any).httpResponseStatusCode = (e as any).response.status;
     }
 
     throw errorObject;

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Utilities to throw exception on failures in ChatSDK.
  *
@@ -53,6 +52,7 @@ export const throwChatSDKError = (chatSDKError: ChatSDKErrors, e: unknown, scena
 
     throw new CustomChatSDKError(
         exceptionDetails.response,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ((e as any)?.isAxiosError && (e as any)?.response?.status) ? (e as any)?.response?.status : undefined
     );
 }

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Utilities to throw exception on failures in ChatSDK.
  *
@@ -36,7 +37,15 @@ export const throwChatSDKError = (chatSDKError: ChatSDKErrors, e: unknown, scena
         console.error(message);
     }
 
-    throw new Error(exceptionDetails.response);
+    const errorObject = {
+        message: exceptionDetails.response
+    };
+    
+    if ((e as any)?.response?.status) {
+        (errorObject as any).status = (e as any).response.status;
+    }
+
+    throw errorObject;
 }
 
 export const throwScriptLoadFailure = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent): void => {


### PR DESCRIPTION
Current returned error object (changed default "Error" into "CustomChatSDKError" class)
![image](https://github.com/microsoft/omnichannel-chat-sdk/assets/14852927/c5bfbfa4-32c1-466a-a693-b62b2ecf43f8)

