### PR TITLE
End Chat Optional Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - uptake [azure/communication-chat@1.5.0](https://www.npmjs.com/package/@azure/communication-chat/v/1.5.0)
 - uptake [azure/communication-common@2.3.1](https://www.npmjs.com/package/@azure/communication-common/v/2.3.1)
 - uptake [acs_webchat-chat-adapter@0.0.35-beta.30](https://www.npmjs.com/package/acs_webchat-chat-adapter/v/0.0.35-beta.30)
+- Uptake [@microsoft/ocsdk@0.5.9](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.9)
 
 ## [1.10.1] - 2024-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- New soft end method, which will allow to cleanup internal properties without calling close session, specific designed for disconnection or when agent ends the chat.
+- Adding optional params for end chat to allow decide internally when to call close session backend.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- New soft end method, which will allow to cleanup internal properties without calling close session, specific designed for disconnection or when agent ends the chat.
+
 ### Changed
 
 - uptake [azure/communication-chat@1.5.0](https://www.npmjs.com/package/@azure/communication-chat/v/1.5.0)

--- a/__tests__/OmnichannelChatSDK.node.spec.ts
+++ b/__tests__/OmnichannelChatSDK.node.spec.ts
@@ -6,8 +6,8 @@
 import * as settings from '../src/config/settings';
 
 import { AWTLogManager } from "../src/external/aria/webjs/AriaSDK";
-import AriaTelemetry from "../src/telemetry/AriaTelemetry";
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
 
 describe('Omnichannel Chat SDK (Node), Sequential', () => {
@@ -24,21 +24,21 @@ describe('Omnichannel Chat SDK (Node), Sequential', () => {
         if (global.navigator) {
             (global as any).navigator = undefined;
         }
-        
+
         if (global.window.document) {
             (global as any).window.document = undefined;
         }
-        
+
         jest.clearAllMocks();
     });
 
     it('ChatSDK.startChat() with sendDefaultInitContext should not work on non-browser platform', async () => {
-        
+
         const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
         chatSDK.getChatConfig = jest.fn();
 
         await chatSDK.initialize();
-        
+
         chatSDK.IC3Client = {
             initialize: jest.fn(),
             joinConversation: jest.fn()

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3130,7 +3130,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
-        it('ChatSDK.endChat() should end conversation without calling closeSession', async () => {
+        it('ChatSDK.endChat() with optional params \'isSessionEnded\' set as \'true\' should not call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -3161,7 +3161,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
-        it('ChatSDK.endChat() should end conversation passing optional params', async () => {
+        it('ChatSDK.endChat() with optional params \'isSessionEnded\' set as \'false\' should call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -3192,7 +3192,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
-        it('ChatSDK.endChat() should end conversation passing optional params as undefined', async () => {
+        it('ChatSDK.endChat() with optional params \'isSessionEnded\' set as \'undefined\' should call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3101,7 +3101,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.IC3Client).toBe(null);
         });
 
-
         it('ChatSDK.endChat() should end conversation', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
@@ -3123,6 +3122,99 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
             await chatSDK.endChat();
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+        it('ChatSDK.endChat() should end conversation without calling closeSession', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({
+                isSessionEnded: true
+            });
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(0);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+        it('ChatSDK.endChat() should end conversation passing optional params', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({
+                isSessionEnded: false
+            });
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+        it('ChatSDK.endChat() should end conversation passing optional params as undefined', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({
+                isSessionEnded: undefined
+            });
 
             expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
             expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -1,4 +1,6 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
 
 import { defaultLocaleId, getLocaleStringFromId } from "../src/utils/locale";
@@ -35,7 +37,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
         if (global.navigator) {
             (global as any).navigator = undefined;
         }
-        
+
         if (global.window.document) {
             (global as any).window.document = undefined;
         }
@@ -423,6 +425,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             await chatSDK.initialize();
 
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const version = require("../package.json").version;
             const userAgent = `omnichannel-chat-sdk/${version}`;
             const expectedResult = [userAgent];
@@ -446,6 +449,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             await chatSDK.initialize();
 
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const version = require("../package.json").version;
             const userAgent = `omnichannel-chat-sdk/${version}`;
             const expectedResult = [...chatSDKConfig.ocUserAgent, userAgent];
@@ -867,7 +871,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.setAuthTokenProvider).toHaveBeenCalledTimes(2);
             expect(chatSDK.scenarioMarker.failScenario).toHaveBeenCalledTimes(2);
             expect(exceptionDetails.response).toBe(expectedResponse);
-        });        
+        });
 
         it('Authenticated Chat with liveChatContext should call OCClient.validateAuthChatRecord()', async () => {
             const chatSDKConfig = {
@@ -1109,7 +1113,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.OCClient.sessionInit).toHaveBeenCalledTimes(1);
         });
 
-
         it('ChatSDK.startChat() should not call OCClient.sessionInit() if OCClient.getChatToken() fails', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
@@ -1316,7 +1319,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
         });
 
         it('ChatSDK.startchat() with existing liveChatContext should not call OCClient.getChatToken() & OCClient.sessionInit()', async() => {
-            
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
 
@@ -1654,7 +1656,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             chatSDK.liveChatVersion = LiveChatVersion.V1;
 
             const oldGetChatConfig = chatSDK.getChatConfig;
-            
+
             chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize();
@@ -1688,7 +1690,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             chatSDK.getChatConfig = oldGetChatConfig;
 
             await chatSDK.getChatConfig();
-            
+
             chatSDK.liveChatVersion = LiveChatVersion.V1;
 
             await chatSDK.startChat({});
@@ -1873,7 +1875,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.OCClient, 'getLWIDetails').mockRejectedValue(new Error('Async error message'));
             const conversationDetails = await chatSDK.getConversationDetails();
-           
+
             expect(conversationDetails).toEqual({});
             expect(chatSDK.OCClient.getLWIDetails).toHaveBeenCalledTimes(1);
         });
@@ -1965,7 +1967,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.OCClient.getLWIDetails).toHaveBeenCalledTimes(1);
             expect(chatSDK.OCClient.getLWIDetails.mock.calls[0][1].reconnectId).toMatch(chatSDK.reconnectId);
         });
-
 
         it('[LiveChatV1] ChatSDK.getConversationDetails() should pass reconnectId to OCClient.getLWIDetails() if any on Persistent Chat', async () => {
             const chatSDKConfig = {
@@ -2078,7 +2079,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.conversation.getMessages).toHaveBeenCalledTimes(1);
         });
 
-
         it('ChatSDK.getMessages() should call conversation.getMessages()', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
@@ -2107,7 +2107,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.conversation.getMessages).toHaveBeenCalledTimes(1);
         });
 
-
         it('[LiveChatV1] ChatSDK.sendMessage() should mask characters if enabled', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
@@ -2123,6 +2122,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendMessage: (message: any) => {}
             }));
 
@@ -2147,8 +2147,9 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             const regex = new RegExp(chatSDK.dataMaskingRules.SSN as string, 'g');
             let match;
             let {content} = messageToSend;
+            // eslint-disable-next-line no-cond-assign
             while (match = regex.exec(content)) {
-                let replaceStr = match[0].replace(/./g, chatSDK.chatSDKConfig.dataMasking.maskingCharacter);
+                const replaceStr = match[0].replace(/./g, chatSDK.chatSDKConfig.dataMasking.maskingCharacter);
                 content = content.replace(match[0], replaceStr);
             }
 
@@ -2174,6 +2175,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendMessage: (message: any) => {}
             }));
 
@@ -2217,6 +2219,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendMessage: (message: any) => {}
             }));
 
@@ -2248,6 +2251,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendMessage: (message: any) => {}
             }));
 
@@ -2312,8 +2316,10 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 indicateTypingStatus: (value: number) => {},
                 getMembers: () => {},
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendMessageToBot: (botId: string, message: any) => {}
             }));
 
@@ -2348,8 +2354,10 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 indicateTypingStatus: (value: number) => {},
                 getMembers: () => {},
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendMessageToBot: (botId: string, message: any) => {}
             }));
 
@@ -2420,7 +2428,9 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.IC3Client, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.IC3Client, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendFileData: (fileInfo: IFileInfo, fileSharingProtocolType: FileSharingProtocolType) => {},
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 sendFileMessage: (fileMetaData: IFileMetadata, message: IMessage) => {}
             }));
 
@@ -2468,7 +2478,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
         });
 
         it('[LiveChatV1] ChatSDK.downloadFileAttachment() should call conversation.downloadFile()', async() => {
-            
+
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2645,35 +2655,33 @@ describe('Omnichannel Chat SDK, Sequential', () => {
                 orgId: '[data-org-id]',
                 widgetId: '[data-app-id]'
             };
-    
+
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
-    
+
             await chatSDK.initialize();
-    
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
             chatSDK.AMSClient.initialize = jest.fn();
-    
+
             const chatToken = {
                 ChatId: 'ChatId',
                 Token: 'Token',
                 RegionGtms: '{}'
             };
-    
             jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve(chatToken));
             jest.spyOn(chatSDK.OCClient, 'sessionInit').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.OCClient, 'emailTranscript').mockResolvedValue(Promise.resolve());
-    
+
             const body = {
                 emailAddress: "contoso@microsoft.com",
                 attachmentMessage: "attachmentMessage",
                 locale: "locale"
             };
-    
+
             await chatSDK.startChat();
             await chatSDK.emailLiveChatTranscript(body);
-    
+
             const liveChatContext = {
                 requestId: 'requestId',
                 chatToken: {
@@ -2681,9 +2689,9 @@ describe('Omnichannel Chat SDK, Sequential', () => {
                     token: 'token'
                 }
             }
-    
+
             await chatSDK.emailLiveChatTranscript(body, {liveChatContext});
-            
+
             expect(chatSDK.OCClient.emailTranscript).toHaveBeenCalledTimes(2);
             expect(chatSDK.OCClient.emailTranscript.mock.calls[0][0]).toBe(chatSDK.requestId);
             expect(chatSDK.OCClient.emailTranscript.mock.calls[0][1]).toBe(chatToken.Token);
@@ -2693,8 +2701,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.OCClient.emailTranscript.mock.calls[1][2].ChatId).toBe(liveChatContext.chatToken.chatId);
             expect(chatSDK.OCClient.emailTranscript.mock.calls[1][0]).not.toBe(chatSDK.requestId);
             expect(chatSDK.OCClient.emailTranscript.mock.calls[1][1]).not.toBe(chatToken.Token);
-            expect(chatSDK.OCClient.emailTranscript.mock.calls[1][2].ChatId).not.toBe(chatToken.ChatId);        
-        });        
+        });
 
         it('ChatSDK.getLiveChatTranscript() should call OCClient.getChatTranscripts()', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -2815,8 +2822,11 @@ describe('Omnichannel Chat SDK, Sequential', () => {
         });
 
         it('[LiveChatV1] ChatSDK.getIC3Client() should return IC3Core if platform is Node', async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const IC3SDKProvider = require('@microsoft/omnichannel-ic3core').SDKProvider;
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const platform = require('../src/utils/platform').default;
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const HostType = require('@microsoft/omnichannel-ic3core/lib/interfaces/HostType').default;
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -2840,8 +2850,11 @@ describe('Omnichannel Chat SDK, Sequential', () => {
         });
 
         it('[LiveChatV1] ChatSDK.getIC3Client() should return IC3Core if platform is RN', async () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const IC3SDKProvider = require('@microsoft/omnichannel-ic3core').SDKProvider;
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const platform = require('../src/utils/platform').default;
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const HostType = require('@microsoft/omnichannel-ic3core/lib/interfaces/HostType').default;
 
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -3674,7 +3687,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(context.reconnectId).toBe(mockedResponse.reconnectid);
         });
 
-
         it('ChatSDK.getChatReconnectContext() with authenticatedUserToken should not call OCClient.getReconnectableChats() & return redirectURL due to expired token', async () => {
             const chatSDKConfig = {
                 telemetry: {
@@ -3754,7 +3766,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(1);
             expect(context.reconnectId).toBe(mockedResponse.reconnectid);
         });
-
 
         it('ChatSDK.getChatReconnectContext() should pass reconnectId to OCClient.getReconnectAvailability() & return reconnectId if valid & return redirectUrl with "null"', async () => {
             const chatSDKConfig = {
@@ -3915,7 +3926,8 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             try {
                 await chatSDK.getPostChatSurveyContext();
-                fail();            } catch (ex) {
+                fail();
+            } catch (ex) {
                 expect(chatSDK.getConversationDetails).not.toHaveBeenCalled();
             }
         });
@@ -4053,12 +4065,11 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             });
             jest.spyOn(console, 'error');
 
-            
-                const postChatContext = await chatSDK.getPostChatSurveyContext();
-                expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);
-                expect(chatSDK.OCClient.getSurveyInviteLink).toHaveBeenCalledTimes(1);
-                expect(postChatContext.participantJoined).toBe(true);
-            
+            const postChatContext = await chatSDK.getPostChatSurveyContext();
+            expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);
+            expect(chatSDK.OCClient.getSurveyInviteLink).toHaveBeenCalledTimes(1);
+            expect(postChatContext.participantJoined).toBe(true);
+
         });
 
         it('ChatSDK.getPostChatSurveyContext() should resolve if survey response is valid and CanRenderPostChat is null', async () => {
@@ -4102,12 +4113,11 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             });
             jest.spyOn(console, 'error');
 
-           
-                const postChatContext = await chatSDK.getPostChatSurveyContext();
-                expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);
-                expect(chatSDK.OCClient.getSurveyInviteLink).toHaveBeenCalledTimes(1);
-                expect(postChatContext.participantJoined).toBeFalsy();
-           
+            const postChatContext = await chatSDK.getPostChatSurveyContext();
+            expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);
+            expect(chatSDK.OCClient.getSurveyInviteLink).toHaveBeenCalledTimes(1);
+            expect(postChatContext.participantJoined).toBeFalsy();
+
         });
 
         it('ChatSDK.getPostChatSurveyContext() should resolve if bot survey is being used', async () => {
@@ -4156,18 +4166,18 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             });
             jest.spyOn(console, 'error');
 
-                const postChatContext = await chatSDK.getPostChatSurveyContext();
-                expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);
-                expect(chatSDK.OCClient.getSurveyInviteLink).toHaveBeenCalledWith("2", {
-                    "FormId": "1",
-                    "ConversationId": "convId",
-                    "OCLocaleCode": "en-us",
-                    "SurveyProvider": "MCS",
-                    "WidgetId": "[data-app-id]"
-                },
-                expect.any(Object));
-                expect(postChatContext.participantJoined).toBeTruthy();
-                expect(postChatContext.participantType).toBe("Bot");
+            const postChatContext = await chatSDK.getPostChatSurveyContext();
+            expect(chatSDK.getConversationDetails).toHaveBeenCalledTimes(1);
+            expect(chatSDK.OCClient.getSurveyInviteLink).toHaveBeenCalledWith("2", {
+                "FormId": "1",
+                "ConversationId": "convId",
+                "OCLocaleCode": "en-us",
+                "SurveyProvider": "MCS",
+                "WidgetId": "[data-app-id]"
+            },
+            expect.any(Object));
+            expect(postChatContext.participantJoined).toBeTruthy();
+            expect(postChatContext.participantType).toBe("Bot");
         });
 
         it('ChatSDK.getAgentAvailability() should throw error if conversation already started', async () => {
@@ -4245,12 +4255,11 @@ describe('Omnichannel Chat SDK, Sequential', () => {
                 isAgentAvailable: true
             });
 
-            
-                const agentAvailability = await chatSDK.getAgentAvailability();
-                expect(agentAvailability).toEqual({
-                    isAgentAvailable: true
-                });
-            
+            const agentAvailability = await chatSDK.getAgentAvailability();
+            expect(agentAvailability).toEqual({
+                isAgentAvailable: true
+            });
+
         });
     });
 })

--- a/__tests__/OmnichannelChatSDK.web.spec.ts
+++ b/__tests__/OmnichannelChatSDK.web.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @jest-environment jsdom

--- a/__tests__/OmnichannelChatSDKParallel.node.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.node.spec.ts
@@ -24,11 +24,11 @@ describe('Omnichannel Chat SDK (Node) Parallel initialization', () => {
         if (global.navigator) {
             (global as any).navigator = undefined;
         }
-        
+
         if (global.window.document) {
             (global as any).window.document = undefined;
         }
-        
+
         jest.clearAllMocks();
     });
 

--- a/__tests__/OmnichannelChatSDKParallel.node.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.node.spec.ts
@@ -6,8 +6,8 @@
 import * as settings from '../src/config/settings';
 
 import { AWTLogManager } from "../src/external/aria/webjs/AriaSDK";
-import AriaTelemetry from "../src/telemetry/AriaTelemetry";
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
 
 describe('Omnichannel Chat SDK (Node) Parallel initialization', () => {

--- a/__tests__/OmnichannelChatSDKParallel.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
 
-import { SDKProvider, uuidv4 } from "@microsoft/ocsdk";
 import { defaultLocaleId, getLocaleStringFromId } from "../src/utils/locale";
 
 import { AWTLogManager } from "../src/external/aria/webjs/AriaSDK";
@@ -9,9 +9,9 @@ import AriaTelemetry from "../src/telemetry/AriaTelemetry";
 import ChatAdapterProtocols from "../src/core/messaging/ChatAdapterProtocols";
 import ConversationMode from '../src/core/ConversationMode';
 import OmnichannelErrorCodes from "../src/core/OmnichannelErrorCodes";
+import { SDKProvider } from "@microsoft/ocsdk";
 import { defaultChatSDKConfig } from "../src/validators/SDKConfigValidators";
 import libraries from "../src/utils/libraries";
-import sleep from "../src/utils/sleep";
 
 describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
@@ -31,7 +31,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
         if (global.navigator) {
             (global as any).navigator = undefined;
         }
-        
+
         if (global.window.document) {
             (global as any).window.document = undefined;
         }
@@ -374,6 +374,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize({ useParallelLoad: true });
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const version = require("../package.json").version;
             const userAgent = `omnichannel-chat-sdk/${version}`;
             const expectedResult = [userAgent];
@@ -396,6 +397,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             chatSDK.getChatConfig = jest.fn();
 
             await chatSDK.initialize({ useParallelLoad: true });
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
             const version = require("../package.json").version;
             const userAgent = `omnichannel-chat-sdk/${version}`;
             const expectedResult = [...chatSDKConfig.ocUserAgent, userAgent];
@@ -505,7 +507,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             };
 
             await chatSDK.initialize(
-
                 {
                     useParallelLoad: true,
                     getLiveChatConfigOptionalParams
@@ -851,7 +852,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve({
                 ChatId: '',
                 Token: '',
@@ -971,7 +971,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve({
                 ChatId: '',
                 Token: '',
@@ -1008,7 +1007,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
             chatSDK.AMSClient.initialize = jest.fn();
@@ -1030,7 +1028,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             expect(chatSDK.OCClient.sessionInit).toHaveBeenCalledTimes(1);
         });
-
 
         it('ChatSDK.startChat() should not call OCClient.sessionInit() if OCClient.getChatToken() fails', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
@@ -1062,7 +1059,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
@@ -1180,7 +1176,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve({
                 ChatId: '',
                 Token: '',
@@ -1216,7 +1211,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve({
                 ChatId: '',
@@ -1395,7 +1389,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.getChatConfig).toHaveBeenCalledTimes(1);
         });
 
-
         it("ChatSDK.startChat() with an unsupported locale should throw an exception", async () => {
             const omnichannelConfig = {
                 orgUrl: '[data-org-url]',
@@ -1415,7 +1408,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
@@ -1445,7 +1437,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.IC3Client = {
                 initialize: jest.fn(),
@@ -1479,7 +1470,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.IC3Client = {
                 initialize: jest.fn(),
@@ -1544,7 +1534,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
             chatSDK.AMSClient.initialize = jest.fn();
@@ -1601,7 +1590,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
             chatSDK.AMSClient.initialize = jest.fn();
@@ -1629,8 +1617,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.OCClient.getLWIDetails.mock.calls[0][1].reconnectId).toMatch(chatSDK.reconnectId);
         });
 
-
-
         it("ChatSDK.getConversationDetails() with liveChatContext should fetch conversation details from liveChatContext", async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
@@ -1643,7 +1629,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
@@ -1690,7 +1675,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             chatSDK.OCClient = {
                 sessionInit: jest.fn()
             }
@@ -1701,6 +1685,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             jest.spyOn(chatSDK.ACSClient, 'initialize').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.ACSClient, 'joinConversation').mockResolvedValue(Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
                 getMessages: () => { }
             }));
 
@@ -1725,7 +1710,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.OCClient = {
                 sessionInit: jest.fn(),
@@ -1766,7 +1750,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             chatSDK.OCClient = {
                 sessionInit: jest.fn(),
                 sendTypingIndicator: jest.fn()
@@ -1801,7 +1784,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.OCClient = {
                 sessionInit: jest.fn()
@@ -1841,7 +1823,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.OCClient = {
                 sessionInit: jest.fn()
@@ -1915,7 +1896,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 await new Promise(resolve => setTimeout(resolve, 2000));
                 retryCount++;
             }
-
 
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
@@ -2227,6 +2207,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             await chatSDK.startChat();
 
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
             await chatSDK.onNewMessage(() => { });
 
             expect(chatSDK.conversation.registerOnNewMessage).toHaveBeenCalledTimes(1);
@@ -2271,6 +2252,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             jest.spyOn(chatSDK, 'getMessages').mockResolvedValue(messages);
 
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
             await chatSDK.onNewMessage(() => { }, { rehydrate: true });
 
             expect(chatSDK.getMessages).toHaveBeenCalledTimes(1);
@@ -2304,6 +2286,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             const count = 3;
             for (let i = 0; i < count; i++) {
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
                 chatSDK.onNewMessage(() => { });
             }
 
@@ -2332,6 +2315,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             const count = 3;
             for (let i = 0; i < count; i++) {
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
                 chatSDK.onAgentEndSession(() => { });
             }
 
@@ -2374,7 +2358,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
-        it('ChatSDK.endChat() should end conversation without calling backend close session', async () => {
+        it('ChatSDK.endChat() with optional params \'isSessionEnded\' set as \'true\' should not call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2412,7 +2396,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
-        it('ChatSDK.endChat() should end conversation not ended by agent', async () => {
+        it('ChatSDK.endChat() with optional params \'isSessionEnded\' set as \'false\' should call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2450,8 +2434,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
-        
-        it('ChatSDK.endChat() should end conversation not ended by agent and empty optional params', async () => {
+        it('ChatSDK.endChat() with optional params set as empty should call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2487,8 +2470,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
-
-        it('ChatSDK.endChat() should end conversation not ended by agent and not defined in optional params', async () => {
+        it('ChatSDK.endChat() with optional params set as \'undefined\' should call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2617,7 +2599,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.OCClient.sessionClose.mock.calls[0][1]).toMatchObject(sessionCloseOptionalParams);
         });
 
-        it('ChatSDK.endChat() should end conversation not ended by agent and passing empty object', async () => {
+        it('ChatSDK.endChat() with optional params set as empty should call sessionClose', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2920,7 +2902,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                 retryCount++;
             }
 
-
             chatSDK.ACSClient.initialize = jest.fn();
             chatSDK.ACSClient.joinConversation = jest.fn();
             chatSDK.AMSClient.initialize = jest.fn();
@@ -2968,7 +2949,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.OCClient.getReconnectAvailability).toHaveBeenCalledTimes(0);
             expect(context.reconnectId).toBe(mockedResponse.reconnectid);
         });
-
 
         it('ChatSDK.getChatReconnectContext() with authenticatedUserToken should not call OCClient.getReconnectableChats() & return redirectURL due to expired token', async () => {
             const chatSDKConfig = {
@@ -3047,7 +3027,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(1);
             expect(context.reconnectId).toBe(mockedResponse.reconnectid);
         });
-
 
         it('ChatSDK.getChatReconnectContext() should pass reconnectId to OCClient.getReconnectAvailability() & return reconnectId if valid & return redirectUrl with "null"', async () => {
             const chatSDKConfig = {
@@ -3137,7 +3116,6 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             expect(chatSDK.OCClient.getReconnectableChats).toHaveBeenCalledTimes(1);
         });
-
 
         it('ChatSDK.getChatReconnectContext() should fail if OCClient.getReconnectAvailability() fails', async () => {
             const chatSDKConfig = {
@@ -3452,7 +3430,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
                     "SurveyProvider": "MCS",
                     "WidgetId": "[data-app-id]"
                 },
-                    expect.any(Object));
+                expect.any(Object));
                 expect(postChatContext.participantJoined).toBeTruthy();
                 expect(postChatContext.participantType).toBe("Bot");
             } catch (ex) {

--- a/__tests__/OmnichannelChatSDKParallel.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.spec.ts
@@ -2374,6 +2374,158 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.IC3Client).toBe(undefined);
         });
 
+        it('ChatSDK.endChat() should end conversation without calling backend close session', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize({ useParallelLoad: true });
+            let retryCount = 0;
+            const maxRetries = 3;
+
+            while (chatSDK.AMSClient === null && retryCount < maxRetries) {
+                await new Promise(resolve => setTimeout(resolve, 2000));
+                retryCount++;
+            }
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({
+                isSessionEnded: true
+            });
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(0);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+        it('ChatSDK.endChat() should end conversation not ended by agent', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize({ useParallelLoad: true });
+            let retryCount = 0;
+            const maxRetries = 3;
+
+            while (chatSDK.AMSClient === null && retryCount < maxRetries) {
+                await new Promise(resolve => setTimeout(resolve, 2000));
+                retryCount++;
+            }
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({
+                isSessionEnded: false
+            });
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+        
+        it('ChatSDK.endChat() should end conversation not ended by agent and empty optional params', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize({ useParallelLoad: true });
+            let retryCount = 0;
+            const maxRetries = 3;
+
+            while (chatSDK.AMSClient === null && retryCount < maxRetries) {
+                await new Promise(resolve => setTimeout(resolve, 2000));
+                retryCount++;
+            }
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({});
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
+
+        it('ChatSDK.endChat() should end conversation not ended by agent and not defined in optional params', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize({ useParallelLoad: true });
+            let retryCount = 0;
+            const maxRetries = 3;
+
+            while (chatSDK.AMSClient === null && retryCount < maxRetries) {
+                await new Promise(resolve => setTimeout(resolve, 2000));
+                retryCount++;
+            }
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({
+                isSessionEnded: undefined
+            });
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
+        });
+
         it('ChatSDK.endChat() should fail if OCClient.sessionClose() fails', async () => {
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
@@ -2463,6 +2615,42 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             await chatSDK.endChat();
             expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
             expect(chatSDK.OCClient.sessionClose.mock.calls[0][1]).toMatchObject(sessionCloseOptionalParams);
+        });
+
+        it('ChatSDK.endChat() should end conversation not ended by agent and passing empty object', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+
+            await chatSDK.initialize({ useParallelLoad: true });
+            let retryCount = 0;
+            const maxRetries = 3;
+
+            while (chatSDK.AMSClient === null && retryCount < maxRetries) {
+                await new Promise(resolve => setTimeout(resolve, 2000));
+                retryCount++;
+            }
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.sessionClose = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                disconnect: jest.fn()
+            };
+
+            const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+            await chatSDK.endChat({});
+
+            expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
+            expect(conversationDisconnectFn).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation).toBe(null);
+            expect(chatSDK.chatToken).toMatchObject({});
+            expect(chatSDK.IC3Client).toBe(undefined);
         });
 
         it('ChatSDK.isPersistentChat should be true on Persistent Chat', async () => {

--- a/__tests__/OmnichannelChatSDKParallel.web.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.web.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @jest-environment jsdom

--- a/__tests__/api/createVoiceVideoCalling.web.spec.ts
+++ b/__tests__/api/createVoiceVideoCalling.web.spec.ts
@@ -1,8 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-function */
 /**
  * @jest-environment jsdom
  */
 
 import createVoiceVideoCalling from '../../src/api/createVoiceVideoCalling';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const VoiceVideoCallingProxy = require('../../src/api/createVoiceVideoCalling').VoiceVideoCallingProxy;
 
 describe('createVoiceVideoCalling', () => {
@@ -12,6 +16,7 @@ describe('createVoiceVideoCalling', () => {
         load: jest.fn().mockResolvedValue(Promise.resolve()),
         initialize: jest.fn(),
         isInitialized: jest.fn().mockResolvedValue(true),
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         registerEvent: jest.fn((eventName: string, callback: Function) => {}),
         isMicrophoneMuted: jest.fn(),
         acceptCall: jest.fn(),

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import ACSClient from "../../../src/core/messaging/ACSClient";
@@ -49,7 +50,6 @@ describe('ACSClient', () => {
         expect(conversation).toBeDefined();
         expect(conversation.sessionInfo).toBeDefined();
     });
-
 
     it('ACSClient.initialize() with ChatClient.getChatThreadClient() failure show throw an error', async () => {
         const client: any = new ACSClient();

--- a/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileManager.spec.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import AMSFileManager from '../../../src/external/ACSAdapter/AMSFileManager';
 
 describe('AMSFileManager', () => {

--- a/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
+++ b/__tests__/external/ACSAdapter/AMSFileScanner.spec.ts
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import AMSFileScanner from '../../../src/external/ACSAdapter/AMSFileScanner';
-import activityUtils from '../../../src/external/ACSAdapter/activityUtils';
 import WebUtils from '../../../src/utils/WebUtils';
+import activityUtils from '../../../src/external/ACSAdapter/activityUtils';
 
 describe("AMSFileScanner", () => {
 

--- a/__tests__/external/ACSAdapter/createFormatEgressTagsMiddleware.spec.ts
+++ b/__tests__/external/ACSAdapter/createFormatEgressTagsMiddleware.spec.ts
@@ -43,7 +43,6 @@ describe('createFormatEgressTagsMiddleware', () => {
         expect(next).toHaveBeenCalledWith(expectedActivity);
     });
 
-
     it('createFormatEgressTagsMiddleware should convert activity with tags in JSON format to string', () => {
         const next = jest.fn();
 

--- a/__tests__/telemetry/AriaTelemetry.spec.ts
+++ b/__tests__/telemetry/AriaTelemetry.spec.ts
@@ -1,6 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as settings from '../../src/config/settings';
+
 import AriaTelemetry from '../../src/telemetry/AriaTelemetry';
 import ScenarioType from '../../src/telemetry/ScenarioType';
-import * as settings from '../../src/config/settings';
 
 describe('AriaTelemetry', () => {
     (settings as any).ariaTelemetryKey = '';

--- a/__tests__/telemetry/ScenarioMarker.spec.ts
+++ b/__tests__/telemetry/ScenarioMarker.spec.ts
@@ -1,6 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as settings from '../../src/config/settings';
+
 import AriaTelemetry from '../../src/telemetry/AriaTelemetry';
 import ScenarioMarker from '../../src/telemetry/ScenarioMarker';
-import * as settings from '../../src/config/settings';
 
 describe('ScenarioMarker', () => {
     (settings as any).ariaTelemetryKey = '';

--- a/__tests__/utils/CoreServicesUtils.spec.ts
+++ b/__tests__/utils/CoreServicesUtils.spec.ts
@@ -1,5 +1,4 @@
-
-import { CoreServicesGeoNamesMapping, coreServicesOrgUrlPrefix, createCoreServicesOrgUrl, getCoreServicesGeoName, isCoreServicesOrgUrl, nonProductionDynamicsLocationCode, unqOrgUrlPattern } from "../../src/utils/CoreServicesUtils";
+import { CoreServicesGeoNamesMapping, createCoreServicesOrgUrl, getCoreServicesGeoName, isCoreServicesOrgUrl, unqOrgUrlPattern } from "../../src/utils/CoreServicesUtils";
 
 describe("CoreServicesUtils", () => {
     it("unqOrgUrlPattern should be able to retrieve the location code from the an UNQ OrgUrl", () => {
@@ -18,7 +17,7 @@ describe("CoreServicesUtils", () => {
         const locationCode = "crmtest";
         const orgUrl = `https://unq1234-${locationCode}.oc.crmlivetie.com`;
         const result = unqOrgUrlPattern.exec(orgUrl);
-        
+
         expect(result).not.toBe(null);
         if (!result) throw new Error("No result object");
         expect(result[1]).toBe(locationCode);
@@ -29,11 +28,10 @@ describe("CoreServicesUtils", () => {
         const locationCode = "crm10";
         const orgUrl = `https://unq1234-${locationCode}.oc.crmlivetie.com`;
         const result = unqOrgUrlPattern.exec(orgUrl);
-        
+
         expect(result).not.toBe(null);
         if (!result) throw new Error("No result object");
         expect(result[1]).toBe(locationCode);
-        const geoName = getCoreServicesGeoName(locationCode);
         expect(createCoreServicesOrgUrl("1234", getCoreServicesGeoName(locationCode))).toBe(`https://m-1234.preprod.omnichannelengagementhub.com`);
     });
 
@@ -41,7 +39,7 @@ describe("CoreServicesUtils", () => {
         const locationCode = "crm12";
         const orgUrl = `https://unq1234-${locationCode}.omnichannelengagementhub.us`;
         const result = unqOrgUrlPattern.exec(orgUrl);
-        
+
         expect(result).not.toBe(null);
         if (!result) throw new Error("No result object");
         expect(result[1]).toBe(locationCode);
@@ -67,9 +65,9 @@ describe("CoreServicesUtils", () => {
                 continue;
             }
 
-            let orgId = "1234";
-            let geoName = getCoreServicesGeoName(locationCode);
-            let coreServicesOrgUrl = createCoreServicesOrgUrl(orgId, geoName);
+            const orgId = "1234";
+            const geoName = getCoreServicesGeoName(locationCode);
+            const coreServicesOrgUrl = createCoreServicesOrgUrl(orgId, geoName);
             expect(coreServicesOrgUrl).toBe(`https://m-${orgId}.${geoName}.${domain}`);
         }
     });

--- a/__tests__/utils/InternalUtils.spec.ts
+++ b/__tests__/utils/InternalUtils.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { isCoreServicesOrgUrlDNSError } from "../../src/utils/internalUtils";
 
 describe('InternalUtils', () => {
@@ -31,5 +33,5 @@ describe('InternalUtils', () => {
         const dynamicsLocationCode = null;
         const result = isCoreServicesOrgUrlDNSError(axiosErrorObject, coreServicesOrgUrl, dynamicsLocationCode);
         expect(result).toBe(false);
-    });  
+    });
 });

--- a/__tests__/utils/WebUtils.web.spec.ts
+++ b/__tests__/utils/WebUtils.web.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * @jest-environment jsdom
  */

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import LiveChatVersion from '../../src/core/LiveChatVersion';
-import createOmnichannelMessage from '../../src/utils/createOmnichannelMessage';
-import { ChatMessageReceivedEvent } from '@azure/communication-signaling';
-import { DeliveryMode, MessageType } from '../../src/core/messaging/OmnichannelMessage';
+import { MessageType } from '../../src/core/messaging/OmnichannelMessage';
 import PersonType from '@microsoft/omnichannel-ic3core/lib/model/PersonType';
+import createOmnichannelMessage from '../../src/utils/createOmnichannelMessage';
 
 describe('createOmnichannelMessage', () => {
     it('createOmnichannelMessage with LiveChatV2 messaging contracts should return OmnichannelMessage contracts', () => {

--- a/__tests__/utils/locale.spec.ts
+++ b/__tests__/utils/locale.spec.ts
@@ -1,4 +1,5 @@
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const locale = require('../../src/utils/locale');
 
 describe('Locales', () => {

--- a/__tests__/utils/loggers.spec.ts
+++ b/__tests__/utils/loggers.spec.ts
@@ -1,5 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {ACSAdapterLogger, ACSClientLogger, AMSClientLogger, CallingSDKLogger, IC3ClientLogger, OCSDKLogger} from '../../src/utils/loggers';
+
 import LogLevel from '@microsoft/omnichannel-ic3core/lib/logging/LogLevel';
-import {ACSAdapterLogger, ACSClientLogger, IC3ClientLogger, OCSDKLogger, CallingSDKLogger, AMSClientLogger} from '../../src/utils/loggers';
 
 describe('loggers', () => {
     describe('IC3ClientLogger', () => {
@@ -214,7 +217,6 @@ describe('loggers', () => {
             expect((logger as any).scenarioMarker.startScenario).toHaveBeenCalledTimes(1);
         });
 
-
         it('ACSClientLogger.failScenario() should call ScenarioMarker.failScenario()', () => {
             const logger = new ACSClientLogger(omnichannelConfig);
 
@@ -317,7 +319,6 @@ describe('loggers', () => {
 
             expect((logger as any).scenarioMarker.startScenario).toHaveBeenCalledTimes(1);
         });
-
 
         it('ACSAdapterLogger.failScenario() should call ScenarioMarker.failScenario()', () => {
             const logger = new ACSAdapterLogger(omnichannelConfig);

--- a/__tests__/utils/setOcUserAgent.spec.ts
+++ b/__tests__/utils/setOcUserAgent.spec.ts
@@ -8,6 +8,7 @@ describe("setOcUserAgent", () => {
 
         setOcUserAgent(OCClient, []);
 
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
         const version = require("../../package.json").version;
         const userAgent = `omnichannel-chat-sdk/${version}`;
         const expectedResult = [userAgent];

--- a/__tests__/utils/sleep.spec.ts
+++ b/__tests__/utils/sleep.spec.ts
@@ -3,7 +3,7 @@ import sleep from "../../src/utils/sleep";
 describe('Sleep', () => {
     it('sleep() should delay function execution', async () => {
         const delay = 5 * 1000;
-        const threshold = delay * (50/100);
+        const threshold = delay * (50 / 100);
         const before = new Date().getTime();
         await sleep(delay);
         const after = new Date().getTime();

--- a/__tests__/validators/SDKConfigValidators.spec.ts
+++ b/__tests__/validators/SDKConfigValidators.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import validateSDKConfig, {defaultChatSDKConfig} from '../../src/validators/SDKConfigValidators';
 
 describe('SDKConfigValidators', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@azure/communication-chat": "1.5.2",
         "@azure/communication-common": "2.3.1",
-        "@microsoft/ocsdk": "^0.5.8",
+        "@microsoft/ocsdk": "^0.5.9",
         "@microsoft/omnichannel-amsclient": "^0.1.6",
         "@microsoft/omnichannel-ic3core": "^0.1.4",
         "acs_webchat-chat-adapter": "^0.0.35-beta.30"
@@ -1463,9 +1463,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.8.tgz",
-      "integrity": "sha512-00C1WSOYB9qu4u2cNDZbPqo2z8LTkzy4VUKYlkvkkvc7sL98YRIW5Lc1srFpTVyEmnvUEzFa9MQxefH4BkTjuQ==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.9.tgz",
+      "integrity": "sha512-ZlCc7fGhy8YeSAmJWpqUO7FWlCbNXkkQhvRiXWzruZASB5vZl9imKEMk88HEGQh+R8kHhIe0PbA+RDScsnV9Wg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
@@ -7418,9 +7418,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.8.tgz",
-      "integrity": "sha512-00C1WSOYB9qu4u2cNDZbPqo2z8LTkzy4VUKYlkvkkvc7sL98YRIW5Lc1srFpTVyEmnvUEzFa9MQxefH4BkTjuQ==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.9.tgz",
+      "integrity": "sha512-ZlCc7fGhy8YeSAmJWpqUO7FWlCbNXkkQhvRiXWzruZASB5vZl9imKEMk88HEGQh+R8kHhIe0PbA+RDScsnV9Wg==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^12.20.26",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@azure/communication-chat": "1.5.2",
     "@azure/communication-common": "2.3.1",
-    "@microsoft/ocsdk": "^0.5.8",
+    "@microsoft/ocsdk": "^0.5.9",
     "@microsoft/omnichannel-amsclient": "^0.1.6",
     "@microsoft/omnichannel-ic3core": "^0.1.4",
     "acs_webchat-chat-adapter": "^0.0.35-beta.30"

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -542,7 +542,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         expect(sessionCloseResponse.status()).toBe(200);
     });
 
-    test('ChatSDK.endChat() should not call close session for identified sessions ended by agent', async ({ page }) => {
+    test('ChatSDK.endChat() with optional params \'isSessionEnded\' set as \'true\' should not call sessionClose', async ({ page }) => {
         await page.goto(testPage);
 
         let counterCalls = 0;

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -785,6 +785,7 @@ class OmnichannelChatSDK {
         const cleanupMetadata = {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string,
+            isSessionEnded: !endChatOptionalParams?.isSessionEnded
         };
 
         // in case a session was ended by agent or disconnected, there is no need to close the session
@@ -815,7 +816,10 @@ class OmnichannelChatSDK {
                 await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
 
             } catch (error) {
-                exceptionThrowers.throwConversationClosureFailure(error, this.scenarioMarker, TelemetryEvent.CloseChatSession, cleanupMetadata);
+                exceptionThrowers.throwConversationClosureFailure(error, this.scenarioMarker, TelemetryEvent.CloseChatSession, {
+                    ...cleanupMetadata,
+                    isSessionEnded: String(!endChatOptionalParams?.isSessionEnded)
+                });
             }
             this.scenarioMarker.completeScenario(TelemetryEvent.CloseChatSession, cleanupMetadata);
         }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -32,6 +32,7 @@ import ChatTranscriptBody from "./core/ChatTranscriptBody";
 import ConversationMode from "./core/ConversationMode";
 import DeliveryMode from "@microsoft/omnichannel-ic3core/lib/model/DeliveryMode";
 import EmailLiveChatTranscriptOptionaParams from "./core/EmailLiveChatTranscriptOptionalParams";
+import EndChatOptionalParams from "./core/EndChatOptionalParams";
 import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
 import FileSharingProtocolType from "@microsoft/omnichannel-ic3core/lib/model/FileSharingProtocolType";
 import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
@@ -779,76 +780,60 @@ class OmnichannelChatSDK {
         }
     }
 
-    public async softEndChat(): Promise<void> {
+    private async closeChat(endChatOptionalParams: EndChatOptionalParams): Promise<void> {
+
+        const cleanupMetadata = {
+            RequestId: this.requestId,
+            ChatId: this.chatToken.chatId as string,
+        };
+
+        // in case a session was ended by agent or disconnected, there is no need to close the session
+        this.scenarioMarker.startScenario(TelemetryEvent.CloseChatSession, cleanupMetadata);
+
+        if (!endChatOptionalParams?.isSessionEnded) {
+            try {
+
+                const sessionCloseOptionalParams: ISessionCloseOptionalParams = {};
+
+                if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
+                    const isReconnectChat = this.reconnectId !== null ? true : false;
+
+                    sessionCloseOptionalParams.isPersistentChat = this.isPersistentChat;
+                    sessionCloseOptionalParams.isReconnectChat = isReconnectChat;
+                }
+
+                if (this.isChatReconnect && !this.chatSDKConfig.chatReconnect?.disable && !this.isPersistentChat) {
+                    const isChatReconnect = this.reconnectId !== null ? true : false;
+                    this.requestId = isChatReconnect ? (this.reconnectId as string) : this.requestId; // Chat Reconnect session to close
+                    sessionCloseOptionalParams.isReconnectChat = isChatReconnect;
+                }
+
+                if (this.authenticatedUserToken) {
+                    sessionCloseOptionalParams.authenticatedUserToken = this.authenticatedUserToken;
+                }
+
+                await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
+
+            } catch (error) {
+                exceptionThrowers.throwConversationClosureFailure(error, this.scenarioMarker, TelemetryEvent.CloseChatSession, cleanupMetadata);
+            }
+            this.scenarioMarker.completeScenario(TelemetryEvent.CloseChatSession, cleanupMetadata);
+        }
+    }
+
+    public async endChat(endChatOptionalParams: EndChatOptionalParams = {}): Promise<void> {
 
         const cleanupMetadata = {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
         };
 
-        this.scenarioMarker.startScenario(TelemetryEvent.SoftEndChat, cleanupMetadata);
-
-        this.conversation?.disconnect();
-
-        if (this.IC3Client) {
-            this.IC3Client.dispose();
-            !platform.isNode() && !platform.isReactNative() && removeElementById(this.IC3Client.id);
-            this.IC3Client = null;
-        }
-
-        if (this.OCClient.sessionId) {
-            this.OCClient.sessionId = null;
-            this.sessionId = null;
-        }
-
-        loggerUtils.setRequestId(this.requestId, this.ocSdkLogger, this.acsClientLogger, this.acsAdapterLogger, this.callingSdkLogger, this.amsClientLogger, this.ic3ClientLogger);
-        loggerUtils.setChatId('', this.ocSdkLogger, this.acsClientLogger, this.acsAdapterLogger, this.callingSdkLogger, this.amsClientLogger, this.ic3ClientLogger);
-
-        if (this.refreshTokenTimer !== null) {
-            clearInterval(this.refreshTokenTimer);
-            this.refreshTokenTimer = null;
-        }
-
-        this.conversation = null;
-        this.requestId = uuidv4();
-        this.chatToken = {};
-        this.reconnectId = null;
-
-        this.scenarioMarker.completeScenario(TelemetryEvent.SoftEndChat, cleanupMetadata);
-    }
-
-    public async endChat(): Promise<void> {
-        this.scenarioMarker.startScenario(TelemetryEvent.EndChat, {
-            RequestId: this.requestId,
-            ChatId: this.chatToken.chatId as string
-        });
-
-        const sessionCloseOptionalParams: ISessionCloseOptionalParams = {};
-
-        if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
-            const isReconnectChat = this.reconnectId !== null ? true : false;
-
-            sessionCloseOptionalParams.isPersistentChat = this.isPersistentChat;
-            sessionCloseOptionalParams.isReconnectChat = isReconnectChat;
-        }
-
-        if (this.isChatReconnect && !this.chatSDKConfig.chatReconnect?.disable && !this.isPersistentChat) {
-            const isChatReconnect = this.reconnectId !== null ? true : false;
-            this.requestId = isChatReconnect ? (this.reconnectId as string) : this.requestId; // Chat Reconnect session to close
-            sessionCloseOptionalParams.isReconnectChat = isChatReconnect;
-        }
-
-        if (this.authenticatedUserToken) {
-            sessionCloseOptionalParams.authenticatedUserToken = this.authenticatedUserToken;
-        }
+        this.scenarioMarker.startScenario(TelemetryEvent.EndChat, cleanupMetadata);
 
         try {
-            await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
 
-            this.scenarioMarker.completeScenario(TelemetryEvent.EndChat, {
-                RequestId: this.requestId,
-                ChatId: this.chatToken.chatId as string
-            });
+            // calling close chat, internally will handle the session close
+            await this.closeChat(endChatOptionalParams);
 
             this.conversation?.disconnect();
             this.conversation = null;
@@ -869,18 +854,20 @@ class OmnichannelChatSDK {
 
             loggerUtils.setRequestId(this.requestId, this.ocSdkLogger, this.acsClientLogger, this.acsAdapterLogger, this.callingSdkLogger, this.amsClientLogger, this.ic3ClientLogger);
             loggerUtils.setChatId('', this.ocSdkLogger, this.acsClientLogger, this.acsAdapterLogger, this.callingSdkLogger, this.amsClientLogger, this.ic3ClientLogger);
+
+            if (this.refreshTokenTimer !== null) {
+                clearInterval(this.refreshTokenTimer);
+                this.refreshTokenTimer = null;
+            }
+
+            this.scenarioMarker.completeScenario(TelemetryEvent.EndChat, cleanupMetadata);
+
         } catch (error) {
             const telemetryData = {
                 RequestId: this.requestId,
                 ChatId: this.chatToken.chatId as string
             };
-
             exceptionThrowers.throwConversationClosureFailure(error, this.scenarioMarker, TelemetryEvent.EndChat, telemetryData);
-        }
-
-        if (this.refreshTokenTimer !== null) {
-            clearInterval(this.refreshTokenTimer);
-            this.refreshTokenTimer = null;
         }
     }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -779,6 +779,44 @@ class OmnichannelChatSDK {
         }
     }
 
+    public async softEndChat(): Promise<void> {
+
+        this.scenarioMarker.startScenario(TelemetryEvent.SoftEndChat, {
+            RequestId: this.requestId,
+            ChatId: this.chatToken.chatId as string
+        });
+
+        this.conversation?.disconnect();
+        this.conversation = null;
+        this.requestId = uuidv4();
+        this.chatToken = {};
+        this.reconnectId = null;
+
+        if (this.IC3Client) {
+            this.IC3Client.dispose();
+            !platform.isNode() && !platform.isReactNative() && removeElementById(this.IC3Client.id);
+            this.IC3Client = null;
+        }
+
+        if (this.OCClient.sessionId) {
+            this.OCClient.sessionId = null;
+            this.sessionId = null;
+        }
+
+        loggerUtils.setRequestId(this.requestId, this.ocSdkLogger, this.acsClientLogger, this.acsAdapterLogger, this.callingSdkLogger, this.amsClientLogger, this.ic3ClientLogger);
+        loggerUtils.setChatId('', this.ocSdkLogger, this.acsClientLogger, this.acsAdapterLogger, this.callingSdkLogger, this.amsClientLogger, this.ic3ClientLogger);
+
+        if (this.refreshTokenTimer !== null) {
+            clearInterval(this.refreshTokenTimer);
+            this.refreshTokenTimer = null;
+        }
+
+        this.scenarioMarker.completeScenario(TelemetryEvent.SoftEndChat, {
+            RequestId: this.requestId,
+            ChatId: this.chatToken.chatId as string
+        });
+    }
+
     public async endChat(): Promise<void> {
         this.scenarioMarker.startScenario(TelemetryEvent.EndChat, {
             RequestId: this.requestId,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -787,10 +787,6 @@ class OmnichannelChatSDK {
         });
 
         this.conversation?.disconnect();
-        this.conversation = null;
-        this.requestId = uuidv4();
-        this.chatToken = {};
-        this.reconnectId = null;
 
         if (this.IC3Client) {
             this.IC3Client.dispose();
@@ -811,10 +807,17 @@ class OmnichannelChatSDK {
             this.refreshTokenTimer = null;
         }
 
-        this.scenarioMarker.completeScenario(TelemetryEvent.SoftEndChat, {
+        const cleanupMetadata = {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
-        });
+        };
+
+        this.conversation = null;
+        this.requestId = uuidv4();
+        this.chatToken = {};
+        this.reconnectId = null;
+
+        this.scenarioMarker.completeScenario(TelemetryEvent.SoftEndChat, cleanupMetadata);
     }
 
     public async endChat(): Promise<void> {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -781,10 +781,12 @@ class OmnichannelChatSDK {
 
     public async softEndChat(): Promise<void> {
 
-        this.scenarioMarker.startScenario(TelemetryEvent.SoftEndChat, {
+        const cleanupMetadata = {
             RequestId: this.requestId,
             ChatId: this.chatToken.chatId as string
-        });
+        };
+
+        this.scenarioMarker.startScenario(TelemetryEvent.SoftEndChat, cleanupMetadata);
 
         this.conversation?.disconnect();
 
@@ -806,11 +808,6 @@ class OmnichannelChatSDK {
             clearInterval(this.refreshTokenTimer);
             this.refreshTokenTimer = null;
         }
-
-        const cleanupMetadata = {
-            RequestId: this.requestId,
-            ChatId: this.chatToken.chatId as string
-        };
 
         this.conversation = null;
         this.requestId = uuidv4();

--- a/src/core/EndChatOptionalParams.ts
+++ b/src/core/EndChatOptionalParams.ts
@@ -1,4 +1,4 @@
 
 export default interface EndChatOptionalParams {
-    isSessionEnded?: false;
+    isSessionEnded?: boolean;
 }

--- a/src/core/EndChatOptionalParams.ts
+++ b/src/core/EndChatOptionalParams.ts
@@ -1,4 +1,4 @@
 
 export default interface EndChatOptionalParams {
-isSessionEnded?: false;
+    isSessionEnded?: false;
 }

--- a/src/core/EndChatOptionalParams.ts
+++ b/src/core/EndChatOptionalParams.ts
@@ -1,0 +1,4 @@
+
+export default interface EndChatOptionalParams {
+isSessionEnded?: false;
+}

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -8,6 +8,7 @@ enum TelemetryEvent {
     InitializeLoadChatConfig = "InitializeLoadChatConfig",
     StartChat = "StartChat",
     EndChat = "EndChat",
+    SoftEndChat = "SoftEndChat",
     GetLiveChatConfig = "GetLiveChatConfig",
     GetAuthToken = "GetAuthToken",
     GetPreChatSurvey = "GetPreChatSurvey",

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -8,7 +8,7 @@ enum TelemetryEvent {
     InitializeLoadChatConfig = "InitializeLoadChatConfig",
     StartChat = "StartChat",
     EndChat = "EndChat",
-    SoftEndChat = "SoftEndChat",
+    CloseChatSession = "CloseChatSession",
     GetLiveChatConfig = "GetLiveChatConfig",
     GetAuthToken = "GetAuthToken",
     GetPreChatSurvey = "GetPreChatSurvey",


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description
_Include a description of the problem to be solved_

For sessions that were disconnected , or ended by agent, when calling endchat is forcing an exception since the conversation is already closed.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Adding optional parameters to allow the caller to identify when a call to end chat is for an already closed chat, this will avoid to call close chat endpoint.

 #### this PR includes a cleanup of warnings and style issues in unit tests :  
- extra lines
- trail spaces
- unused variables
- rename let to const
- whitelist for empty arrow functions
- whitelist for any 
- whitelist unused declared variables inside callbacks
- fix tabs and spaces

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

![image](https://github.com/user-attachments/assets/a12fa753-1728-4c3a-a47a-cc75b791f136)


_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/user-attachments/assets/2e30daae-5cb8-4106-831b-8f17aed7fc50)




### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
