### PR TITLE
Fix Integration Tests with Chats Running Too Fast

### DIFF
--- a/playwright/integrations/authenticated-chat-with-attachments.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-attachments.spec.ts
@@ -1,6 +1,7 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import ACSEndpoints from '../utils/ACSEndpoints';
 import AMSEndpoints from '../utils/AMSEndpoints';
@@ -8,6 +9,7 @@ import AMSEndpoints from '../utils/AMSEndpoints';
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithAttachments');
 const authUrl = fetchAuthUrl('AuthenticatedChatWithAttachments');
+const testSettings = fetchTestSettings('AuthenticatedChatWithAttachments');
 
 test.describe('AuthenticatedChat @AuthenticatedChatWithAttachments', () => {
     test('ChatSDK.uploadFileAttachment() should upload attachment to the attachment service & send a message with the metadata', async ({ page }) => {
@@ -26,7 +28,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithAttachments', () => {
             page.waitForResponse(response => {
                 return response.url().match(ACSEndpoints.sendMessagePathPattern)?.length >= 0;
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -68,10 +71,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithAttachments', () => {
                 const messages = await chatSDK.getMessages();
                 runtimeContext.messages = messages;
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const sendMessageRequestPostDataDataJson = sendMessageRequest.postDataJSON();
@@ -105,7 +110,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithAttachments', () => {
             page.waitForResponse(response => {
                 return response.url().includes(AMSEndpoints.rootDomain) && response.url().match(AMSEndpoints.getImageViewPattern)?.length >= 0 && !response.url().endsWith("status");
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -160,10 +166,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithAttachments', () => {
                     runtimeContext.errorObject = `${err}`;
                 }
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         expect(getImageViewStatusRequest.method()).toBe('GET');

--- a/playwright/integrations/authenticated-chat-with-masking.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-masking.spec.ts
@@ -1,12 +1,14 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import ACSEndpoints from '../utils/ACSEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithMasking');
 const authUrl = fetchAuthUrl('AuthenticatedChatWithMasking');
+const testSettings = fetchTestSettings('AuthenticatedChatWithMasking');
 
 test.describe('AuthenticatedChat @AuthenticatedChatWithMasking', () => {
     test('ChatSDK.sendMessage() should send the message masked', async ({ page }) => {
@@ -20,7 +22,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithMasking', () => {
             page.waitForResponse(response => {
                 return response.url().match(ACSEndpoints.sendMessagePathPattern)?.length >= 0;
             }),
-            await page.evaluate(async ({ omnichannelConfig, content, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, content, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -51,10 +54,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithMasking', () => {
                     content
                 });
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, content, authUrl })
+            }, { omnichannelConfig, content, authUrl, chatDuration: testSettings.chatDuration })
         ]);
         
         const sendMessageRequestPostDataDataJson = sendMessageRequest.postDataJSON();

--- a/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
@@ -1,5 +1,6 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
@@ -7,6 +8,7 @@ import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithPersistentChat');
 const authUrl = fetchAuthUrl('AuthenticatedChatWithPersistentChat');
+const testSettings = fetchTestSettings('AuthenticatedChatWithPersistentChat');
 
 test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
     test('ChatSDK.endChat() without any reconnect id should call session close with isPersistentChat=true as query params', async ({ page }) => {
@@ -22,7 +24,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionClosePath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK, uuidv4 } = window;
 
                 const data = {
@@ -56,10 +59,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;
@@ -116,7 +121,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -145,10 +151,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId, authToken } = runtimeContext;
@@ -183,7 +191,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthReconnectableChats);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK, uuidv4 } = window;
 
                 const data = {
@@ -217,10 +226,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { authToken } = runtimeContext;
@@ -267,7 +278,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionClosePath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -296,10 +308,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;

--- a/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
@@ -1,7 +1,7 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
-import fetchTestSettings from '../utils/fetchTestSettings';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 

--- a/playwright/integrations/authenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-prechat.spec.ts
@@ -1,12 +1,14 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithPrechat');
 const authUrl = fetchAuthUrl('AuthenticatedChatWithPrechat');
+const testSettings = fetchTestSettings('AuthenticatedChatWithPrechat');
 
 test.describe('AuthenticatedChat @AuthenticatedChatWithPrechat', () => {
     test('ChatSDK.startChat() with preChatResponse should be part of session init payload', async ({ page }) => {
@@ -26,7 +28,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPrechat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, optionalParams, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, optionalParams, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -55,10 +58,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPrechat', () => {
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, optionalParams, authUrl })
+            }, { omnichannelConfig, optionalParams, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;

--- a/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
@@ -1,5 +1,6 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
@@ -7,6 +8,7 @@ import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithChatReconnect');
 const authUrl = fetchAuthUrl('AuthenticatedChatWithChatReconnect');
+const testSettings = fetchTestSettings('AuthenticatedChatWithChatReconnect');
 
 test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
     test("ChatSDK.getChatReconnectContext() should not return a reconnect id if there's no existing chat session", async ({ page }) => {
@@ -19,7 +21,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthReconnectableChats) && response.request().method() === 'GET';
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK, uuidv4 } = window;
 
                 const data = {
@@ -57,10 +60,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { authToken, reconnectId } = runtimeContext;
@@ -108,7 +113,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthReconnectableChats) && response.request().method() === 'GET';
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -142,10 +148,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
 
                 await chatSDK.startChat({reconnectId});
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { authToken, reconnectId } = runtimeContext;
@@ -199,7 +207,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -234,10 +243,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
 
                 await chatSDK.startChat({ reconnectId });
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId, reconnectId, authToken } = runtimeContext;
@@ -289,7 +300,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionClosePath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -324,10 +336,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
 
                 await chatSDK.startChat({ reconnectId });
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { reconnectId } = runtimeContext;
@@ -454,7 +468,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK, runtimeContext } = window;
                 const payload = {
                     method: "POST"
@@ -482,6 +497,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
                 const liveChatContext = await chatSDK.getCurrentLiveChatContext();
                 runtimeContext.liveChatContext = liveChatContext;
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
                 runtimeContext.invalidRequestId = chatSDK.requestId;
 
@@ -489,7 +506,7 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
                 runtimeContext.invalidRequestIdConversationDetails = invalidRequestIdConversationDetails;
 
                 (window as any).runtimeContext = runtimeContext;
-            }, { omnichannelConfig, authUrl }),
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration }),
             page.waitForRequest(request => {
                 return request.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
             }),

--- a/playwright/integrations/authenticated-chat-with-transcripts.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-transcripts.spec.ts
@@ -1,12 +1,14 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithTranscripts');
 const authUrl = fetchAuthUrl('AuthenticatedChatWithTranscripts');
+const testSettings = fetchTestSettings('AuthenticatedChatWithTranscripts');
 
 test.describe('@AuthenticatedChat @AuthenticatedChatWithTranscripts', () => {
     test('ChatSDK.getLiveChatTranscript() should not fail', async ({ page }) => {
@@ -19,7 +21,8 @@ test.describe('@AuthenticatedChat @AuthenticatedChatWithTranscripts', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatv2AuthGetChatTranscriptPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -49,10 +52,12 @@ test.describe('@AuthenticatedChat @AuthenticatedChatWithTranscripts', () => {
                 const transcript = await chatSDK.getLiveChatTranscript();
                 runtimeContext.transcript = transcript;
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { authToken, requestId, token, chatId, transcript } = runtimeContext;
@@ -85,7 +90,8 @@ test.describe('@AuthenticatedChat @AuthenticatedChatWithTranscripts', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatv2AuthGetChatTranscriptPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -114,13 +120,15 @@ test.describe('@AuthenticatedChat @AuthenticatedChatWithTranscripts', () => {
                 runtimeContext.token = chatSDK.chatToken.token;
                 runtimeContext.chatId = chatSDK.chatToken.chatId;
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 const transcript = await chatSDK.getLiveChatTranscript({ liveChatContext });
                 runtimeContext.transcript = transcript;
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { authToken, requestId, token, chatId, transcript } = runtimeContext;
@@ -147,7 +155,8 @@ test.describe('@AuthenticatedChat @AuthenticatedChatWithTranscripts', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthTranscriptEmailRequestPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -180,10 +189,12 @@ test.describe('@AuthenticatedChat @AuthenticatedChatWithTranscripts', () => {
 
                 await chatSDK.emailLiveChatTranscript(body);
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;

--- a/playwright/integrations/authenticated-chat-with-typing.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-typing.spec.ts
@@ -1,12 +1,14 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChatWithTyping');
 const authUrl = fetchAuthUrl('AuthenticatedChatWithTyping');
+const testSettings = fetchTestSettings('AuthenticatedChatWithTyping');
 
 test.describe('AuthenticatedChat @AuthenticatedChatWithTyping', () => {
     test('ChatSDK.sendTyping() should not fail', async ({ page }) => {
@@ -19,7 +21,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithTyping', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.SendTypingIndicatorPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -45,10 +48,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithTyping', () => {
 
                 await chatSDK.sendTypingEvent();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;
@@ -62,7 +67,8 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithTyping', () => {
         await page.goto(testPage);
 
         const [runtimeContext] = await Promise.all([
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -97,10 +103,12 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithTyping', () => {
                     runtimeContext.errorObject = `${err}`;
                 }
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         expect(runtimeContext?.errorMessage).not.toBeDefined();

--- a/playwright/integrations/authenticated-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat.spec.ts
@@ -1,12 +1,14 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
 import fetchAuthUrl from '../utils/fetchAuthUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('AuthenticatedChat');
 const authUrl = fetchAuthUrl('AuthenticatedChat');
+const testSettings = fetchTestSettings('AuthenticatedChat');
 
 test.describe('AuthenticatedChat @AuthenticatedChat', () => {
     test('ChatSDK.startChat() should fetch the chat token & perform session init', async ({ page }) => {
@@ -25,7 +27,8 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -51,10 +54,12 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId, authToken } = runtimeContext;
@@ -126,7 +131,8 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthChatMapRecord);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK, runtimeContext } = window;
 
                 const payload = {
@@ -154,10 +160,12 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
                     runtimeContext.errorMessage = `${err.message}`;
                 }
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, authUrl })
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestIdFirstSession: requestId, authToken } = runtimeContext;
@@ -298,7 +306,8 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
+            await page.evaluate(async ({ omnichannelConfig, authUrl, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
                 const payload = {
@@ -325,6 +334,8 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
                     liveChatContext
                 };
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
                 runtimeContext.invalidRequestId = chatSDK.requestId;
 
@@ -332,7 +343,7 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
                 runtimeContext.invalidRequestIdConversationDetails = invalidRequestIdConversationDetails;
 
                 (window as any).runtimeContext = runtimeContext;
-            }, { omnichannelConfig, authUrl }),
+            }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration }),
             page.waitForRequest(request => {
                 return request.url().includes(OmnichannelEndpoints.LiveChatAuthLiveWorkItemDetailsPath);
             }),
@@ -357,7 +368,7 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
 
                 await chatSDK.initialize();
 
-                runtimeContext.authToken= authToken;
+                runtimeContext.authToken = authToken;
 
                 const liveChatContextConversationDetails = await chatSDK.getConversationDetails({ liveChatContext: runtimeContext.liveChatContext });
                 runtimeContext.liveChatContextConversationDetails = liveChatContextConversationDetails;

--- a/playwright/integrations/unauthenticated-chat-with-masking.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-masking.spec.ts
@@ -1,10 +1,12 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import ACSEndpoints from '../utils/ACSEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithMasking');
+const testSettings = fetchTestSettings('UnauthenticatedChatWithMasking');
 
 test.describe('UnauthenticatedChat @UnauthenticatedChatWithMasking', () => {
     test('ChatSDK.sendMessage() should send the message masked', async ({ page }) => {
@@ -18,7 +20,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithMasking', () => {
             page.waitForResponse(response => {
                 return response.url().match(ACSEndpoints.sendMessagePathPattern)?.length >= 0;
             }),
-            await page.evaluate(async ({ omnichannelConfig, content }) => {
+            await page.evaluate(async ({ omnichannelConfig, content, chatDuration }) => {
                 const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
@@ -37,12 +39,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithMasking', () => {
                     content
                 });
 
-                await sleep(1000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, content })
+            }, { omnichannelConfig, content, chatDuration: testSettings.chatDuration })
         ]);
 
         const sendMessageRequestPostDataDataJson = sendMessageRequest.postDataJSON();

--- a/playwright/integrations/unauthenticated-chat-with-masking.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-masking.spec.ts
@@ -19,6 +19,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithMasking', () => {
                 return response.url().match(ACSEndpoints.sendMessagePathPattern)?.length >= 0;
             }),
             await page.evaluate(async ({ omnichannelConfig, content }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -35,6 +36,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithMasking', () => {
                 await chatSDK.sendMessage({
                     content
                 });
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -25,6 +25,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
             }),
             await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
@@ -39,6 +40,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
                 const preChatSurveyRes = await chatSDK.getPreChatSurvey();
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -1,10 +1,12 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithPrechat');
+const testSettings = fetchTestSettings('UnauthenticatedChatWithPrechat');
 
 test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
     test('ChatSDK.startChat() with preChatResponse should be part of session init payload', async ({ page }) => {
@@ -24,7 +26,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
+            await page.evaluate(async ({ omnichannelConfig, optionalParams, chatDuration }) => {
                 const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
@@ -41,12 +43,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
 
-                await sleep(2000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, optionalParams })
+            }, { omnichannelConfig, optionalParams, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId, preChatSurvey } = runtimeContext;

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -41,7 +41,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
 
-                await sleep(1000);
+                await sleep(2000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
@@ -55,7 +55,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithChatReconnect', () =>
 
                 await chatSDK.startChat();
 
-                await sleep(1000);
+                await sleep(2000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
@@ -1,10 +1,12 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithChatReconnect');
+const testSettings = fetchTestSettings('UnauthenticatedChatWithChatReconnect');
 
 test.describe('UnauthenticatedChat @UnauthenticatedChatWithChatReconnect', () => {
     test('ChatSDK.getChatReconnectContext() with invalid reconnect id & redirect URL should only return a redirect URL', async ({ page }) => {
@@ -33,7 +35,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithChatReconnect', () =>
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatReConnect);
             }),
-            await page.evaluate(async ({ omnichannelConfig, params }) => {
+            await page.evaluate(async ({ omnichannelConfig, params, chatDuration }) => {
                 const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDKConfig = {
@@ -55,12 +57,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithChatReconnect', () =>
 
                 await chatSDK.startChat();
 
-                await sleep(2000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, params })
+            }, { omnichannelConfig, params, chatDuration: testSettings.chatDuration })
         ]);
 
         const { reconnectId, redirectURL, requestId } = runtimeContext;

--- a/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
@@ -34,6 +34,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithChatReconnect', () =>
                 return response.url().includes(OmnichannelEndpoints.LiveChatReConnect);
             }),
             await page.evaluate(async ({ omnichannelConfig, params }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDKConfig = {
                     chatReconnect: {
@@ -53,6 +54,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithChatReconnect', () =>
                 runtimeContext.requestId = chatSDK.requestId;
 
                 await chatSDK.startChat();
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
@@ -1,10 +1,12 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithTranscripts');
+const testSettings = fetchTestSettings('UnauthenticatedChat');
 
 test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => {
     test('ChatSDK.emailLiveChatTranscript() should not fail', async ({ page }) => {
@@ -17,7 +19,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatTranscriptEmailRequestPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
@@ -37,12 +39,12 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
 
                 await chatSDK.emailLiveChatTranscript(body);
 
-                await sleep(1000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const {requestId} = runtimeContext;
@@ -62,7 +64,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatTranscriptEmailRequestPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
@@ -82,14 +84,14 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                     attachmentMessage: 'Attachment Message'
                 };
 
-                await sleep(1000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
                 await chatSDK.emailLiveChatTranscript(body, {liveChatContext});
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const {requestId, liveChatContext} = runtimeContext;
@@ -112,7 +114,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatv2GetChatTranscriptPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
@@ -130,12 +132,12 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 const transcript = await chatSDK.getLiveChatTranscript();
                 runtimeContext.transcript = transcript;
 
-                await sleep(1000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const {requestId, token, chatId, transcript} = runtimeContext;
@@ -167,7 +169,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatv2GetChatTranscriptPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
@@ -184,7 +186,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 runtimeContext.token = chatSDK.chatToken.token;
                 runtimeContext.chatId = chatSDK.chatToken.chatId;
 
-                await sleep(1000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
@@ -192,7 +194,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 runtimeContext.transcript = transcript;
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const {requestId, token, chatId, transcript} = runtimeContext;

--- a/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
@@ -6,7 +6,7 @@ import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithTranscripts');
-const testSettings = fetchTestSettings('UnauthenticatedChat');
+const testSettings = fetchTestSettings('UnauthenticatedChatWithTranscripts');
 
 test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => {
     test('ChatSDK.emailLiveChatTranscript() should not fail', async ({ page }) => {

--- a/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-transcripts.spec.ts
@@ -18,6 +18,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 return response.url().includes(OmnichannelEndpoints.LiveChatTranscriptEmailRequestPath);
             }),
             await page.evaluate(async ({ omnichannelConfig }) => {
+                const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
@@ -35,6 +36,8 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 };
 
                 await chatSDK.emailLiveChatTranscript(body);
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 
@@ -60,6 +63,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 return response.url().includes(OmnichannelEndpoints.LiveChatTranscriptEmailRequestPath);
             }),
             await page.evaluate(async ({ omnichannelConfig }) => {
+                const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
@@ -77,6 +81,8 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                     emailAddress: 'contoso@microsoft.com',
                     attachmentMessage: 'Attachment Message'
                 };
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 
@@ -107,6 +113,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 return response.url().includes(OmnichannelEndpoints.LiveChatv2GetChatTranscriptPath);
             }),
             await page.evaluate(async ({ omnichannelConfig }) => {
+                const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
@@ -122,6 +129,8 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
 
                 const transcript = await chatSDK.getLiveChatTranscript();
                 runtimeContext.transcript = transcript;
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 
@@ -159,6 +168,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 return response.url().includes(OmnichannelEndpoints.LiveChatv2GetChatTranscriptPath);
             }),
             await page.evaluate(async ({ omnichannelConfig }) => {
+                const {sleep} = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
                 const runtimeContext = {};
@@ -173,6 +183,8 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTranscripts', () => 
                 runtimeContext.requestId = chatSDK.requestId;
                 runtimeContext.token = chatSDK.chatToken.token;
                 runtimeContext.chatId = chatSDK.chatToken.chatId;
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat-with-typing.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-typing.spec.ts
@@ -6,7 +6,7 @@ import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChatWithTyping');
-const testSettings = fetchTestSettings('UnauthenticatedChat');
+const testSettings = fetchTestSettings('UnauthenticatedChatWithTyping');
 
 test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTyping', () => {
     test('ChatSDK.sendTyping() should not fail', async ({ page }) => {

--- a/playwright/integrations/unauthenticated-chat-with-typing.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-typing.spec.ts
@@ -49,6 +49,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTyping', () => {
 
         const [runtimeContext] = await Promise.all([
             await page.evaluate(async ({ omnichannelConfig}) => {
+                const { sleep } = window;
                 const {OmnichannelChatSDK_1: OmnichannelChatSDK} = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -70,6 +71,8 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTyping', () => {
                     runtimeContext.errorMessage = `${err.message}`;
                     runtimeContext.errorObject = `${err}`;
                 }
+
+                await sleep(1000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat-with-typing.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-typing.spec.ts
@@ -72,7 +72,7 @@ test.describe('@UnauthenticatedChat @UnauthenticatedChatWithTyping', () => {
                     runtimeContext.errorObject = `${err}`;
                 }
 
-                await sleep(1000);
+                await sleep(2000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -330,7 +330,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, content, chatDuration: fetchTestSettings.chatDuration })
+            }, { omnichannelConfig, content, chatDuration: testSettings.chatDuration })
         ]);
 
         const { acsEndpoint, chatId } = runtimeContext;
@@ -384,7 +384,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, content, chatDuration: fetchTestSettings.chatDuration })
+            }, { omnichannelConfig, content, chatDuration: testSettings.chatDuration })
         ]);
 
         const { acsEndpoint, chatId } = runtimeContext;

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -1,11 +1,13 @@
 import fetchOmnichannelConfig from '../utils/fetchOmnichannelConfig';
 import fetchTestPageUrl from '../utils/fetchTestPageUrl';
+import fetchTestSettings from '../utils/fetchTestSettings';
 import { test, expect } from '@playwright/test';
 import OmnichannelEndpoints from '../utils/OmnichannelEndpoints';
 import ACSEndpoints from '../utils/ACSEndpoints';
 
 const testPage = fetchTestPageUrl();
 const omnichannelConfig = fetchOmnichannelConfig('UnauthenticatedChat');
+const testSettings = fetchTestSettings('UnauthenticatedChat');
 
 test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
     test('ChatSDK.initialize() should fetch the live chat configuration', async ({ page }) => {
@@ -99,7 +101,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -112,10 +115,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -527,6 +527,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 return response.url().includes("https://unpkg.com/acs_webchat-chat-adapter");
             }),
             await page.evaluate(async ({ omnichannelConfig }) => {
+                const { sleep } = window;
                 const { preloadChatAdapter } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
@@ -546,6 +547,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                     runtimeContext.errorMessage = `${err.message}`;
                     runtimeContext.errorObject = `${err}`;
                 }
+
+                await sleep(3000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -548,7 +548,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                     runtimeContext.errorObject = `${err}`;
                 }
 
-                await sleep(3000);
+                await sleep(1000);
 
                 await chatSDK.endChat();
 

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -149,7 +149,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, customContext }) => {
+            await page.evaluate(async ({ omnichannelConfig, customContext, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -162,10 +163,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
 
                 await chatSDK.startChat({ customContext });
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, customContext })
+            }, { omnichannelConfig, customContext, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;
@@ -298,7 +301,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().match(ACSEndpoints.sendMessagePathPattern)?.length >= 0;
             }),
-            await page.evaluate(async ({ omnichannelConfig, content }) => {
+            await page.evaluate(async ({ omnichannelConfig, content, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -316,10 +320,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                     content
                 });
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, content })
+            }, { omnichannelConfig, content, chatDuration: fetchTestSettings.chatDuration })
         ]);
 
         const { acsEndpoint, chatId } = runtimeContext;
@@ -347,7 +353,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().match(ACSEndpoints.getMessagesPathPattern)?.length >= 0 && response.request().method() === 'GET'
             }),
-            await page.evaluate(async ({ omnichannelConfig, content }) => {
+            await page.evaluate(async ({ omnichannelConfig, content, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -367,10 +374,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
 
                 await chatSDK.getMessages();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig, content })
+            }, { omnichannelConfig, content, chatDuration: fetchTestSettings.chatDuration })
         ]);
 
         const { acsEndpoint, chatId } = runtimeContext;
@@ -498,7 +507,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionClosePath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -511,10 +521,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
 
                 await chatSDK.startChat();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;
@@ -629,7 +641,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -646,10 +659,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
 
                 await chatSDK.startChat(optionalParams);
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestId } = runtimeContext;

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -548,7 +548,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes("https://unpkg.com/acs_webchat-chat-adapter");
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const { sleep } = window;
                 const { preloadChatAdapter } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
@@ -570,12 +570,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                     runtimeContext.errorObject = `${err}`;
                 }
 
-                await sleep(1000);
+                await sleep(chatDuration);
 
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         expect(createChatAdapterResponse.status()).toBe(200);

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -185,7 +185,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         await page.goto(testPage);
 
         const [runtimeContext] = await Promise.all([
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const { sleep } = window;
 
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
@@ -203,6 +203,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
 
                 const liveChatContext = await chatSDK.getCurrentLiveChatContext();
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 await sleep(3000); // Sleep to avoid race condition
@@ -214,7 +216,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 }
 
                 return runtimeContext;
-            }, { omnichannelConfig }),
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration }),
         ]);
 
         const expectedErrorMessage = "ClosedConversation";
@@ -258,7 +260,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatLiveWorkItemDetailsPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK, runtimeContext } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -273,10 +276,12 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                     runtimeContext.errorMessage = `${err.message}`;
                 }
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
 
                 return runtimeContext;
-            }, { omnichannelConfig })
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration })
         ]);
 
         const { requestIdFirstSession: requestId } = runtimeContext;
@@ -736,7 +741,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatLiveWorkItemDetailsPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig }) => {
+            await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
+                const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
 
@@ -751,6 +757,8 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                     liveChatContext
                 };
 
+                await sleep(chatDuration);
+
                 await chatSDK.endChat();
                 runtimeContext.invalidRequestId = chatSDK.requestId;
 
@@ -758,7 +766,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 runtimeContext.invalidRequestIdConversationDetails = invalidRequestIdConversationDetails;
 
                 (window as any).runtimeContext = runtimeContext;
-            }, { omnichannelConfig }),
+            }, { omnichannelConfig, chatDuration: testSettings.chatDuration }),
             page.waitForRequest(request => {
                 return request.url().includes(OmnichannelEndpoints.LiveChatLiveWorkItemDetailsPath);
             }),

--- a/playwright/test.config.sample.yml
+++ b/playwright/test.config.sample.yml
@@ -3,7 +3,7 @@ DefaultSettings:
   orgUrl: ''
   widgetId: ''
   authUrl: ''
-  chatDuration: 3000 # Time to wait before `chatSDK.endChat()` to prevent `sessionclose` failure
+  chatDuration: 5000 # Time to wait before `chatSDK.endChat()` to prevent `sessionclose` failure
 UnauthenticatedChat:
 UnauthenticatedChatWithTyping:
 UnauthenticatedChatWithTranscripts:

--- a/playwright/test.config.sample.yml
+++ b/playwright/test.config.sample.yml
@@ -3,6 +3,7 @@ DefaultSettings:
   orgUrl: ''
   widgetId: ''
   authUrl: ''
+  chatDuration: 3000 # Time to wait before `chatSDK.endChat()` to prevent `sessionclose` failure
 UnauthenticatedChat:
 UnauthenticatedChatWithTyping:
 UnauthenticatedChatWithTranscripts:

--- a/playwright/utils/fetchTestSettings.ts
+++ b/playwright/utils/fetchTestSettings.ts
@@ -4,21 +4,19 @@ const fetchTestSettings = (scenario = "") => {
     const testConfig = fetchTestConfig();
     scenario = scenario? scenario: "DefaultSettings";
 
-    const testSettings: any = {};  // eslint-disable-line @typescript-eslint/no-explicit-any
-    testSettings.chatDuration = 3000;
+    let chatDuration = testConfig["DefaultSettings"].chatDuration || 3000;
 
     if (!scenario) {
-        return testSettings;  // eslint-disable-line @typescript-eslint/no-explicit-any
+        return {chatDuration};
     }
 
     if (!Object.keys(testConfig).includes(scenario)) {
-        return testSettings;
+        return {chatDuration};
     }
 
     // Overwrite value only if it exists
-    testSettings.chatDuration = testConfig[scenario]?.chatDuration || testSettings.chatDuration;
-
-    return testSettings;
+    chatDuration = testConfig[scenario]?.chatDuration || chatDuration;
+    return {chatDuration};
 }
 
 export default fetchTestSettings;

--- a/playwright/utils/fetchTestSettings.ts
+++ b/playwright/utils/fetchTestSettings.ts
@@ -1,0 +1,24 @@
+import fetchTestConfig from "./fetchTestConfig";
+
+const fetchTestSettings = (scenario = "") => {
+    const testConfig = fetchTestConfig();
+    scenario = scenario? scenario: "DefaultSettings";
+
+    const testSettings: any = {};  // eslint-disable-line @typescript-eslint/no-explicit-any
+    testSettings.chatDuration = 3000;
+
+    if (!scenario) {
+        return testSettings;  // eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+
+    if (!Object.keys(testConfig).includes(scenario)) {
+        return testSettings;
+    }
+
+    // Overwrite value only if it exists
+    testSettings.chatDuration = testConfig[scenario]?.chatDuration || testSettings.chatDuration;
+
+    return testSettings;
+}
+
+export default fetchTestSettings;

--- a/playwright/utils/fetchTestSettings.ts
+++ b/playwright/utils/fetchTestSettings.ts
@@ -4,7 +4,7 @@ const fetchTestSettings = (scenario = "") => {
     const testConfig = fetchTestConfig();
     scenario = scenario? scenario: "DefaultSettings";
 
-    let chatDuration = testConfig["DefaultSettings"].chatDuration || 3000;
+    let chatDuration = testConfig["DefaultSettings"].chatDuration || 5000;
 
     if (!scenario) {
         return {chatDuration};


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference
Task: #4329297

### Description

- Fix Playwright Integrations Tests
- Tests were running "too fast"
- Calling `ChatSDK.startChat()` then `ChatSDK.endChat()` too quickly would cause failures on `sessionclose` given that the `LiveWorkItem` may not be fully created and available to be retrieved from the DB

## Solution Proposed

- Added a configurable setting `chatDuration` to mimic the scenario of a normal person chatting would resolve the issue

### Acceptance criteria

- Integration tests should be more reliable 

## Test cases and evidence
- Ran the integration tests with 100% success rate

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
