### PR TITLE
removing override, causing problems in LCW with http-server and other…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7873,7 +7873,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
       "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
-        "follow-redirects": "1.15.6",
+        "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -44,8 +44,5 @@
     "@microsoft/ocsdk": "^0.4.5",
     "@microsoft/omnichannel-amsclient": "^0.1.6",
     "@microsoft/omnichannel-ic3core": "^0.1.3"
-  },
-  "overrides": {
-    "follow-redirects": "1.15.6"
   }
 }


### PR DESCRIPTION
on final integration, it was detected the override for follow-redirect cause conflics with ACS libs and httpserver, 

removing this to unblock other fixes, we need to explore on alternatives