### PR TITLE
Authenticated Chat Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 ## [Unreleased]
+### Changed
+- Throw exception when `ChatSDK.startChat()` fails with `ChatSDKConfig.getAuthToken()` failures
 
 ## [1.6.3] - 2024-01-30
 ### Changed

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -727,7 +727,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(exceptionDetails.response).toBe(expectedResponse);
         });
 
-        it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should throw \'UndefinedAuthToken\' error on ChatSDK.startChat() if we failed to retrieve auth token', async () => {
+        it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should throw \'UndefinedAuthToken\' error on ChatSDK.startChat() if auth token is undefined', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.authSettings = {};
@@ -757,7 +757,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(exceptionDetails.response).toBe(expectedResponse);
         });
 
-        it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should throw \'GetAuthTokenFailed\' error on ChatSDK.startChat() if auth token is undefined', async () => {
+        it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should throw \'GetAuthTokenFailed\' error on ChatSDK.startChat() if we failed to retrieve auth token', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.authSettings = {};

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -615,7 +615,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(1);
         });
 
-        it('Authenticated Chat without chatSDKConfig.getAuthToken() set should fail silently with \'GetAuthTokenNotFound\'', async () => {
+        it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should not be called', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
 
             chatSDK.OCClient = {};
@@ -630,16 +630,10 @@ describe('Omnichannel Chat SDK', () => {
             }));
 
             jest.spyOn(chatSDK, 'setAuthTokenProvider');
-            jest.spyOn(chatSDK.scenarioMarker, 'failScenario');
             await chatSDK.getChatConfig();
 
-            const expectedResponse = 'GetAuthTokenNotFound';
-            const exceptionDetails = JSON.parse(chatSDK.scenarioMarker.failScenario.mock.calls[0][1].ExceptionDetails);
-
             expect(chatSDK.OCClient.getChatConfig).toHaveBeenCalledTimes(1);
-            expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(1);
-            expect(chatSDK.scenarioMarker.failScenario).toHaveBeenCalledTimes(1);
-            expect(exceptionDetails.response).toBe(expectedResponse);
+            expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(0);
         });
 
         it('Authenticated Chat with liveChatContext should call OCClient.validateAuthChatRecord()', async () => {

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -648,6 +648,39 @@ describe('Omnichannel Chat SDK', () => {
             expect(exceptionDetails.response).toBe(expectedResponse);
         });
 
+        it('Authenticated Chat without chatSDKConfig.getAuthToken() set should fail silently with \'GetAuthTokenFailed\'', async () => {
+            const chatSDKConfig = {
+                getAuthToken: async () => {
+                    throw Error("Operation Failed")
+                }
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+
+            chatSDK.OCClient = {};
+            chatSDK.OCClient.getChatConfig = jest.fn(() => Promise.resolve({
+                DataMaskingInfo: { setting: { msdyn_maskforcustomer: false } },
+                LiveWSAndLiveChatEngJoin: { PreChatSurvey: { msdyn_prechatenabled: false } },
+                LiveChatConfigAuthSettings: {},
+                ChatWidgetLanguage: {
+                    msdyn_localeid: '1033',
+                    msdyn_languagename: 'English - United States'
+                }
+            }));
+
+            jest.spyOn(chatSDK, 'setAuthTokenProvider');
+            jest.spyOn(chatSDK.scenarioMarker, 'failScenario');
+            await chatSDK.getChatConfig();
+
+            const expectedResponse = 'GetAuthTokenFailed';
+            const exceptionDetails = JSON.parse(chatSDK.scenarioMarker.failScenario.mock.calls[0][1].ExceptionDetails);
+
+            expect(chatSDK.OCClient.getChatConfig).toHaveBeenCalledTimes(1);
+            expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(1);
+            expect(chatSDK.scenarioMarker.failScenario).toHaveBeenCalledTimes(1);
+            expect(exceptionDetails.response).toBe(expectedResponse);
+        });
+
         it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should not be called', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -615,6 +615,39 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(1);
         });
 
+        it('Authenticated Chat without chatSDKConfig.getAuthToken() set should fail silently with \'UndefinedAuthToken\'', async () => {
+            const chatSDKConfig = {
+                getAuthToken: async () => {
+                    return undefined
+                }
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+
+            chatSDK.OCClient = {};
+            chatSDK.OCClient.getChatConfig = jest.fn(() => Promise.resolve({
+                DataMaskingInfo: { setting: { msdyn_maskforcustomer: false } },
+                LiveWSAndLiveChatEngJoin: { PreChatSurvey: { msdyn_prechatenabled: false } },
+                LiveChatConfigAuthSettings: {},
+                ChatWidgetLanguage: {
+                    msdyn_localeid: '1033',
+                    msdyn_languagename: 'English - United States'
+                }
+            }));
+
+            jest.spyOn(chatSDK, 'setAuthTokenProvider');
+            jest.spyOn(chatSDK.scenarioMarker, 'failScenario');
+            await chatSDK.getChatConfig();
+
+            const expectedResponse = 'UndefinedAuthToken';
+            const exceptionDetails = JSON.parse(chatSDK.scenarioMarker.failScenario.mock.calls[0][1].ExceptionDetails);
+
+            expect(chatSDK.OCClient.getChatConfig).toHaveBeenCalledTimes(1);
+            expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(1);
+            expect(chatSDK.scenarioMarker.failScenario).toHaveBeenCalledTimes(1);
+            expect(exceptionDetails.response).toBe(expectedResponse);
+        });
+
         it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should not be called', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -615,7 +615,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(1);
         });
 
-        it('Authenticated Chat without chatSDKConfig.getAuthToken() set should fail silently with \'UndefinedAuthToken\'', async () => {
+        it('Authenticated Chat with chatSDKConfig.getAuthToken() returning \'undefined\' as token should fail silently with \'UndefinedAuthToken\'', async () => {
             const chatSDKConfig = {
                 getAuthToken: async () => {
                     return undefined
@@ -648,7 +648,7 @@ describe('Omnichannel Chat SDK', () => {
             expect(exceptionDetails.response).toBe(expectedResponse);
         });
 
-        it('Authenticated Chat without chatSDKConfig.getAuthToken() set should fail silently with \'GetAuthTokenFailed\'', async () => {
+        it('Authenticated Chat with chatSDKConfig.getAuthToken() failing should fail silently with \'GetAuthTokenFailed\'', async () => {
             const chatSDKConfig = {
                 getAuthToken: async () => {
                     throw Error("Operation Failed")

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -702,6 +702,31 @@ describe('Omnichannel Chat SDK', () => {
             expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(0);
         });
 
+        it('Authenticated Chat without chatSDKConfig.getAuthToken() initially set should throw \'GetAuthTokenNotFound\' error on ChatSDK.startChat()', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.authSettings = {};
+
+            await chatSDK.initialize();
+
+            jest.spyOn(chatSDK, 'setAuthTokenProvider');
+            jest.spyOn(chatSDK.scenarioMarker, 'failScenario');
+
+            const expectedResponse = 'GetAuthTokenNotFound';
+
+            try {
+                await chatSDK.startChat();
+            } catch (e) {
+                expect(e.message).toBe(expectedResponse);
+            }
+
+            const exceptionDetails = JSON.parse(chatSDK.scenarioMarker.failScenario.mock.calls[0][1].ExceptionDetails);
+
+            expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(1);
+            expect(chatSDK.scenarioMarker.failScenario).toHaveBeenCalledTimes(1);
+            expect(exceptionDetails.response).toBe(expectedResponse);
+        });
+
         it('Authenticated Chat with liveChatContext should call OCClient.validateAuthChatRecord()', async () => {
             const chatSDKConfig = {
                 getAuthToken: async () => {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1973,7 +1973,7 @@ class OmnichannelChatSDK {
             this.preChatSurvey = preChatSurvey;
         }
 
-        if (this.authSettings) {
+        if (this.authSettings && this.chatSDKConfig.getAuthToken) {
             await this.setAuthTokenProvider(this.chatSDKConfig.getAuthToken);
         }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2054,10 +2054,14 @@ class OmnichannelChatSDK {
                         throw Error(exceptionDetails.response);
                     }
                 }
-            } catch {
+            } catch (error) {
                 const exceptionDetails = {
                     response: "GetAuthTokenFailed"
                 };
+
+                if ((error as Error).message == "UndefinedAuthToken") {
+                    exceptionDetails.response = (error as Error).message;
+                }
 
                 this.scenarioMarker.failScenario(TelemetryEvent.GetAuthToken, {
                     ExceptionDetails: JSON.stringify(exceptionDetails)

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -76,6 +76,7 @@ import PluggableLogger from "@microsoft/omnichannel-amsclient/lib/PluggableLogge
 import PostChatContext from "./core/PostChatContext";
 import ProtocolType from "@microsoft/omnichannel-ic3core/lib/interfaces/ProtocoleType";
 import ScenarioMarker from "./telemetry/ScenarioMarker";
+import SetAuthTokenProviderOptionalParams from "./core/SetAuthTokenProviderOptionalParams";
 import StartChatOptionalParams from "./core/StartChatOptionalParams";
 import TelemetryEvent from "./telemetry/TelemetryEvent";
 import createAMSClient from "@microsoft/omnichannel-amsclient";
@@ -459,7 +460,7 @@ class OmnichannelChatSDK {
 
         if (this.authSettings) {
             if (!this.authenticatedUserToken) {
-                await this.setAuthTokenProvider(this.chatSDKConfig.getAuthToken);
+                await this.setAuthTokenProvider(this.chatSDKConfig.getAuthToken, {throwError: true});
             }
 
             if (optionalParams.liveChatContext && Object.keys(optionalParams.liveChatContext).length > 0) {
@@ -1974,7 +1975,7 @@ class OmnichannelChatSDK {
         }
 
         if (this.authSettings && this.chatSDKConfig.getAuthToken) {
-            await this.setAuthTokenProvider(this.chatSDKConfig.getAuthToken);
+            await this.setAuthTokenProvider(this.chatSDKConfig.getAuthToken, {throwError: false}); // throwError set to 'false` for backward compatibility
         }
 
         if (this.preChatSurvey) {
@@ -2029,7 +2030,7 @@ class OmnichannelChatSDK {
         }
     }
 
-    private async setAuthTokenProvider(provider: ChatSDKConfig["getAuthToken"]) {
+    private async setAuthTokenProvider(provider: ChatSDKConfig["getAuthToken"], optionalParams: SetAuthTokenProviderOptionalParams = {}) {
         this.scenarioMarker.startScenario(TelemetryEvent.GetAuthToken);
 
         this.chatSDKConfig.getAuthToken = provider;
@@ -2048,6 +2049,10 @@ class OmnichannelChatSDK {
                     this.scenarioMarker.failScenario(TelemetryEvent.GetAuthToken, {
                         ExceptionDetails: JSON.stringify(exceptionDetails)
                     });
+
+                    if (optionalParams?.throwError) {
+                        throw Error(exceptionDetails.response);
+                    }
                 }
             } catch {
                 const exceptionDetails = {
@@ -2057,6 +2062,10 @@ class OmnichannelChatSDK {
                 this.scenarioMarker.failScenario(TelemetryEvent.GetAuthToken, {
                     ExceptionDetails: JSON.stringify(exceptionDetails)
                 });
+
+                if (optionalParams?.throwError) {
+                    throw Error(exceptionDetails.response);
+                }
             }
         } else {
             const exceptionDetails = {
@@ -2066,6 +2075,10 @@ class OmnichannelChatSDK {
             this.scenarioMarker.failScenario(TelemetryEvent.GetAuthToken, {
                 ExceptionDetails: JSON.stringify(exceptionDetails)
             });
+
+            if (optionalParams?.throwError) {
+                throw Error(exceptionDetails.response);
+            }
         }
     }
 }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2043,7 +2043,7 @@ class OmnichannelChatSDK {
                     this.scenarioMarker.completeScenario(TelemetryEvent.GetAuthToken);
                 } else {
                     const exceptionDetails = {
-                        response: "UndefinedAuthToken"
+                        response: ChatSDKErrorName.UndefinedAuthToken
                     };
 
                     if (optionalParams?.throwError) {
@@ -2057,10 +2057,10 @@ class OmnichannelChatSDK {
                 }
             } catch (error) {
                 const exceptionDetails = {
-                    response: "GetAuthTokenFailed"
+                    response: ChatSDKErrorName.GetAuthTokenFailed as string
                 };
 
-                if ((error as Error).message == "UndefinedAuthToken") {
+                if ((error as Error).message == ChatSDKErrorName.UndefinedAuthToken) {
                     exceptionDetails.response = (error as Error).message;
                 }
 
@@ -2074,7 +2074,7 @@ class OmnichannelChatSDK {
             }
         } else {
             const exceptionDetails = {
-                response: "GetAuthTokenNotFound"
+                response: ChatSDKErrorName.GetAuthTokenNotFound
             };
 
             this.scenarioMarker.failScenario(TelemetryEvent.GetAuthToken, {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2046,13 +2046,14 @@ class OmnichannelChatSDK {
                         response: "UndefinedAuthToken"
                     };
 
-                    this.scenarioMarker.failScenario(TelemetryEvent.GetAuthToken, {
-                        ExceptionDetails: JSON.stringify(exceptionDetails)
-                    });
-
                     if (optionalParams?.throwError) {
                         throw Error(exceptionDetails.response);
                     }
+
+                    // Fail scenario only if error is not thrown then bubbled up
+                    this.scenarioMarker.failScenario(TelemetryEvent.GetAuthToken, {
+                        ExceptionDetails: JSON.stringify(exceptionDetails)
+                    });
                 }
             } catch (error) {
                 const exceptionDetails = {

--- a/src/core/ChatSDKError.ts
+++ b/src/core/ChatSDKError.ts
@@ -47,7 +47,13 @@ export enum ChatSDKErrorName {
     /** Failure on retrieving conversation details */
     ConversationDetailsRetrievalFailure = "ConversationDetailsRetrievalFailure",
     /** Failure on finding the contact id related to the auth code */
-    AuthContactIdNotFoundFailure = "AuthContactIdNotFoundFailure"
+    AuthContactIdNotFoundFailure = "AuthContactIdNotFoundFailure",
+    /** AuthTokenProvider is not implemented */
+    GetAuthTokenNotFound = "GetAuthTokenNotFound",
+    /** Failure on retrieving AuthToken from AuthTokenProvider */
+    GetAuthTokenFailed = "GetAuthTokenFailed",
+    /** AuthToken is undefined */
+    UndefinedAuthToken = "UndefinedAuthToken"
 }
 
 export class ChatSDKError {

--- a/src/core/SetAuthTokenProviderOptionalParams.ts
+++ b/src/core/SetAuthTokenProviderOptionalParams.ts
@@ -1,3 +1,3 @@
 export default interface SetAuthTokenProviderOptionalParams {
     throwError?: boolean
-};
+}

--- a/src/core/SetAuthTokenProviderOptionalParams.ts
+++ b/src/core/SetAuthTokenProviderOptionalParams.ts
@@ -1,0 +1,3 @@
+export default interface SetAuthTokenProviderOptionalParams {
+    throwError?: boolean
+};


### PR DESCRIPTION
- Update `ChatSDKConfig.getAuthToken` to be optional
- Throw exceptions on `ChatSDK.startChat()` if `ChatSDKConfig.getAuthToken()` fails