### PR TITLE
bump ocsdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ## Changed
 - core service url regex to include crmtest
+- Uptake [@microsoft/ocsdk@0.4.6](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.6)
 
 ## [1.9.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ## Changed
 - core service url regex to include crmtest
-- Uptake [@microsoft/ocsdk@0.4.6](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.4.6)
+- Uptake [@microsoft/ocsdk@0.5.6](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.6)
 
 ## [1.9.4]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@azure/communication-chat": "1.1.1",
         "@azure/communication-common": "1.1.0",
-        "@microsoft/ocsdk": "^0.5.5",
+        "@microsoft/ocsdk": "^0.5.6",
         "@microsoft/omnichannel-amsclient": "^0.1.6",
         "@microsoft/omnichannel-ic3core": "^0.1.4"
       },
@@ -1574,9 +1574,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.5.tgz",
-      "integrity": "sha512-z2qA0A81QSQMN7iUxRWY0RIFd0+ByEZc4kZLWg4NFMIsueMbI2RLBfSQCQhcTRpsn6w5FhihBS+j2fwYNgAgZA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.6.tgz",
+      "integrity": "sha512-TuC8kQ2W3lP6atxt0u41pqIdRdytlNw98m0EI1wW9EOrz+L7YfchoVVqbMHNpV4NHON7nxKyRtLO3DWolUUULQ==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",
@@ -7428,9 +7428,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.5.tgz",
-      "integrity": "sha512-z2qA0A81QSQMN7iUxRWY0RIFd0+ByEZc4kZLWg4NFMIsueMbI2RLBfSQCQhcTRpsn6w5FhihBS+j2fwYNgAgZA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.6.tgz",
+      "integrity": "sha512-TuC8kQ2W3lP6atxt0u41pqIdRdytlNw98m0EI1wW9EOrz+L7YfchoVVqbMHNpV4NHON7nxKyRtLO3DWolUUULQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@azure/communication-chat": "1.1.1",
     "@azure/communication-common": "1.1.0",
-    "@microsoft/ocsdk": "^0.5.5",
+    "@microsoft/ocsdk": "^0.5.6",
     "@microsoft/omnichannel-amsclient": "^0.1.6",
     "@microsoft/omnichannel-ic3core": "^0.1.4"
   }


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

 4255474

### Description
_Include a description of the problem to be solved_
The chat wi.dget remains in a loading state continuously

This is due to sometimes getchattoken endpoint is unresponsive, causing the widget to hand due to a improper way to send reject the promisse in ocsdk

## Solution Proposed

_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

patch was already applied in OCSDK

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_


## Timeout getchatoken
<img width="960" alt="image" src="https://github.com/user-attachments/assets/938a9991-176b-4010-b36c-afe27dd96766">

## normal chat
![image](https://github.com/user-attachments/assets/b703cd03-739c-435c-960b-c0e369ad60e5)


### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
