### PR TITLE
Fix Reconnectable Chats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `requestId` to `OCClient.getReconnectableChats()` parameters
+
 ## [1.10.0] - 2024-10-31
 
 ### Changed

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -419,7 +419,8 @@ class OmnichannelChatSDK {
 
         try {
             const reconnectableChatsParams: IReconnectableChatsParams = {
-                authenticatedUserToken: this.authenticatedUserToken as string
+                authenticatedUserToken: this.authenticatedUserToken as string,
+                requestId: this.requestId as string
             }
 
             const reconnectableChatsResponse = await this.OCClient.getReconnectableChats(reconnectableChatsParams);
@@ -552,7 +553,8 @@ class OmnichannelChatSDK {
         if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
             try {
                 const reconnectableChatsParams: IReconnectableChatsParams = {
-                    authenticatedUserToken: this.authenticatedUserToken as string
+                    authenticatedUserToken: this.authenticatedUserToken as string,
+                    requestId: this.requestId as string
                 }
 
                 const reconnectableChatsResponse = await this.OCClient.getReconnectableChats(reconnectableChatsParams);


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference
Bug #4292896

### Description
- Add `requestId` to  `OCClient.getReconnectableChats()` parameters to update API with `requestId` instead of `orgId`