### PR TITLE
Adding params to  close session - on hold while talking with backend team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Adding optional params for endchat, to prevent calls to session close for sessions ended by agent
 
 - Added to new versioned path to callingbundle.js
+
 ## [1.9.6]
 
 ### Added
@@ -23,6 +24,7 @@ All notable changes to this project will be documented in this file.
 ## [1.9.5]
 
 ### Security
+
 - Uptake [@microsoft/ocsdk@0.5.5](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.5)
 - Uptake [@microsoft/omnichannel-ic3core@0.1.4](https://www.npmjs.com/package/@microsoft/omnichannel-ic3core/v/0.1.4)
 
@@ -30,6 +32,7 @@ All notable changes to this project will be documented in this file.
 ## [1.9.3] - 2024-07-12
 
 ### Added
+
 - Add `crm9` as part of `CoreServicesGeoNamesMapping`
 
 ### Changed
@@ -62,6 +65,7 @@ All notable changes to this project will be documented in this file.
 ## [1.8.3] - 2024-05-15
 
 ### Added
+
 - Add `RequestHeaders` telemetry base property to `OCSDKContract`
 - Add ability to send `ocUserAgent`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Adding optional params for endchat, to prevent calls to session close for sessions ended by agent
+
 ## [1.9.6]
 
 ### Added

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3141,7 +3141,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
             const optionalParams = {
-                isEndedByAgent: true
+                isEndedByAgentOrDisconnected: true
             }
             await chatSDK.endChat(optionalParams);
 
@@ -3173,7 +3173,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
             const optionalParams = {
-                isEndedByAgent: false
+                isEndedByAgentOrDisconnected: false
             }
             await chatSDK.endChat(optionalParams);
 

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3120,6 +3120,102 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
+        it('ChatSDK.endChat() should not call close session, because of conversation was ended by agent', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            const optionalParams = {
+                isEndedByAgent: true
+            }
+            await chatSDK.endChat(optionalParams);
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(0);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+        it('ChatSDK.endChat() should call close session ', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            const optionalParams = {
+                isEndedByAgent: false
+            }
+            await chatSDK.endChat(optionalParams);
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+        it('ChatSDK.endChat() should call close session, with empty optional params', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            const optionalParams = {
+                
+            }
+            await chatSDK.endChat(optionalParams);
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
         it('ChatSDK.endChat() should fail if OCClient.sessionClose() fails', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -572,7 +572,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 await sleep(chatDuration);
 
                 const optionalParams = {
-                    isEndedByAgent: true
+                    isEndedByAgentOrDisconnected: true
                 };
 
                await chatSDK.endChat(optionalParams);
@@ -617,7 +617,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
                 await sleep(chatDuration);
 
                 const optionalParams = {
-                    isEndedByAgent: false
+                    isEndedByAgentOrDisconnected: false
                 };
 
                 await chatSDK.endChat(optionalParams);

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -593,8 +593,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         let sessionCloseRequestMade = false;
         await page.goto(testPage);
 
- 
-            await Promise.all([page.waitForRequest(request => {
+             await Promise.all([page.waitForRequest(request => {
                 if (request.url().includes(OmnichannelEndpoints.LiveChatSessionClosePath)) {
                     sessionCloseRequestMade = true;
                     return true;

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -32,6 +32,7 @@ import ChatTranscriptBody from "./core/ChatTranscriptBody";
 import ConversationMode from "./core/ConversationMode";
 import DeliveryMode from "@microsoft/omnichannel-ic3core/lib/model/DeliveryMode";
 import EmailLiveChatTranscriptOptionaParams from "./core/EmailLiveChatTranscriptOptionalParams";
+import EndChatOptionalParams from "./core/EndChatOptionalParams";
 import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
 import FileSharingProtocolType from "@microsoft/omnichannel-ic3core/lib/model/FileSharingProtocolType";
 import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
@@ -778,7 +779,7 @@ class OmnichannelChatSDK {
         }
     }
 
-    public async endChat(): Promise<void> {
+    public async endChat(optionalParams?: EndChatOptionalParams): Promise<void> {
         this.scenarioMarker.startScenario(TelemetryEvent.EndChat, {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
@@ -804,13 +805,19 @@ class OmnichannelChatSDK {
         }
 
         try {
-            await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
+            console.log("ELOPEZANAYA :: endchat :: sessionCloseOptionalParams", sessionCloseOptionalParams);
+           
+            //no need to call session close since is already ended by agent, this way we avoid the error
+            if (optionalParams?.isEndedByAgent !== true) {
+                await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
+            }
 
+            
             this.scenarioMarker.completeScenario(TelemetryEvent.EndChat, {
                 RequestId: this.requestId,
                 ChatId: this.chatToken.chatId as string
             });
-
+            
             this.conversation?.disconnect();
             this.conversation = null;
             this.requestId = uuidv4();

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -805,13 +805,10 @@ class OmnichannelChatSDK {
         }
 
         try {
-            console.log("ELOPEZANAYA :: endchat :: sessionCloseOptionalParams", sessionCloseOptionalParams);
-           
             //no need to call session close since is already ended by agent, this way we avoid the error
             if (optionalParams?.isEndedByAgent !== true) {
                 await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
             }
-
             
             this.scenarioMarker.completeScenario(TelemetryEvent.EndChat, {
                 RequestId: this.requestId,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -85,6 +85,7 @@ import ScenarioMarker from "./telemetry/ScenarioMarker";
 import SetAuthTokenProviderOptionalParams from "./core/SetAuthTokenProviderOptionalParams";
 import StartChatOptionalParams from "./core/StartChatOptionalParams";
 import TelemetryEvent from "./telemetry/TelemetryEvent";
+import { callingBundleVersion } from "./config/settings";
 import createAMSClient from "@microsoft/omnichannel-amsclient";
 import createOcSDKConfiguration from "./utils/createOcSDKConfiguration";
 import createOmnichannelMessage from "./utils/createOmnichannelMessage";
@@ -101,7 +102,6 @@ import retrieveCollectorUri from "./telemetry/retrieveCollectorUri";
 import setOcUserAgent from "./utils/setOcUserAgent";
 import urlResolvers from "./utils/urlResolvers";
 import validateOmnichannelConfig from "./validators/OmnichannelConfigValidator";
-import { callingBundleVersion } from "./config/settings";
 
 class OmnichannelChatSDK {
     private debug: boolean;
@@ -807,7 +807,7 @@ class OmnichannelChatSDK {
 
         try {
             //no need to call session close since is already ended by agent, this way we avoid the error
-            if (optionalParams?.isEndedByAgent !== true) {
+            if (optionalParams?.isEndedByAgentOrDisconnected !== true) {
                 await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
             }
             

--- a/src/core/EndChatOptionalParams.ts
+++ b/src/core/EndChatOptionalParams.ts
@@ -1,4 +1,4 @@
 
 export default interface EndChatOptionalParams {
-    isEndedByAgent?: boolean;
+    isEndedByAgentOrDisconnected?: boolean;
 }

--- a/src/core/EndChatOptionalParams.ts
+++ b/src/core/EndChatOptionalParams.ts
@@ -1,0 +1,4 @@
+
+export default interface EndChatOptionalParams {
+    isEndedByAgent?: boolean;
+}


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description
_Include a description of the problem to be solved_

For conversations ended by agent, when calling close chat session endpoint it throws an exception, since the conversation is already closed , its throwing an exception which is logged and being taking in account by monitors.


## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

- passing the flag to indentify when a chat was ended by agent to do not call the endpoint , but stll be able to perform cleanup tasks required for new sessions.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
## Test cases and evidence

When session was not ended by customer, dont call close session endpoitn

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

#### calling end chat without params , expected to call close session endpoint

![image](https://github.com/user-attachments/assets/2b3b4f93-b74c-4109-b195-c006e2b3f03e)

#### calling end chat with params, not calling close session endpoint

![image](https://github.com/user-attachments/assets/3733d3fd-2145-4ca5-817c-91814a2e970e)

![image](https://github.com/user-attachments/assets/70bca4ed-5d76-4c11-8270-b60830e4ec68)



- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
