### PR TITLE
adding sync mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Adding new externalRuntimeId, allows to pass external runtimeId to ChatSDK and keep in sync sessions for telemetry.
+- Adding new template for PR's
+
 ## [1.8.0] - 2024-03-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Adding new externalRuntimeId, allows to pass external runtimeId to ChatSDK and keep in sync sessions for telemetry.
-- Adding new template for PR's
 
 ## [1.8.0] - 2024-03-29
 

--- a/__tests__/utils/utilities.spec.ts
+++ b/__tests__/utils/utilities.spec.ts
@@ -1,3 +1,5 @@
+import { getRuntimeId, isNotEmpty } from "../../src/utils/utilities";
+
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { MessageType } = require("../../src");
 const utilities = require('../../src/utils/utilities');
@@ -99,4 +101,24 @@ describe('Utilities', () => {
 
         expect(utilities.isClientIdNotFoundErrorMessage(error)).toBe(false);
     });
+    it("isNotEmpty should return true if the value is not null, undefined or empty string", () => {
+        const value = "test";
+        expect(isNotEmpty(value)).toBe(true);
+    });
+        
+    it("isNotEmpty should return false if the value is null", () => {
+        const value = null;
+        expect(isNotEmpty(value)).toBe(false);
+    });
+
+    it("getRuntimeId should return externalRuntimeId if it is not empty", () => {
+        const externalRuntimeId = "test";
+        expect(getRuntimeId(externalRuntimeId)).toBe(externalRuntimeId);
+    });
+
+    it("getRuntimeId should return a new uuid if externalRuntimeId is empty", () => {
+        const externalRuntimeId = null;
+        expect(getRuntimeId(externalRuntimeId)).not.toBe(externalRuntimeId);
+    });
+
 });

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,33 @@
+# PR Details
+
+## **Thank you for your contribution. Before submitting this PR, please include:**
+
+### Id of the task, bug, story or other reference
+
+### Description
+
+_Include a description of the problem to be solved_
+
+## Solution Proposed
+
+_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
+
+### Acceptance criteria
+
+_Define what are the conditions to consider the PR has achieved the intended goal_
+
+## Test cases and evidence
+
+_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
+
+### Sanity Tests
+
+- [ ] You have tested all changes in Popout mode
+- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
+- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)
+
+## A11y
+
+- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues
+
+***Please provide justification if any of the validations has been skipped.***

--- a/playwright/integrations/utilities.spec.ts
+++ b/playwright/integrations/utilities.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import {getRuntimeId, isNotEmpty} from '../../src/utils/utilities';
 
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 
@@ -103,25 +102,5 @@ test.describe('Utilities @Utilities', () => {
         const isAscending = (arr) => arr.every((value, index) => index === 0 || value >= arr[index - 1])
         const differenceArray = createDifference(runtimeContext.traces);
         expect(isAscending(differenceArray)).toBe(true);
-    });
-
-    test("isNotEmpty should return true if the value is not null, undefined or empty string", () => {
-        const value = "test";
-        expect(isNotEmpty(value)).toBe(true);
-    });
-        
-    test("isNotEmpty should return false if the value is null", () => {
-        const value = null;
-        expect(isNotEmpty(value)).toBe(false);
-    });
-
-    test("getRuntimeId should return externalRuntimeId if it is not empty", () => {
-        const externalRuntimeId = "test";
-        expect(getRuntimeId(externalRuntimeId)).toBe(externalRuntimeId);
-    });
-
-    test("getRuntimeId should return a new uuid if externalRuntimeId is empty", () => {
-        const externalRuntimeId = null;
-        expect(getRuntimeId(externalRuntimeId)).not.toBe(externalRuntimeId);
     });
 });

--- a/playwright/integrations/utilities.spec.ts
+++ b/playwright/integrations/utilities.spec.ts
@@ -1,5 +1,7 @@
+import { expect, test } from '@playwright/test';
+import {getRuntimeId, isNotEmpty} from '../../src/utils/utilities';
+
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
-import { test, expect } from '@playwright/test';
 
 const testPage = fetchTestPageUrl();
 
@@ -101,5 +103,29 @@ test.describe('Utilities @Utilities', () => {
         const isAscending = (arr) => arr.every((value, index) => index === 0 || value >= arr[index - 1])
         const differenceArray = createDifference(runtimeContext.traces);
         expect(isAscending(differenceArray)).toBe(true);
+    });
+
+    test("isNotEmpty should return true if the value is not null, undefined or empty string", () => {
+        const value = "test";
+        expect(isNotEmpty(value)).toBe(true);
+    });
+    test("isNotEmpty should return true if the value is not null, undefined or empty string", () => {
+        const value = "test";
+        expect(isNotEmpty(value)).toBe(true);
+    });
+    
+    test("isNotEmpty should return false if the value is null", () => {
+        const value = null;
+        expect(isNotEmpty(value)).toBe(false);
+    });
+
+    test("getRuntimeId should return externalRuntimeId if it is not empty", () => {
+        const externalRuntimeId = "test";
+        expect(getRuntimeId(externalRuntimeId)).toBe(externalRuntimeId);
+    });
+
+    test("getRuntimeId should return a new uuid if externalRuntimeId is empty", () => {
+        const externalRuntimeId = null;
+        expect(getRuntimeId(externalRuntimeId)).not.toBe(externalRuntimeId);
     });
 });

--- a/playwright/integrations/utilities.spec.ts
+++ b/playwright/integrations/utilities.spec.ts
@@ -109,11 +109,7 @@ test.describe('Utilities @Utilities', () => {
         const value = "test";
         expect(isNotEmpty(value)).toBe(true);
     });
-    test("isNotEmpty should return true if the value is not null, undefined or empty string", () => {
-        const value = "test";
-        expect(isNotEmpty(value)).toBe(true);
-    });
-    
+        
     test("isNotEmpty should return false if the value is null", () => {
         const value = null;
         expect(isNotEmpty(value)).toBe(false);

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -134,7 +134,7 @@ class OmnichannelChatSDK {
 
     constructor(omnichannelConfig: OmnichannelConfig, chatSDKConfig: ChatSDKConfig = defaultChatSDKConfig) {
         this.debug = false;
-        this.runtimeId = getRuntimeId(omnichannelConfig?.externalRuntimeId ?? null);
+        this.runtimeId = getRuntimeId(chatSDKConfig?.telemetry?.runtimeId ?? null);
         this.omnichannelConfig = omnichannelConfig;
         this.chatSDKConfig = {
             ...defaultChatSDKConfig,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -6,7 +6,7 @@ import { ChatMessageEditedEvent, ChatMessageReceivedEvent, ParticipantsRemovedEv
 import { SDKProvider as OCSDKProvider, uuidv4 } from "@microsoft/ocsdk";
 import { createACSAdapter, createDirectLine, createIC3Adapter } from "./utils/chatAdapterCreators";
 import { defaultLocaleId, getLocaleStringFromId } from "./utils/locale";
-import { isClientIdNotFoundErrorMessage, isCustomerMessage } from "./utils/utilities";
+import { getRuntimeId, isClientIdNotFoundErrorMessage, isCustomerMessage } from "./utils/utilities";
 import { loadScript, removeElementById } from "./utils/WebUtils";
 import platform, { isBrowser } from "./utils/platform";
 import validateSDKConfig, { defaultChatSDKConfig } from "./validators/SDKConfigValidators";
@@ -134,7 +134,7 @@ class OmnichannelChatSDK {
 
     constructor(omnichannelConfig: OmnichannelConfig, chatSDKConfig: ChatSDKConfig = defaultChatSDKConfig) {
         this.debug = false;
-        this.runtimeId = uuidv4();
+        this.runtimeId = getRuntimeId(omnichannelConfig?.externalRuntimeId ?? null);
         this.omnichannelConfig = omnichannelConfig;
         this.chatSDKConfig = {
             ...defaultChatSDKConfig,

--- a/src/core/ChatSDKConfig.ts
+++ b/src/core/ChatSDKConfig.ts
@@ -9,7 +9,8 @@ interface DataMaskingSDKConfig {
 interface TelemetrySDKConfig {
     disable: boolean,
     ariaTelemetryKey?: string,
-    ariaCollectorUri?: string
+    ariaCollectorUri?: string, 
+    runtimeId?: string
 }
 
 interface PersistentChatConfig {

--- a/src/core/OmnichannelConfig.ts
+++ b/src/core/OmnichannelConfig.ts
@@ -2,5 +2,4 @@ export default interface OmnichannelConfig {
     orgId: string;
     orgUrl: string;
     widgetId: string;
-    externalRuntimeId?: string | null;
 }

--- a/src/core/OmnichannelConfig.ts
+++ b/src/core/OmnichannelConfig.ts
@@ -2,4 +2,5 @@ export default interface OmnichannelConfig {
     orgId: string;
     orgUrl: string;
     widgetId: string;
+    externalRuntimeId?: string | null;
 }

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -1,5 +1,6 @@
 import ACSParticipantDisplayName from "../core/messaging/ACSParticipantDisplayName";
 import MessageType from "@microsoft/omnichannel-ic3core/lib/model/MessageType";
+import { uuidv4 } from "..";
 
 export const isSystemMessage = (message: any): boolean => { // eslint-disable-line @typescript-eslint/no-explicit-any,  @typescript-eslint/explicit-module-boundary-types
     const {messageType, properties} = message;
@@ -26,4 +27,15 @@ export const isCustomerMessage = (message: any): boolean => { // eslint-disable-
 export const isClientIdNotFoundErrorMessage = (e: any): boolean => {
     return e?.response?.status === 401
         && e?.response?.headers?.message === "UserId not found";
+}
+
+export const isNotEmpty = (value: string | null) : boolean => {
+    return value !== null && value !== undefined && value.trim() !== '';
+}
+
+export const getRuntimeId = (externalRuntimeId : string | null ): string => {
+    if (externalRuntimeId !== null && isNotEmpty(externalRuntimeId)) {
+        return externalRuntimeId;
+    }
+    return uuidv4();
 }


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description
_Include a description of the problem to be solved_
Gap identified as part of engineering enhancement.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

- Expose a new config attribute, when the attribute is present then that value will be used, when the value is not present then a new UUID will be generated

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
- Expose a new config attribute, when the attribute is present then that value will be used, when the value is not present then a new UUID will be generated
- Telemetry shares same runtimeId value for telemetry

## Test cases and evidence
### Passing external Id
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/microsoft/omnichannel-chat-sdk/assets/981914/4a67e8cf-968a-4922-9155-47badc8d30ce)

![image](https://github.com/microsoft/omnichannel-chat-sdk/assets/981914/187682bf-a6f1-4042-9030-0557b2e64dae)

### Not passing external Id
<img width="715" alt="image" src="https://github.com/microsoft/omnichannel-chat-sdk/assets/981914/80d75161-0189-417a-b26e-14e6c5d1b156">



### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
