### PR TITLE
Adding survey provider to getinvitelink call for MCS survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `OCClient.getSurveyInviteLink` request payload to support Copilot Survey
+
 ## [1.7.2] - 2024-03-20
 
 ### Fixed

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3941,7 +3941,8 @@ describe('Omnichannel Chat SDK', () => {
                     msfp_sourcesurveyidentifier: "",
                     msfp_botsourcesurveyidentifier: "1",
                     postConversationSurveyOwnerId: "",
-                    postConversationBotSurveyOwnerId: "2"
+                    postConversationBotSurveyOwnerId: "2",
+                    msdyn_surveyprovider: "MCS"
                 },
                 ChatWidgetLanguage: {
                     msdyn_localeid: "1033"
@@ -3976,7 +3977,9 @@ describe('Omnichannel Chat SDK', () => {
                 expect(chatSDK.OCClient.getSurveyInviteLink).toHaveBeenCalledWith("2", {
                     "FormId": "1",
                     "ConversationId": "convId",
-                    "OCLocaleCode": "en-us"
+                    "OCLocaleCode": "en-us",
+                    "SurveyProvider": "MCS",
+                    "WidgetId": "[data-app-id]"
                 },
                 expect.any(Object));
                 expect(postChatContext.participantJoined).toBeTruthy();

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1705,7 +1705,7 @@ class OmnichannelChatSDK {
         try {
             const chatConfig: ChatConfig = this.liveChatConfig;
             const { LiveWSAndLiveChatEngJoin: liveWSAndLiveChatEngJoin } = chatConfig;
-            const { msdyn_postconversationsurveyenable, msfp_sourcesurveyidentifier, msfp_botsourcesurveyidentifier, postConversationSurveyOwnerId, postConversationBotSurveyOwnerId } = liveWSAndLiveChatEngJoin;
+            const { msdyn_postconversationsurveyenable, msfp_sourcesurveyidentifier, msfp_botsourcesurveyidentifier, postConversationSurveyOwnerId, postConversationBotSurveyOwnerId, msdyn_surveyprovider } = liveWSAndLiveChatEngJoin;
 
             if (parseLowerCaseString(msdyn_postconversationsurveyenable) === "true") {
                 const liveWorkItemDetails = await this.getConversationDetails();
@@ -1724,12 +1724,16 @@ class OmnichannelChatSDK {
                 conversationId = liveWorkItemDetails?.conversationId;
                 
                 const agentSurveyInviteLinkRequest = {
+                    "SurveyProvider": msdyn_surveyprovider,
+                    "WidgetId": this.omnichannelConfig.widgetId,
                     "FormId": msfp_sourcesurveyidentifier,
                     "ConversationId": conversationId,
                     "OCLocaleCode": getLocaleStringFromId(this.localeId)
                 };
 
                 const botSurveyInviteLinkRequest = {
+                    "SurveyProvider": msdyn_surveyprovider,
+                    "WidgetId": this.omnichannelConfig.widgetId,
                     "FormId": msfp_botsourcesurveyidentifier,
                     "ConversationId": conversationId,
                     "OCLocaleCode": getLocaleStringFromId(this.localeId)


### PR DESCRIPTION
Will not break current flow, as survey provider (acting as a fcb) is checked first in the backend