### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Read package.json
         id: read-package-json
         run: |
-          echo "::set-output name=name::$(cat package.json | jq -r '.name')"
-          echo "::set-output name=version::$(cat package.json | jq -r '.version')"
+          echo "name=$(cat package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
 
       - name: Install packages
         run: npm install
@@ -59,10 +59,10 @@ jobs:
       - name: Read package.json
         id: read-package-json
         run: |
-          echo "::set-output name=name::$(tar xOf *.tgz package/package.json | jq -r '.name')"
-          echo "::set-output name=version::$(tar xOf *.tgz package/package.json | jq -r '.version')"
-          echo "::set-output name=tarball::$(ls *.tgz)"
-          echo "::set-output name=date::$(date +%Y-%m-%d)"
+          echo "name=$(tar xOf *.tgz package/package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(tar xOf *.tgz package/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "tarball=$(ls *.tgz)" >> $GITHUB_OUTPUT
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Run npm publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


