### PR TITLE
Fix queue position message edits being recognized  in chatSDK onNewMessage()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 ## Unreleased
 
+### Fixed
+- Fix queue position message edits being recognized in chatSDK `onNewMessage()`
+
 ## [1.5.7] - 2023-11-20
 ### Changed
 - Uptake [@microsoft/omnichannel-amsclient@0.1.6](https://www.npmjs.com/package/@microsoft/omnichannel-amsclient/v/0.1.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Fixed
-- Fix queue position message edits being recognized in chatSDK `onNewMessage()`
+- Subscribe to `chatMessageEdited` events within `onNewMessage()` for queue position message updates
 
 ## [1.6.0] - 2023-12-04
 ### Changed

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -152,7 +152,7 @@ describe('ACSClient', () => {
         expect(messages).toBeDefined();
     });
 
-    it('ACSClient.conversation.registerOnNewMessage() should call ChatThreadClient.getMessages() & register to "chatMessageReceived" event', async () => {
+    it('ACSClient.conversation.registerOnNewMessage() should call ChatThreadClient.getMessages() & register to "chatMessageReceived" and "chatMessageEdited" events', async () => {
         const client: any = new ACSClient();
         const config = {
             token: 'token',
@@ -191,10 +191,12 @@ describe('ACSClient', () => {
         (global as any).setTimeout = jest.fn();
         await conversation.registerOnNewMessage(() => {});
 
-        const event = "chatMessageReceived";
+        const chatMessageReceivedEvent = "chatMessageReceived";
+        const chatMessageEditedEvent = "chatMessageEdited";
         expect(conversation.getMessages).toHaveBeenCalledTimes(1);
-        expect(client.chatClient.on).toHaveBeenCalledTimes(1);
-        expect(client.chatClient.on.mock.calls[0][0]).toEqual(event);
+        expect(client.chatClient.on).toHaveBeenCalledTimes(2);
+        expect(client.chatClient.on.mock.calls[0][0]).toEqual(chatMessageReceivedEvent);
+        expect(client.chatClient.on.mock.calls[1][0]).toEqual(chatMessageEditedEvent);
     });
 
     it('ACSClient.conversation.registerOnThreadUpdate() should register to "participantsRemoved" event', async () => {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2,7 +2,7 @@
 
 import { ACSAdapterLogger, ACSClientLogger, AMSClientLogger, CallingSDKLogger, IC3ClientLogger, OCSDKLogger, createACSAdapterLogger, createACSClientLogger, createAMSClientLogger, createCallingSDKLogger, createIC3ClientLogger, createOCSDKLogger } from "./utils/loggers";
 import ACSClient, { ACSConversation } from "./core/messaging/ACSClient";
-import { ChatMessageReceivedEvent, ParticipantsRemovedEvent } from '@azure/communication-signaling';
+import { ChatMessageReceivedEvent, ChatMessageEditedEvent, ParticipantsRemovedEvent } from '@azure/communication-signaling';
 import { SDKProvider as OCSDKProvider, uuidv4 } from "@microsoft/ocsdk";
 import { createACSAdapter, createDirectLine, createIC3Adapter } from "./utils/chatAdapterCreators";
 import { defaultLocaleId, getLocaleStringFromId } from "./utils/locale";
@@ -17,7 +17,7 @@ import AuthSettings from "./core/AuthSettings";
 import CallingOptionsOptionSetNumber from "./core/CallingOptionsOptionSetNumber";
 import ChatAdapterOptionalParams from "./core/messaging/ChatAdapterOptionalParams";
 import ChatAdapterProtocols from "./core/messaging/ChatAdapterProtocols";
-import { ChatClient, ChatMessageEditedEvent } from "@azure/communication-chat";
+import { ChatClient } from "@azure/communication-chat";
 import ChatConfig from "./core/ChatConfig";
 import ChatReconnectContext from "./core/ChatReconnectContext";
 import ChatReconnectOptionalParams from "./core/ChatReconnectOptionalParams";

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -17,7 +17,7 @@ import AuthSettings from "./core/AuthSettings";
 import CallingOptionsOptionSetNumber from "./core/CallingOptionsOptionSetNumber";
 import ChatAdapterOptionalParams from "./core/messaging/ChatAdapterOptionalParams";
 import ChatAdapterProtocols from "./core/messaging/ChatAdapterProtocols";
-import { ChatClient } from "@azure/communication-chat";
+import { ChatClient, ChatMessageEditedEvent } from "@azure/communication-chat";
 import ChatConfig from "./core/ChatConfig";
 import ChatReconnectContext from "./core/ChatReconnectContext";
 import ChatReconnectOptionalParams from "./core/ChatReconnectOptionalParams";
@@ -1053,6 +1053,7 @@ class OmnichannelChatSDK {
     }
 
     public async onNewMessage(onNewMessageCallback: CallableFunction, optionalParams: OnNewMessageOptionalParams | unknown = {}): Promise<void> {
+        console.log("ADAD onNewMessage method");
         this.scenarioMarker.startScenario(TelemetryEvent.OnNewMessage, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
@@ -1064,8 +1065,11 @@ class OmnichannelChatSDK {
             if ((optionalParams as OnNewMessageOptionalParams).rehydrate) {
                 this.debug && console.log('[OmnichannelChatSDK][onNewMessage] rehydrate');
                 const messages = await this.getMessages() as OmnichannelMessage[];
+                console.log("ADAD messages", messages);
                 for (const message of messages.reverse()) {
+                    console.log("ADAD message", message);
                     const { id } = message;
+                    console.log("ADAD id", id);
                     if (postedMessages.has(id)) {
                         continue;
                     }
@@ -1076,14 +1080,18 @@ class OmnichannelChatSDK {
             }
 
             try {
-                (this.conversation as ACSConversation)?.registerOnNewMessage((event: ChatMessageReceivedEvent) => {
+                (this.conversation as ACSConversation)?.registerOnNewMessage((event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
+                    console.log("ADAD event onNewMessageCallback", event);
                     const { id } = event;
 
                     const omnichannelMessage = createOmnichannelMessage(event, {
                         liveChatVersion: this.liveChatVersion,
                         debug: this.debug
                     });
+                    console.log("ADAD omnichannelMessage onNewMessageCallback", omnichannelMessage);
 
+                    console.log("ADAD postedMessages", postedMessages);
+                    console.log("ADAD id", id);
                     if (!postedMessages.has(id)) {
                         onNewMessageCallback(omnichannelMessage);
                         postedMessages.add(id);

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1053,7 +1053,6 @@ class OmnichannelChatSDK {
     }
 
     public async onNewMessage(onNewMessageCallback: CallableFunction, optionalParams: OnNewMessageOptionalParams | unknown = {}): Promise<void> {
-        console.log("ADAD onNewMessage method");
         this.scenarioMarker.startScenario(TelemetryEvent.OnNewMessage, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
@@ -1065,11 +1064,8 @@ class OmnichannelChatSDK {
             if ((optionalParams as OnNewMessageOptionalParams).rehydrate) {
                 this.debug && console.log('[OmnichannelChatSDK][onNewMessage] rehydrate');
                 const messages = await this.getMessages() as OmnichannelMessage[];
-                console.log("ADAD messages", messages);
                 for (const message of messages.reverse()) {
-                    console.log("ADAD message", message);
                     const { id } = message;
-                    console.log("ADAD id", id);
                     if (postedMessages.has(id)) {
                         continue;
                     }
@@ -1081,17 +1077,13 @@ class OmnichannelChatSDK {
 
             try {
                 (this.conversation as ACSConversation)?.registerOnNewMessage((event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
-                    console.log("ADAD event onNewMessageCallback", event);
                     const { id } = event;
 
                     const omnichannelMessage = createOmnichannelMessage(event, {
                         liveChatVersion: this.liveChatVersion,
                         debug: this.debug
                     });
-                    console.log("ADAD omnichannelMessage onNewMessageCallback", omnichannelMessage);
 
-                    console.log("ADAD postedMessages", postedMessages);
-                    console.log("ADAD id", id);
                     if (!postedMessages.has(id)) {
                         onNewMessageCallback(omnichannelMessage);
                         postedMessages.add(id);

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -3,9 +3,9 @@ import ACSClientConfig from "./ACSClientConfig";
 import { ACSClientLogger } from "../../utils/loggers";
 import ACSParticipantDisplayName from "./ACSParticipantDisplayName";
 import ACSSessionInfo from "./ACSSessionInfo";
-import { ChatClient, ChatParticipant, ChatThreadClient, ChatMessage, ChatMessageEditedEvent } from "@azure/communication-chat";
+import { ChatClient, ChatParticipant, ChatThreadClient, ChatMessage } from "@azure/communication-chat";
 import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from "@azure/communication-common";
-import { ChatMessageReceivedEvent, ParticipantsRemovedEvent, TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
+import { ChatMessageReceivedEvent, ChatMessageEditedEvent, ParticipantsRemovedEvent, TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
 import ChatSDKMessage from "./ChatSDKMessage";
 import createOmnichannelMessage from "../../utils/createOmnichannelMessage";
 import { defaultMessageTags } from "./MessageTags";
@@ -209,9 +209,10 @@ export class ACSConversation {
             const listener = (event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
                 isReceivingNotifications = true;
 
-                const {id, version, sender} = event;
+                const {id, sender} = event;
 
-                const customerMessageCondition = ((sender as CommunicationUserIdentifier).communicationUserId === (this.sessionInfo?.id as string))
+                const customerMessageCondition = ((sender as CommunicationUserIdentifier).communicationUserId === (this.sessionInfo?.id as string));
+                const isChatMessageEditedEvent = event.hasOwnProperty('editedOn');
 
                 // Filter out customer messages
                 if (customerMessageCondition) {
@@ -219,7 +220,7 @@ export class ACSConversation {
                 }
 
                 // Filter out duplicate messages
-                if (postedMessageIds.has(id) && postedMessageIds.has(version)) {
+                if (postedMessageIds.has(id) && !isChatMessageEditedEvent) {
                     return;
                 }
 

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -212,7 +212,7 @@ export class ACSConversation {
                 const {id, sender} = event;
 
                 const customerMessageCondition = ((sender as CommunicationUserIdentifier).communicationUserId === (this.sessionInfo?.id as string));
-                const isChatMessageEditedEvent = event.hasOwnProperty('editedOn');
+                const isChatMessageEditedEvent = Object.keys(event).includes("editedOn");
 
                 // Filter out customer messages
                 if (customerMessageCondition) {

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -166,7 +166,6 @@ export class ACSConversation {
     }
 
     public async registerOnNewMessage(onNewMessageCallback: CallableFunction): Promise<void> {
-        console.log("ADAD registerOnNewMessage method");
         this.logger?.startScenario(ACSClientEvent.RegisterOnNewMessage);
 
         let isReceivingNotifications = false;
@@ -174,19 +173,14 @@ export class ACSConversation {
 
         try {
             const pollForMessages = async (delay: number) => {
-                console.log("ADAD pollForMessages");
                 if (isReceivingNotifications) {
                     return;
                 }
 
                 try {
                     const messages = await this.getMessages();
-                    console.log("ADAD messages", messages);
                     for (const message of messages.reverse()) {
-                        console.log("ADAD message", message);
                         const {id, sender} = message;
-                        console.log("ADAD id", id);
-                        console.log("ADAD sender", sender);
                         const customerMessageCondition = sender.displayName === ACSParticipantDisplayName.Customer;
 
                         // Filter out customer messages
@@ -213,12 +207,9 @@ export class ACSConversation {
             await pollForMessages(this.sessionInfo?.pollingInterval as number);
 
             const listener = (event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
-                console.log("ADAD listener event", event);
                 isReceivingNotifications = true;
 
                 const {id, version, sender} = event;
-                console.log("ADAD id", id);
-                console.log("ADAD sender", sender);
 
                 const customerMessageCondition = ((sender as CommunicationUserIdentifier).communicationUserId === (this.sessionInfo?.id as string))
 
@@ -227,14 +218,11 @@ export class ACSConversation {
                     return;
                 }
 
-                console.log("ADAD postedMessageIds", postedMessageIds);
-
                 // Filter out duplicate messages
                 if (postedMessageIds.has(id) && postedMessageIds.has(version)) {
                     return;
                 }
 
-                console.log("ADAD event.message", event.message);
                 if (event.message) {
                     Object.assign(event, {content: event.message});
                 }

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -17,8 +17,6 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
 
     if (optionalParams.liveChatVersion === LiveChatVersion.V2) {
         const {id, content, metadata, sender, senderDisplayName, createdOn, editedOn} = message as any;  // eslint-disable-line  @typescript-eslint/no-explicit-any
-        console.log("ADAD createdOn", createdOn);
-        console.log("ADAD editedOn", editedOn);
 
         omnichannelMessage.id = id;
         omnichannelMessage.messageid = undefined;

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from "@azure/communication-chat";
+import { ChatMessage, ChatMessageEditedEvent } from "@azure/communication-chat";
 import { ChatMessageReceivedEvent } from '@azure/communication-signaling';
 import IRawMessage from "@microsoft/omnichannel-ic3core/lib/model/IRawMessage";
 import LiveChatVersion from '../core/LiveChatVersion';
@@ -9,14 +9,16 @@ interface CreateOmnichannelMessageOptionalParams {
     debug?: boolean;
 }
 
-const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEvent | ChatMessage, optionalParams: CreateOmnichannelMessageOptionalParams): OmnichannelMessage => {
+const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEvent | ChatMessageEditedEvent | ChatMessage, optionalParams: CreateOmnichannelMessageOptionalParams): OmnichannelMessage => {
     let omnichannelMessage = {} as OmnichannelMessage;
     omnichannelMessage.liveChatVersion = optionalParams.liveChatVersion || LiveChatVersion.V1;
 
     optionalParams.debug && console.log(message);
 
     if (optionalParams.liveChatVersion === LiveChatVersion.V2) {
-        const {id, content, metadata, sender, senderDisplayName, createdOn} = message as any;  // eslint-disable-line  @typescript-eslint/no-explicit-any
+        const {id, content, metadata, sender, senderDisplayName, createdOn, editedOn} = message as any;  // eslint-disable-line  @typescript-eslint/no-explicit-any
+        console.log("ADAD createdOn", createdOn);
+        console.log("ADAD editedOn", editedOn);
 
         omnichannelMessage.id = id;
         omnichannelMessage.messageid = undefined;
@@ -27,7 +29,7 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
         omnichannelMessage.content = content || '';
         omnichannelMessage.properties.tags = metadata && metadata.tags? metadata.tags : [];
         omnichannelMessage.tags = metadata && metadata.tags? metadata.tags.replace(/\"/g, "").split(",").filter((tag: string) => tag.length > 0): [];   // eslint-disable-line no-useless-escape
-        omnichannelMessage.timestamp = createdOn;
+        omnichannelMessage.timestamp = editedOn ?? createdOn;
         omnichannelMessage.messageType = MessageType.UserMessage; // Backward compatibility
         omnichannelMessage.sender = {
             id: sender.communicationUserId,

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -1,5 +1,5 @@
-import { ChatMessage, ChatMessageEditedEvent } from "@azure/communication-chat";
-import { ChatMessageReceivedEvent } from '@azure/communication-signaling';
+import { ChatMessage } from "@azure/communication-chat";
+import { ChatMessageReceivedEvent, ChatMessageEditedEvent } from '@azure/communication-signaling';
 import IRawMessage from "@microsoft/omnichannel-ic3core/lib/model/IRawMessage";
 import LiveChatVersion from '../core/LiveChatVersion';
 import OmnichannelMessage, { IFileMetadata, IPerson, MessageType, PersonType } from "../core/messaging/OmnichannelMessage";


### PR DESCRIPTION
**Problem:**
`chat.onNewMessage()` was not recognizing queue position message edits. Investigations traced root cause to queue position message edits coming in as `chatMessageEdited` event type, not `chatMessageReceived`.

**Solution:**
Add a `chatMessageEdited` listener to listen to those queue position message edit events. `chatMessageEdited` events contain this `editedOn` property. For this edited message, `createdOn` timestamp will be updated with `editedOn` timestamp. 

Video demo: https://microsoft-my.sharepoint.com/:v:/p/kevinlin/EZsNY7oI5QRGqlacnUVDbo8BlT8Sy2pQ5CRqq-tdTWOeSw?e=PtIX9k

<img width="872" alt="image" src="https://github.com/microsoft/omnichannel-chat-sdk/assets/13504205/27c28ca1-e0ca-41c8-8c30-2b2c741c453c">
<img width="854" alt="image" src="https://github.com/microsoft/omnichannel-chat-sdk/assets/13504205/483f6519-b9e7-4cca-a15b-8c6f93a7eed9">
<img width="865" alt="image" src="https://github.com/microsoft/omnichannel-chat-sdk/assets/13504205/f890e0fb-e3da-414e-9790-c1c98b31baed">
