### PR TITLE
Reduce Config Calls on Escalation to Voice & Video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 ## [Unreleased]
+### Changed
+- Reduce number of `config` calls on loading `Escalation to Voice & Video` library by retrieving the config from runtime cache
 
 ## [1.6.2] - 2023-12-12
 ### Fixed

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1593,7 +1593,7 @@ class OmnichannelChatSDK {
             exceptionThrowers.throwFeatureDisabled(this.scenarioMarker, TelemetryEvent.GetVoiceVideoCalling, message);
         }
 
-        const chatConfig = await this.getChatConfig();
+        const chatConfig = await this.getLiveChatConfig();
         const { LiveWSAndLiveChatEngJoin: liveWSAndLiveChatEngJoin } = chatConfig;
         const { msdyn_widgetsnippet } = liveWSAndLiveChatEngJoin;
 


### PR DESCRIPTION
- Changes to retrieve config from runtime cache instead since it already exists instead of making additional HTTP call