### PR TITLE
adding handle of missing conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,134 +1,190 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
+
 ## [Unreleased]
 
+## Changed
+
+- Fix ChatSDK.getPostConversationContext() to reject promise when conversation is not found
+
 ## [1.7.0] - 2024-03-07
+
 ### Added
+
 - Add ability to use `ChatSDK.emailLiveChatTranscript()` to email live chat transcript from `liveChatContext`
 - Handling the lifecycle of `sessionId` if it exists
 
 ### Changed
+
 - Throw exception when `ChatSDK.startChat()` fails with `ChatSDKConfig.getAuthToken()` failures
 - Uptake [@microsoft/ocsdk@0.4.3](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.3)
 
 ## [1.6.3] - 2024-01-30
+
 ### Changed
+
 - Reduce number of `config` calls on loading `Escalation to Voice & Video` library by retrieving the config from runtime cache
 
 ## [1.6.2] - 2023-12-12
+
 ### Fixed
+
 - Add `supportedImagesMimeTypes` to support `MIME` types `image/heic` & `image/webp` as images
 
 ## [1.6.1] - 2023-12-07
+
 ### Added
+
 - Exported `ChatSDKErrorName` and `ChatSDKError` for downstream component to use
 
 ### Fixed
+
 - Subscribe to `chatMessageEdited` events within `onNewMessage()` for queue position message updates
 
 ### Changed
+
 - Uptake [@microsoft/ocsdk@0.4.2](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.2)
 
 ## [1.6.0] - 2023-12-04
+
 ### Changed
+
 - Added "httpResponseStatusCode" attribute in the error object thrown
 
 ## [1.5.7] - 2023-11-20
+
 ### Changed
+
 - Uptake [@microsoft/omnichannel-amsclient@0.1.6](https://www.npmjs.com/package/@microsoft/omnichannel-amsclient/v/0.1.6)
 
 ## [1.5.6] - 2023-11-13
+
 ### Added
+
 - Add `RequestPayload`, `RequestPath`, `RequestMethod`, `ResponseStatusCode` telemetry base property to `OCSDKContract`
 - Update Jest configuration and tests to support new libraries
 
 ### Security
+
 - Uptake [@microsoft/omnichannel-ic3core@0.1.3](https://www.npmjs.com/package/@microsoft/omnichannel-ic3core/v/0.1.3)
 - Uptake [@microsoft/ocsdk@0.4.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.1)
 
 ### Changed
+
 - Use `parseLowerCaseString()` on chat config properties to protect text case change
 
 ## [1.5.5] - 2023-10-31
+
 ### Added
+
 - Add ability to pass custom `ariaCollectorUri`
 
 ### Fixed
+
 - Add missing `PACS` URL for `EUDomainNames`
 - Fixed an issue where startChat failed due to optionalParam being null
 
 ## [1.5.4] - 2023-10-20
+
 ### Fixed
+
 - Fix `AriaTelemetry._configuration` not being passed to `AriaTelemetry._logger`
 
 ## [1.5.3] - 2023-10-18
+
 ### Fixed
+
 - Fix `ChatSDK.emailLiveChatTranscript()` calling `OCClient.emailTranscript()` without waiting until its completion
 - Fix `EU` orgs telemetry to flow to the proper `EU` location
 
 ## [1.5.2] - 2023-10-14
+
 ### Changed
+
 - Disable `tokenRefresher` temporarily
 
 ## [1.5.1] - 2023-10-11
+
 ### Fixed
+
 - Modify `getChatReconnectContext` to return redirection URL when reconnection ID is not longer Valid for Auth Chats.
 
 ## [1.5.0] - 2023-09-29
+
 ### Added
+
 - Add `Attachment File Scan` to `ChatSDK.createChatAdapter()`
 
 ## [1.4.7] - 2023-09-13
+
 ### Changed
+
 - Supporting getAgentAvailable SDK method for unauthenticated chat widget
 
 ## [1.4.6] - 2023-08-15
+
 ### Fixed
+
 - Fix `tokenRefresher` to update `chatToken` properly on expiry through reinitialization of AMSClient
 
 ## [1.4.5] - 2023-08-02
+
 ### Changed
+
 - Upgraded ACSAdapter to version beta.20
 
 ## [1.4.4] - 2023-07-19
+
 ### Added
+
 - Add `tokenRefresher` mechanism to retrieve chat token on expiry
 
 ### Changed
+
 - Add `ocSDKConfiguration` to reduce `chatToken` retries to 2
 - Uptake [@microsoft/ocsdk@0.4.0](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.0)
 - Remove redundant call to create of `participantsMapping`
 
 ### Fixed
+
 - Set `enableSenderDisplayNameInTypingNotification` to true to include display name on sending typing notification
 - Add `async` to `ChatSDK.getLiveChatTranscript()` internal call
 
 ## [1.4.3] - 2023-06-15
+
 ### Fixed
 
 - [Perf] Make sessionInit, AcsClientInit/Ic3ClientInit and AmsClientInit calls in parallel
 
 ## [1.4.2] - 2023-05-19
+
 ### Fixed
 
 - Fixed null check on startChat failure
 
 ## [1.4.1] - 2023-05-05
+
 ### Fixed
 
 - Skipped empty string or null context variables (parity with v1)
 
 ## [1.4.0] - 2023-05-02
+
 ### Added
+
 - Add ability to use `ChatSDK.getLiveChatTranscript()` to fetch live chat transcript from `liveChatContext`
 - Add ability to use `ChatSDK.getConversationDetails()` to fetch conversation details from `liveChatContext`
 - Add `AuthContactIdNotFoundFailure` to `ExceptionThrower`
 
 ### Changed
+
 - Update `ChatSDKErrors` to include standard ChatSDK errors to be more predictable
 
 ## [1.3.0] - 2023-04-05
+
 ### Added
+
 - Add ability to use `ChatSDK.createChatAdapter()` for `DirectLine` protocol
 - Add `CreateACSAdapter` telemetry event
 - Improve `ChatSDK.createChatAdapter()` with retries using exponential backoff & additional details on failures
@@ -140,17 +196,21 @@ All notable changes to this project will be documented in this file.
 - Added `botSurveyInviteLink` and `botFormsProLocale` the `getPostChatSurveyContext()` response
 
 ### Fixed
+
 - Fix `ChatAdapterOptionalParams.ACSAdapter.options.egressMiddleware` being used as `ingressMiddleware`
 - Fix `ChatSDK.onTypingEvent()` being triggered on current user typing
 - Update `ChatSDK.liveChatVersion` to be `V2` by default
 
 ### Changed
+
 - Uptake [@microsoft/omnichannel-amsclient@0.1.4](https://www.npmjs.com/package/@microsoft/omnichannel-amsclient/v/0.1.4)
 - Uptake [acs_webchat-chat-adapter@0.0.35-beta.17](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.17/dist/chat-adapter.js)
 - Uptake [@microsoft/ocsdk@0.3.4](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.4)
 
 ## [1.2.0] - 2022-11-11
+
 ### Added
+
 - Add `sendDefaultInitContext` optional parameter to `ChatSDK.startChat()` to automatically populate `browser`, `device`, `originurl` & `os` as default init context on web
 - Add `sendCacheHeaders` as optional paramater to `ChatSDK.initialize()` and `ChatSDK.getLiveChatConfig()`
 - Add `validateAuthChatRecord` call on `ChatSDK.startChat()` with `liveChatContext` for all authenticated chat scenarios
@@ -158,6 +218,7 @@ All notable changes to this project will be documented in this file.
 - Pass `multiClient` to `AMSClient` on initialization to support `ChatSDK` multi-client
 
 ### Fixed
+
 - Prevent `AMSFileManager.getFileIds()` & `AMSFileManager.getFileMetadata()` to be triggered on all activities with null checks
 - Add `LiveChatVersion` check on `ChatSDK.updateChatToken()`
 - Use `amsreferences` property instead of `amsReferences` by default
@@ -165,6 +226,7 @@ All notable changes to this project will be documented in this file.
 - Remove `fileMetadata` property on messages not containing any attachment
 
 ### Changed
+
 - Uptake [@microsoft/ocsdk@0.3.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.1)
 - Uptake [acs_webchat-chat-adapter@0.0.35-beta.8](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.8/dist/chat-adapter.js)
 - Uptake [acs_webchat-chat-adapter@0.0.35-beta.9](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.9/dist/chat-adapter.js)
@@ -173,7 +235,9 @@ All notable changes to this project will be documented in this file.
 - Uptake [@microsoft/ocsdk@0.3.2](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.2)
 
 ## [1.1.0] - 2022-04-15
+
 ### Added
+
 - Add `getPostChatSurveyContext` API method
 - Add `GetPostChatSurveyContext` telemetry event
 - Add `widgetId` & `clientMessageId` as metadata on sending message
@@ -190,6 +254,7 @@ All notable changes to this project will be documented in this file.
 - Pass `logger` to `acs_webchat-chat-adapter`
 
 ### Fixed
+
 - Add `acs_webchat-chat-adapter` middlewares to format `channelData.tags`
 - Skip `session init` call on existing conversation
 - Fix `chat reconnect` not ending the conversation on calling `ChatSDK.endChat()`
@@ -198,6 +263,7 @@ All notable changes to this project will be documented in this file.
 - Fix `IC3Client.dispose()` called when `IC3Client` is `undefined`
 
 ### Changed
+
 - README: added examples on usages of the post chat APIs.
 - Uptake [@azure/communication-chat@1.1.1](https://www.npmjs.com/package/@azure/communication-chat/v/1.1.1)
 - Uptake [acs_webchat-chat-adapter@0.0.35-beta.2](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.2/dist/chat-adapter.js)
@@ -205,7 +271,9 @@ All notable changes to this project will be documented in this file.
 - Uptake [acs_webchat-chat-adapter@0.0.35-beta.4](https://unpkg.com/acs_webchat-chat-adapter@0.0.35-beta.4/dist/chat-adapter.js)
 
 ## [1.0.0] - 2021-10-08
+
 ### Added
+
 - Add `GetAuthToken` & `GetPreChatSurvey` telemetry events
 - Add `Domain` telemetry base property
 - Add `GetCurrentLiveChatContext`, `GetMessages`, `SendMessages`, `OnNewMessage` & `OnTypingEvent` telemetry events
@@ -213,21 +281,26 @@ All notable changes to this project will be documented in this file.
 - Add `PlatformDetails` telemetry event
 
 ### Changed
+
 - Uptake [@microsoft/ocsdk@0.3.0](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.3.0)
 - Uptake [@microsoft/omnichannel-ic3core@0.1.2](https://www.npmjs.com/package/@microsoft/omnichannel-ic3core/v/0.1.2)
 
 ### Fixed
+
 - `onNewMessage` with `rehydrate` flag set to `true` crashing when `getMessages` returns `undefined`
 - Fix `AriaTelemetry` unable to read property `logEvent` of undefined on `React Native`
 - Fix `Escalation to Voice & Video` library not being imported properly
 
 ## [0.3.0] - 2021-09-03
+
 ### Added
+
 - Persistent Chat Support
 - Chat Reconnect Support
 - Operating Hours Documentation
 
 ### Changed
+
 - Uptake [@microsoft/ocsdk@0.2.0](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.2.0)
 - Add `getCallingToken`
 - Send `ChannelId-lcw` message tag
@@ -238,12 +311,15 @@ All notable changes to this project will be documented in this file.
 - Uptake [ts-jest@27.0.5](https://www.npmjs.com/package/ts-jest/v/27.0.5)
 
 ### Fixed
+
 - `msdyn_enablechatreconnect` not being parsed properly
 - Fix unable to start multiple conversations with same instance due to chat client being disposed
 - Pass logger to adapter
 
 ## [0.2.0] - 2021-04-30
+
 ### Added
+
 - React Native sample app using Omnichannel Chat SDK with [react-native-gifted-chat](https://github.com/FaridSafi/react-native-gifted-chat)
 - Escalation to Voice & Video support (Web Only)
 - React sample app using Omnichannel Chat SDK with [BotFramework-WebChat](https://github.com/microsoft/BotFramework-WebChat)
@@ -255,6 +331,7 @@ All notable changes to this project will be documented in this file.
 - Add ability to pass custom `ariaTelemetryKey`
 
 ### Changed
+
 - Uptake [@microsoft/ocsdk@0.1.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.1.1)
 - Uptake [@microsoft/omnichannel-ic3core@0.1.1](https://www.npmjs.com/package/@microsoft/omnichannel-ic3core/v/0.1.1)
 - Uptake [jest@26.6.3](https://www.npmjs.com/package/jest/v/26.6.3)
@@ -263,13 +340,17 @@ All notable changes to this project will be documented in this file.
 - Uptake [botframework-webchat-adapter-ic3@0.1.0-master.f4dfd7d](https://www.npmjs.com/package/botframework-webchat-adapter-ic3/v/0.1.0-master.f4dfd7d)
 
 ### Fixed
+
 - onAgentEndSession triggered on accept voice & video call
 - Fix multiple instances of IC3Client initialized
 - `uploadFileAttachment` failing on Web
 
 ### Security
+
 - Fix eslint errors
 
 ## [0.1.0] - 2020-10-26
+
 ### Added
+
 - Initial release of Omnichannel Chat SDK v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
 - Fix ChatSDK.getPostConversationContext() to reject promise when conversation is not found
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@azure/communication-chat": "1.1.1",
         "@azure/communication-common": "1.1.0",
-        "@microsoft/ocsdk": "^0.4.3",
+        "@microsoft/ocsdk": "^0.4.5",
         "@microsoft/omnichannel-amsclient": "^0.1.6",
         "@microsoft/omnichannel-ic3core": "^0.1.3"
       },
@@ -1574,9 +1574,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.3.tgz",
-      "integrity": "sha512-5SqZND6Llo+OkdqDBOcs3E0zsLz2XC9WpEwTvqIFLypMoFaI++VCPfuMzTZp30UJRivcHXEuF8ulxn/7TJRF+g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.5.tgz",
+      "integrity": "sha512-1JbwowR87u680iGxyeWv17idTNqZlNpgMFAYHJLmyQ+smnsZKYWwLPjdgase6B/9aHliQ+p2BYiKCai7AQwCgA==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",
@@ -7407,9 +7407,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.3.tgz",
-      "integrity": "sha512-5SqZND6Llo+OkdqDBOcs3E0zsLz2XC9WpEwTvqIFLypMoFaI++VCPfuMzTZp30UJRivcHXEuF8ulxn/7TJRF+g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.4.5.tgz",
+      "integrity": "sha512-1JbwowR87u680iGxyeWv17idTNqZlNpgMFAYHJLmyQ+smnsZKYWwLPjdgase6B/9aHliQ+p2BYiKCai7AQwCgA==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3411,9 +3411,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -7873,7 +7873,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
       "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
@@ -8795,9 +8795,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@azure/communication-chat": "1.1.1",
     "@azure/communication-common": "1.1.0",
-    "@microsoft/ocsdk": "^0.4.3",
+    "@microsoft/ocsdk": "^0.4.5",
     "@microsoft/omnichannel-amsclient": "^0.1.6",
     "@microsoft/omnichannel-ic3core": "^0.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "@microsoft/ocsdk": "^0.4.5",
     "@microsoft/omnichannel-amsclient": "^0.1.6",
     "@microsoft/omnichannel-ic3core": "^0.1.3"
+  },
+  "overrides": {
+    "follow-redirects": "1.15.6"
   }
 }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -320,6 +320,7 @@ class OmnichannelChatSDK {
 
     private async getChatReconnectContextWithReconnectId(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
 
+
         this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContextWithReconnectId, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
@@ -1708,15 +1709,13 @@ class OmnichannelChatSDK {
             const { msdyn_postconversationsurveyenable, msfp_sourcesurveyidentifier, msfp_botsourcesurveyidentifier, postConversationSurveyOwnerId, postConversationBotSurveyOwnerId } = liveWSAndLiveChatEngJoin;
 
             if (parseLowerCaseString(msdyn_postconversationsurveyenable) === "true") {
-
                 const liveWorkItemDetails = await this.getConversationDetails();
-                
-                if ( Object.keys(liveWorkItemDetails).length == 0) {
+                if (Object.keys(liveWorkItemDetails).length == 0) {
                     this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                         RequestId: this.requestId,
-                        ExceptionDetails: "LiveWorkItemDetails is null."
+                        ExceptionDetails: "GetPostChatSurveyContext : LiveWorkItemDetails is null."
                     });
-                    return Promise.reject("LiveWorkItemDetails is null.");
+                    return Promise.reject("GetPostChatSurveyContext : LiveWorkItemDetails is null.");
                 }
                 
                 const participantJoined = parseLowerCaseString(liveWorkItemDetails?.canRenderPostChat as string) === "true";

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -317,7 +317,7 @@ class OmnichannelChatSDK {
 
         return context;
     }
-    
+
     private async getChatReconnectContextWithReconnectId(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
         this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContextWithReconnectId, {
             RequestId: this.requestId,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1697,7 +1697,8 @@ class OmnichannelChatSDK {
 
     public async getPostChatSurveyContext(): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
         this.scenarioMarker.startScenario(TelemetryEvent.GetPostChatSurveyContext, {
-            RequestId: this.requestId
+            RequestId: this.requestId,
+            ChatId: this.chatToken?.chatId as string,
         });
         let conversationId;
 
@@ -1797,6 +1798,7 @@ class OmnichannelChatSDK {
             } else {
                 this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                     RequestId: this.requestId,
+                    ChatId: this.chatToken?.chatId as string,
                     ExceptionDetails: "Post Chat Survey is disabled. Please check the Omnichannel Administration Portal."
                 });
                 return Promise.reject("Post Chat is disabled from admin side.");

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1711,7 +1711,7 @@ class OmnichannelChatSDK {
 
                 const liveWorkItemDetails = await this.getConversationDetails();
                 
-                if (liveWorkItemDetails == null) {
+                if ( Object.keys(liveWorkItemDetails).length == 0) {
                     this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                         RequestId: this.requestId,
                         ExceptionDetails: "LiveWorkItemDetails is null."

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -317,10 +317,8 @@ class OmnichannelChatSDK {
 
         return context;
     }
-
+    
     private async getChatReconnectContextWithReconnectId(optionalParams: ChatReconnectOptionalParams = {}): Promise<ChatReconnectContext> {
-
-
         this.scenarioMarker.startScenario(TelemetryEvent.GetChatReconnectContextWithReconnectId, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
@@ -1713,6 +1711,7 @@ class OmnichannelChatSDK {
                 if (Object.keys(liveWorkItemDetails).length == 0) {
                     this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                         RequestId: this.requestId,
+                        ChatId: this.chatToken?.chatId as string,
                         ExceptionDetails: "GetPostChatSurveyContext : LiveWorkItemDetails is null."
                     });
                     return Promise.reject("GetPostChatSurveyContext : LiveWorkItemDetails is null.");
@@ -1756,6 +1755,7 @@ class OmnichannelChatSDK {
                         this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                             ConversationId: conversationId,
                             RequestId: this.requestId,
+                            ChatId: this.chatToken?.chatId as string,
                             ExceptionDetails: "Survey Invite link failed to send response."
                         });
                         return Promise.reject("Survey Invite link failed to send response.");
@@ -1789,6 +1789,7 @@ class OmnichannelChatSDK {
                     this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                         ConversationId: conversationId,
                         RequestId: this.requestId,
+                        ChatId: this.chatToken?.chatId as string,
                         ExceptionDetails: "surveyInviteLinkResponse is null."
                     });
                     return Promise.reject("surveyInviteLinkResponse is null.");
@@ -1804,6 +1805,7 @@ class OmnichannelChatSDK {
             this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                 ConversationId: conversationId ?? "",
                 RequestId: this.requestId,
+                ChatId: this.chatToken?.chatId as string,
                 ExceptionDetails: JSON.stringify(ex)
             });
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1709,7 +1709,7 @@ class OmnichannelChatSDK {
 
             if (parseLowerCaseString(msdyn_postconversationsurveyenable) === "true") {
                 const liveWorkItemDetails = await this.getConversationDetails();
-                if (Object.keys(liveWorkItemDetails).length == 0) {
+                if (Object.keys(liveWorkItemDetails).length === 0) {
                     this.scenarioMarker.failScenario(TelemetryEvent.GetPostChatSurveyContext, {
                         RequestId: this.requestId,
                         ChatId: this.chatToken?.chatId as string,


### PR DESCRIPTION
For GetPostChatSurveyContext , when liveworkitem details is returninig null, it wont continue with the flow.

![image](https://github.com/microsoft/omnichannel-chat-sdk/assets/981914/598bd387-298d-4927-bb00-238d2941a75b)

<img width="306" alt="image" src="https://github.com/microsoft/omnichannel-chat-sdk/assets/981914/b118cc58-9166-4c76-bba1-e077bf21d0b8">

## ENDED by Agent

<img width="930" alt="image" src="https://github.com/microsoft/omnichannel-chat-sdk/assets/981914/ca90d727-cc1d-4bef-b81f-d5de48072d2a">


### Ended by customer
- not showing survey
