### PR TITLE
Core services GCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add `crm9` as part of `CoreServicesGeoNamesMapping`
+
 ### Changed
 
 - Log `error` object on failures on sending message and send typing
+- Update `retrieveCollectorUri()` to detect `GCCDomainPatterns` to return `GCCCollectorUri`
 
 ## [1.9.2] - 2024-06-25
 

--- a/__tests__/telemetry/retrieveCollectorUri.spec.ts
+++ b/__tests__/telemetry/retrieveCollectorUri.spec.ts
@@ -1,9 +1,11 @@
 import retrieveCollectorUri from '../../src/telemetry/retrieveCollectorUri';
 import EUDomainNames from '../../src/telemetry/EUDomainNames';
+import GCCDomainPatterns from '../../src/telemetry/GCCDomainPatterns';
 
 describe('retrieveCollectorUri', () => {
     const defaultCollectorUri = "https://browser.pipe.aria.microsoft.com/Collector/3.0/";
     const EUCollectorUri = "https://eu-mobile.events.data.microsoft.com/Collector/3.0/";
+    const GCCCollectorUri = "https://tb.pipe.aria.microsoft.com/Collector/3.0/";
 
     it('retrieveCollectorUri() should return default EUCollectorUri on EU orgUrls', () => {
         for (const domain of EUDomainNames) {
@@ -17,6 +19,22 @@ describe('retrieveCollectorUri', () => {
         const orgUrl = "microsoft.com";
         const collectorUri = retrieveCollectorUri(orgUrl);
 
+        expect(collectorUri).toBe(defaultCollectorUri);
+    });
+
+    it('retrieveCollectorUri() should return default GCCCollectorUri on GCC orgUrl', () => {
+        for (const domainPattern of GCCDomainPatterns) {
+            const orgUrl = `foo.${domainPattern}.bar`;
+            const collectorUri = retrieveCollectorUri(orgUrl);
+            expect(collectorUri).toBe(GCCCollectorUri);
+        }
+    });
+
+    it('retrieveCollectorUri() with \'crm9\' as part of the org name should NOT return GCCCollectorUri on GCC orgUrl', () => {
+        const orgUrl = `[prefix]crm9[suffix].crm90.bar`;
+        const collectorUri = retrieveCollectorUri(orgUrl);
+
+        expect(collectorUri).not.toBe(GCCCollectorUri);
         expect(collectorUri).toBe(defaultCollectorUri);
     });
 });

--- a/src/telemetry/GCCDomainPatterns.ts
+++ b/src/telemetry/GCCDomainPatterns.ts
@@ -1,0 +1,6 @@
+const GCCDomainPatterns = [
+    "gov.omnichannelengagementhub.com",
+    "-crm9"
+];
+
+export default GCCDomainPatterns;

--- a/src/telemetry/retrieveCollectorUri.ts
+++ b/src/telemetry/retrieveCollectorUri.ts
@@ -1,8 +1,10 @@
 import EUDomainNames from "./EUDomainNames";
+import GCCDomainPatterns from "./GCCDomainPatterns";
 
 const retrieveCollectorUri = (orgUrl: string): string => {
     const defaultCollectorUri = "https://browser.pipe.aria.microsoft.com/Collector/3.0/";
     const EUCollectorUri = "https://eu-mobile.events.data.microsoft.com/Collector/3.0/";
+    const GCCCollectorUri = "https://tb.pipe.aria.microsoft.com/Collector/3.0/";
 
     let url = orgUrl;
     if (orgUrl.endsWith("/")) {
@@ -12,6 +14,12 @@ const retrieveCollectorUri = (orgUrl: string): string => {
     for (let i = 0; i < EUDomainNames.length; i++) {
         if (url.endsWith(EUDomainNames[i])) {
             return EUCollectorUri;
+        }
+    }
+
+    for (let i = 0; i < GCCDomainPatterns.length; i++) {
+        if (url.includes(GCCDomainPatterns[i])) {
+            return GCCCollectorUri;
         }
     }
 

--- a/src/utils/CoreServicesUtils.ts
+++ b/src/utils/CoreServicesUtils.ts
@@ -7,6 +7,7 @@ export const CoreServicesGeoNamesMapping: any = { // eslint-disable-line @typesc
     "crm6": "au", // OCE
     "crm7": "jp", // JPN
     "crm8": "in", // IND
+    "crm9": "gov", // GCC
     "crm10": "preprod", // PREPROD
     "crm11": "uk", // GBR
     "crm12": "fr", // FRA


### PR DESCRIPTION
- Add `crm9` as part of CoreServicesGeoNamesMapping
- Update `retrieveCollectorUri` to return GCCCollectorUri accordingly