### PR TITLE
`sessionId` Lifecycle Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Add ability to use `ChatSDK.emailLiveChatTranscript()` to email live chat transcript from `liveChatContext`
+- Handling the lifecycle of `sessionId` if it exists
 
 ### Changed
 - Throw exception when `ChatSDK.startChat()` fails with `ChatSDKConfig.getAuthToken()` failures
+- Uptake [@microsoft/ocsdk@0.4.3](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.3)
 
 ## [1.6.3] - 2024-01-30
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@azure/communication-chat": "1.1.1",
         "@azure/communication-common": "1.1.0",
-        "@microsoft/ocsdk": "^0.4.2",
+        "@microsoft/ocsdk": "^0.4.3",
         "@microsoft/omnichannel-amsclient": "^0.1.6",
         "@microsoft/omnichannel-ic3core": "^0.1.3"
       },
@@ -1574,9 +1574,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.2.tgz",
-      "integrity": "sha512-x2cMpdkKB5psuS6ChE6w9R7TygSeJwXJBJTo8iGD0BEo03JbV85hHJUL7xaV2oBHAvCpwl5CcWUQez1ZnE/3mQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.3.tgz",
+      "integrity": "sha512-5SqZND6Llo+OkdqDBOcs3E0zsLz2XC9WpEwTvqIFLypMoFaI++VCPfuMzTZp30UJRivcHXEuF8ulxn/7TJRF+g==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",
@@ -7407,9 +7407,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.2.tgz",
-      "integrity": "sha512-x2cMpdkKB5psuS6ChE6w9R7TygSeJwXJBJTo8iGD0BEo03JbV85hHJUL7xaV2oBHAvCpwl5CcWUQez1ZnE/3mQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.3.tgz",
+      "integrity": "sha512-5SqZND6Llo+OkdqDBOcs3E0zsLz2XC9WpEwTvqIFLypMoFaI++VCPfuMzTZp30UJRivcHXEuF8ulxn/7TJRF+g==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@azure/communication-chat": "1.1.1",
     "@azure/communication-common": "1.1.0",
-    "@microsoft/ocsdk": "^0.4.2",
+    "@microsoft/ocsdk": "^0.4.3",
     "@microsoft/omnichannel-amsclient": "^0.1.6",
     "@microsoft/omnichannel-ic3core": "^0.1.3"
   }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -748,6 +748,10 @@ class OmnichannelChatSDK {
             chatSession.reconnectId = this.reconnectId;
         }
 
+        if (this.sessionId) {
+            chatSession.sessionId = this.sessionId;
+        }
+
         this.scenarioMarker.completeScenario(TelemetryEvent.GetCurrentLiveChatContext, {
             RequestId: requestId,
             ChatId: chatToken.chatId as string

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -437,6 +437,7 @@ class OmnichannelChatSDK {
         if (optionalParams.liveChatContext && Object.keys(optionalParams.liveChatContext).length > 0 && !this.reconnectId) {
             this.chatToken = optionalParams.liveChatContext.chatToken || {};
             this.requestId = optionalParams.liveChatContext.requestId || uuidv4();
+            this.sessionId = optionalParams.liveChatContext.sessionId || null;
 
             // Validate conversation
             const conversationDetails = await this.getConversationDetails();

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -108,6 +108,7 @@ class OmnichannelChatSDK {
     public isInitialized: boolean;
     public localeId: string;
     public requestId: string;
+    public sessionId: string | null = null;
     private chatToken: IChatToken;
     private liveChatConfig: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     private liveChatVersion: number;
@@ -890,6 +891,10 @@ class OmnichannelChatSDK {
 
                 if (attachmentConfiguration && attachmentConfiguration.AttachmentServiceEndpoint) {
                     this.chatToken.amsEndpoint = attachmentConfiguration.AttachmentServiceEndpoint;
+                }
+
+                if (this.OCClient.sessionId) {
+                    this.sessionId = this.OCClient.sessionId;
                 }
 
                 this.scenarioMarker.completeScenario(TelemetryEvent.GetChatToken, {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -766,6 +766,7 @@ class OmnichannelChatSDK {
         let chatToken = this.chatToken;
         let chatId = chatToken.chatId as string;
         let reconnectId = this.reconnectId;
+        let sessionId = this.sessionId;
 
         if (optionalParams.liveChatContext) {
             requestId = optionalParams.liveChatContext.requestId;
@@ -775,6 +776,11 @@ class OmnichannelChatSDK {
 
         if (optionalParams.liveChatContext?.reconnectId) {
             reconnectId = optionalParams.liveChatContext.reconnectId;
+        }
+
+        if (optionalParams.liveChatContext?.sessionId) {
+            sessionId = optionalParams.liveChatContext.sessionId;
+            this.OCClient.sessionId = sessionId;
         }
 
         this.scenarioMarker.startScenario(TelemetryEvent.GetConversationDetails, {
@@ -815,6 +821,10 @@ class OmnichannelChatSDK {
 
             if (participantType) {
                 liveWorkItemDetails.participantType = participantType;
+            }
+
+            if (sessionId) {
+                this.OCClient.sessionId = sessionId;
             }
 
             this.scenarioMarker.completeScenario(TelemetryEvent.GetConversationDetails, {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -823,8 +823,8 @@ class OmnichannelChatSDK {
                 liveWorkItemDetails.participantType = participantType;
             }
 
-            if (sessionId) {
-                this.OCClient.sessionId = sessionId;
+            if (this.sessionId) {
+                this.OCClient.sessionId = this.sessionId;
             }
 
             this.scenarioMarker.completeScenario(TelemetryEvent.GetConversationDetails, {
@@ -1500,11 +1500,17 @@ class OmnichannelChatSDK {
         let requestId = this.requestId;
         let chatToken = this.chatToken;
         let chatId = chatToken.chatId as string;
+        let sessionId = this.sessionId;
 
         if (optionalParams.liveChatContext) {
             requestId = optionalParams.liveChatContext.requestId;
             chatToken = optionalParams.liveChatContext.chatToken;
             chatId = chatToken.chatId as string;
+        }
+
+        if (optionalParams.liveChatContext?.sessionId) {
+            sessionId = optionalParams.liveChatContext.sessionId;
+            this.OCClient.sessionId = sessionId;
         }
 
         this.scenarioMarker.startScenario(TelemetryEvent.EmailLiveChatTranscript, {
@@ -1529,6 +1535,10 @@ class OmnichannelChatSDK {
                 chatToken.token,
                 emailRequestBody,
                 emailTranscriptOptionalParams);
+
+            if (this.sessionId) {
+                this.OCClient.sessionId = this.sessionId;
+            }
 
             this.scenarioMarker.completeScenario(TelemetryEvent.EmailLiveChatTranscript, {
                 RequestId: requestId,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -689,6 +689,11 @@ class OmnichannelChatSDK {
                 this.IC3Client = null;
             }
 
+            if (this.OCClient.sessionId) {
+                this.OCClient.sessionId = null;
+                this.sessionId = null;
+            }
+
             this.ic3ClientLogger?.setRequestId(this.requestId);
             this.ic3ClientLogger?.setChatId('');
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1561,11 +1561,17 @@ class OmnichannelChatSDK {
         let requestId = this.requestId;
         let chatToken = this.chatToken;
         let chatId = chatToken.chatId as string;
+        let sessionId = this.sessionId;
 
         if (optionalParams.liveChatContext) {
             requestId = optionalParams.liveChatContext.requestId;
             chatToken = optionalParams.liveChatContext.chatToken;
             chatId = chatToken.chatId as string;
+        }
+
+        if (optionalParams.liveChatContext?.sessionId) {
+            sessionId = optionalParams.liveChatContext.sessionId;
+            this.OCClient.sessionId = sessionId;
         }
 
         this.scenarioMarker.startScenario(TelemetryEvent.GetLiveChatTranscript, {
@@ -1583,6 +1589,10 @@ class OmnichannelChatSDK {
                 chatToken.chatId,
                 chatToken.token,
                 getChatTranscriptOptionalParams);
+
+            if (this.sessionId) {
+                this.OCClient.sessionId = this.sessionId;
+            }
 
             this.scenarioMarker.completeScenario(TelemetryEvent.GetLiveChatTranscript, {
                 RequestId: requestId,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -224,6 +224,7 @@ class OmnichannelChatSDK {
             getChatTokenRetryCount: 2,
             getChatTokenTimeBetweenRetriesOnFailure: 2000,
             getChatTokenRetryOn429: false,
+            useUnauthReconnectIdSigQueryParam: false
         };
 
         try {

--- a/src/core/ChatSDKConfig.ts
+++ b/src/core/ChatSDKConfig.ts
@@ -19,6 +19,7 @@ interface PersistentChatConfig {
 
 interface ChatReconnectConfig {
     disable: boolean;
+    useUnauthReconnectIdSigQueryParam?: boolean;
 }
 
 interface ChatSDKConfig {

--- a/src/core/ChatSDKConfig.ts
+++ b/src/core/ChatSDKConfig.ts
@@ -19,7 +19,6 @@ interface PersistentChatConfig {
 
 interface ChatReconnectConfig {
     disable: boolean;
-    useUnauthReconnectIdSigQueryParam?: boolean;
 }
 
 interface ChatSDKConfig {

--- a/src/core/LiveChatContext.ts
+++ b/src/core/LiveChatContext.ts
@@ -10,5 +10,6 @@ import IChatToken from "../external/IC3Adapter/IChatToken";
 export default interface LiveChatContext {
     chatToken: IChatToken,
     requestId: string,
-    reconnectId?: string
+    reconnectId?: string,
+    sessionId?: string
 }


### PR DESCRIPTION
- Handle lifecycle of `sessionId` to improve the security of unauth endpoints 
  - Retrieving `sessionId` if exits after `getchattoken` call
  - Clearing `sessionId` if exists after `sessionclose` call
  - Returns `sessionId` as part of `liveChatContext` if exists
  - Reassigning `sessionId` on methods which using `liveChatContext`
    - `ChatSDK.getConversationDetails()`
    - `ChatSDK.getLiveChatTranscript()`
    - `ChatSDK.emailLiveChatTranscript()`