### PR TITLE
Add Ability to Send OC User Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Add `RequestHeaders` telemetry base property to `OCSDKContract`
+- Add ability to send `ocUserAgent`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add `RequestHeaders` telemetry base property to `OCSDKContract`
+
 ### Changed
 
 - Uptake [@microsoft/ocsdk@0.5.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Uptake [@microsoft/ocsdk@0.5.0](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.0)
+- Uptake [@microsoft/ocsdk@0.5.1](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.1)
 
 ## [1.8.2] - 2024-05-07
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -394,6 +394,48 @@ describe('Omnichannel Chat SDK', () => {
 
             expect(chatSDK.chatSDKConfig.chatReconnect.disable).toBe(chatSDKConfig.chatReconnect.disable);
         });
+
+        it("ChatSDK.initialize() should pass default 'omnichannel-chat-sdk' user agent", async () => {
+            const omnichannelConfig = {
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+
+            await chatSDK.initialize();
+
+            const version = require("../package.json").version;
+            const userAgent = `omnichannel-chat-sdk/${version}`;
+            const expectedResult = [userAgent];
+
+            expect(chatSDK.OCClient.ocUserAgent).toEqual(expectedResult)
+        });
+
+        it("ChatSDK.initialize() with additional user agent should be added as part of oc user agent", async () => {
+            const omnichannelConfig = {
+                orgUrl: '[data-org-url]',
+                orgId: '[data-org-id]',
+                widgetId: '[data-app-id]'
+            };
+
+            const chatSDKConfig = {
+                ocUserAgent: ["user-agent"]
+            }
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            chatSDK.getChatConfig = jest.fn();
+
+            await chatSDK.initialize();
+
+            const version = require("../package.json").version;
+            const userAgent = `omnichannel-chat-sdk/${version}`;
+            const expectedResult = [...chatSDKConfig.ocUserAgent, userAgent];
+
+            expect(chatSDK.OCClient.ocUserAgent).toEqual(expectedResult)
+        });
     });
 
     describe('Functionalities', () => {

--- a/__tests__/utils/setOcUserAgent.spec.ts
+++ b/__tests__/utils/setOcUserAgent.spec.ts
@@ -1,0 +1,17 @@
+import setOcUserAgent from "../../src/utils/setOcUserAgent";
+
+describe("setOcUserAgent", () => {
+    it("setOcUserAgent() should add `omnichannel-chat-sdk` as oc user agent", () => {
+        const OCClient = {
+            ocUserAgent: []
+        }
+
+        setOcUserAgent(OCClient, []);
+
+        const version = require("../../package.json").version;
+        const userAgent = `omnichannel-chat-sdk/${version}`;
+        const expectedResult = [userAgent];
+
+        expect(OCClient.ocUserAgent).toEqual(expectedResult);
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@azure/communication-chat": "1.1.1",
         "@azure/communication-common": "1.1.0",
-        "@microsoft/ocsdk": "^0.5.0",
+        "@microsoft/ocsdk": "^0.5.1",
         "@microsoft/omnichannel-amsclient": "^0.1.6",
         "@microsoft/omnichannel-ic3core": "^0.1.3"
       },
@@ -1574,9 +1574,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.0.tgz",
-      "integrity": "sha512-N016gpKQfVMifKtS0Rqn3THn9XgVO0pXlOZoVLmJyUKLfKzUueKL4ub/9LNve0ssZbqTX+l+Se4P81zNJY/yeg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.1.tgz",
+      "integrity": "sha512-e8CWDYMw2NJpwm5j5S4oDh3Z16GpwzvJNdZII+8LvzmgpsFermASNteHgFdVvRSqI7zRfOOAJkY36tdaNbFSwg==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",
@@ -7407,9 +7407,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.0.tgz",
-      "integrity": "sha512-N016gpKQfVMifKtS0Rqn3THn9XgVO0pXlOZoVLmJyUKLfKzUueKL4ub/9LNve0ssZbqTX+l+Se4P81zNJY/yeg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.1.tgz",
+      "integrity": "sha512-e8CWDYMw2NJpwm5j5S4oDh3Z16GpwzvJNdZII+8LvzmgpsFermASNteHgFdVvRSqI7zRfOOAJkY36tdaNbFSwg==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@azure/communication-chat": "1.1.1",
     "@azure/communication-common": "1.1.0",
-    "@microsoft/ocsdk": "^0.5.0",
+    "@microsoft/ocsdk": "^0.5.1",
     "@microsoft/omnichannel-amsclient": "^0.1.6",
     "@microsoft/omnichannel-ic3core": "^0.1.3"
   }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -97,6 +97,7 @@ import { coreServicesOrgUrlPrefix, createCoreServicesOrgUrl, getCoreServicesGeoN
 import loggerUtils from "./utils/loggerUtils";
 import ocSDKConfiguration from "./config/ocSDKConfiguration";
 import { isCoreServicesOrgUrlDNSError } from "./utils/internalUtils";
+import setOcUserAgent from "./utils/setOcUserAgent";
 
 class OmnichannelChatSDK {
     private debug: boolean;
@@ -212,6 +213,7 @@ class OmnichannelChatSDK {
         try {
             this.OCSDKProvider = OCSDKProvider;
             this.OCClient = await OCSDKProvider.getSDK(this.omnichannelConfig as IOmnichannelConfiguration, ocSDKConfiguration as ISDKConfiguration, this.ocSdkLogger as OCSDKLogger);
+            setOcUserAgent(this.OCClient);
         } catch (e) {
             exceptionThrowers.throwOmnichannelClientInitializationFailure(e, this.scenarioMarker, TelemetryEvent.InitializeChatSDK);
         }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -213,7 +213,7 @@ class OmnichannelChatSDK {
         try {
             this.OCSDKProvider = OCSDKProvider;
             this.OCClient = await OCSDKProvider.getSDK(this.omnichannelConfig as IOmnichannelConfiguration, ocSDKConfiguration as ISDKConfiguration, this.ocSdkLogger as OCSDKLogger);
-            setOcUserAgent(this.OCClient);
+            setOcUserAgent(this.OCClient, this.chatSDKConfig?.ocUserAgent);
         } catch (e) {
             exceptionThrowers.throwOmnichannelClientInitializationFailure(e, this.scenarioMarker, TelemetryEvent.InitializeChatSDK);
         }

--- a/src/core/ChatSDKConfig.ts
+++ b/src/core/ChatSDKConfig.ts
@@ -37,7 +37,8 @@ interface ChatSDKConfig {
     getAuthToken?: () => Promise<string|null>,
     ic3Config?: IC3Config,
     chatAdapterConfig?: ChatAdapterConfig,
-    internalConfig?: InternalChatSDKConfig
+    internalConfig?: InternalChatSDKConfig,
+    ocUserAgent?: string[]
 }
 
 export {

--- a/src/external/OCSDK/IOCSDKLogData.ts
+++ b/src/external/OCSDK/IOCSDKLogData.ts
@@ -6,6 +6,7 @@ export default interface IOCSDKLogData {
     TransactionId: string;
     ExceptionDetails: object;
     Description: string;
+    RequestHeaders: string;
     RequestPayload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     RequestPath: string;
     RequestMethod: string;

--- a/src/telemetry/AriaTelemetry.ts
+++ b/src/telemetry/AriaTelemetry.ts
@@ -70,6 +70,7 @@ interface OCSDKContract {
     Event?: string;
     ExceptionDetails?: string;
     ElapsedTimeInMilliseconds?: string;
+    RequestHeaders?: string;
     RequestPayload?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     RequestPath?: string;
     RequestMethod?: string;
@@ -786,6 +787,7 @@ class AriaTelemetry {
             Event: '',
             ExceptionDetails: '',
             ElapsedTimeInMilliseconds: '',
+            RequestHeaders: '',
             RequestPayload: '',
             RequestPath: '',
             RequestMethod: '',

--- a/src/telemetry/AriaTelemetry.ts
+++ b/src/telemetry/AriaTelemetry.ts
@@ -28,7 +28,6 @@ interface NPMPackagesInfo {
     IC3Core?: string;
     ACSChat?: string;
     ACSCommon?: string;
-    ACSSignaling?: string;
     AMSClient?: string;
 }
 
@@ -674,7 +673,6 @@ class AriaTelemetry {
             IC3Core: require('@microsoft/omnichannel-ic3core/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
             ACSChat: require('@azure/communication-chat/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
             ACSCommon: require('@azure/communication-common/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
-            ACSSignaling: require('@azure/communication-signaling').version, // eslint-disable-line @typescript-eslint/no-var-requires
             AMSClient:  require('@microsoft/omnichannel-amsclient/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
         };
 

--- a/src/telemetry/AriaTelemetry.ts
+++ b/src/telemetry/AriaTelemetry.ts
@@ -28,6 +28,7 @@ interface NPMPackagesInfo {
     IC3Core?: string;
     ACSChat?: string;
     ACSCommon?: string;
+    ACSSignaling?: string;
     AMSClient?: string;
 }
 
@@ -672,6 +673,7 @@ class AriaTelemetry {
             IC3Core: require('@microsoft/omnichannel-ic3core/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
             ACSChat: require('@azure/communication-chat/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
             ACSCommon: require('@azure/communication-common/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
+            ACSSignaling: require('@azure/communication-signaling').version, // eslint-disable-line @typescript-eslint/no-var-requires
             AMSClient:  require('@microsoft/omnichannel-amsclient/package.json').version, // eslint-disable-line @typescript-eslint/no-var-requires
         };
 

--- a/src/utils/loggers.ts
+++ b/src/utils/loggers.ts
@@ -143,6 +143,7 @@ export class OCSDKLogger {
 
         const additionalProperties: AWTEventData["properties"] = {
             ...event,
+            RequestHeaders: event.RequestHeaders? JSON.stringify(event.RequestHeaders): '',
             RequestPayload: event.RequestPayload? JSON.stringify(event.RequestPayload): '',
             ExceptionDetails: event.ExceptionDetails? JSON.stringify(event.ExceptionDetails): '',
         };

--- a/src/utils/setOcUserAgent.ts
+++ b/src/utils/setOcUserAgent.ts
@@ -1,7 +1,11 @@
-const setOcUserAgent = (OCClient: any) => {
+const setOcUserAgent = (OCClient: any, ocUserAgent?: string[]) => {
     const version = require('../../package.json').version;
     const userAgent = `omnichannel-chat-sdk/${version}`;
     OCClient.ocUserAgent = [userAgent, ...OCClient.ocUserAgent];
+
+    if (ocUserAgent) {
+        OCClient.ocUserAgent = [...ocUserAgent, ...OCClient.ocUserAgent];
+    }
 }
 
 export default setOcUserAgent;

--- a/src/utils/setOcUserAgent.ts
+++ b/src/utils/setOcUserAgent.ts
@@ -1,0 +1,7 @@
+const setOcUserAgent = (OCClient: any) => {
+    const version = require('../../package.json').version;
+    const userAgent = `omnichannel-chat-sdk/${version}`;
+    OCClient.ocUserAgent = [userAgent, ...OCClient.ocUserAgent];
+}
+
+export default setOcUserAgent;

--- a/src/utils/setOcUserAgent.ts
+++ b/src/utils/setOcUserAgent.ts
@@ -1,5 +1,5 @@
-const setOcUserAgent = (OCClient: any, ocUserAgent?: string[]) => {
-    const version = require('../../package.json').version;
+const setOcUserAgent = (OCClient: any, ocUserAgent?: string[]): void => { // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types 
+    const version = require('../../package.json').version; // eslint-disable-line @typescript-eslint/no-var-requires
     const userAgent = `omnichannel-chat-sdk/${version}`;
     OCClient.ocUserAgent = [userAgent, ...OCClient.ocUserAgent];
 


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference
Task: 3985297

### Description
- Sending default OC User Agent HTTP Request Headers for better analytics
- Add ability to send additional OC User Agent HTTP Request Headers

### Acceptance criteria

- OC User Agent should be sent as part of every HTTP calls

## Test cases and evidence

- Validated the scenario 
- Verified scenario with telemetry logs

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
