### PR TITLE
adding new versioning logic for calling bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added to new versioned path to callingbundle.js
 ## [1.9.6]
 
 ### Added

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -100,6 +100,7 @@ import retrieveCollectorUri from "./telemetry/retrieveCollectorUri";
 import setOcUserAgent from "./utils/setOcUserAgent";
 import urlResolvers from "./utils/urlResolvers";
 import validateOmnichannelConfig from "./validators/OmnichannelConfigValidator";
+import { callingBundleVersion } from "./config/settings";
 
 class OmnichannelChatSDK {
     private debug: boolean;
@@ -1784,7 +1785,7 @@ class OmnichannelChatSDK {
         if (result && result.length) {
             return new Promise(async (resolve) => { // eslint-disable-line no-async-promise-executor
                 // When there is new calling version, release new omni-channel chat sdk version with updated calling version
-                const LiveChatWidgetLibCDNUrl = `${result[1]}/livechatwidget/v2scripts/callingsdk/1.0.20240809-2/CallingBundle.js`;
+                const LiveChatWidgetLibCDNUrl = `${result[1]}/livechatwidget/v2scripts/callingsdk/${callingBundleVersion}/CallingBundle.js`;
 
                 this.telemetry?.setCDNPackages({
                     VoiceVideoCalling: LiveChatWidgetLibCDNUrl

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1783,7 +1783,8 @@ class OmnichannelChatSDK {
         const result = msdyn_widgetsnippet.match(widgetSnippetSourceRegex);
         if (result && result.length) {
             return new Promise(async (resolve) => { // eslint-disable-line no-async-promise-executor
-                const LiveChatWidgetLibCDNUrl = `${result[1]}/livechatwidget/WebChatControl/lib/CallingBundle.js`;
+                // When there is new calling version, release new omni-channel chat sdk version with updated calling version
+                const LiveChatWidgetLibCDNUrl = `${result[1]}/livechatwidget/v2scripts/callingsdk/1.0.20240809-2/CallingBundle.js`;
 
                 this.telemetry?.setCDNPackages({
                     VoiceVideoCalling: LiveChatWidgetLibCDNUrl

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -2,6 +2,7 @@ const ic3ClientVersion = '2021.08.14.1';
 const webChatIC3AdapterVersion = '0.1.0-master.2dba07b';
 const webChatACSAdapterVersion = '0.0.35-beta.20';
 const webChatDirectLineVersion = '0.15.1';
+const callingBundleVersion = '1.0.20240809-2s';
 const ariaTelemetryKey = 'c7655518acf1403f93ff6b9f77942f0a-d01a02fd-6b50-4de3-a566-62eda11f93bc-7083';
 
 export {
@@ -9,5 +10,6 @@ export {
     webChatIC3AdapterVersion,
     webChatACSAdapterVersion,
     webChatDirectLineVersion,
-    ariaTelemetryKey
+    ariaTelemetryKey,
+    callingBundleVersion
 };

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -2,7 +2,7 @@ const ic3ClientVersion = '2021.08.14.1';
 const webChatIC3AdapterVersion = '0.1.0-master.2dba07b';
 const webChatACSAdapterVersion = '0.0.35-beta.20';
 const webChatDirectLineVersion = '0.15.1';
-const callingBundleVersion = '1.0.20240809-2s';
+const callingBundleVersion = '1.0.20240809-2';
 const ariaTelemetryKey = 'c7655518acf1403f93ff6b9f77942f0a-d01a02fd-6b50-4de3-a566-62eda11f93bc-7083';
 
 export {


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

This is to make sure that omnichannel-chat-sdk callingbundle dependency is tied to specific version so that clients do not break when there is an update to callingBundle.


## Solution Proposed

LCW pipeline added versioned folder for upcoming callingBundle.

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
