### PR TITLE
Fix for OnNewMessage Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fix for ACS client preventing new messages from being populated in the new message callback.
+
 ## [1.10.5] - 2025-16-01
 
 ### Added

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
 
-import {  MaskingRule, MaskingRules, GetPreChatSurveyResponse } from "../src/types/response";
+import { GetPreChatSurveyResponse, MaskingRule, MaskingRules } from "../src/types/response";
 import { defaultLocaleId, getLocaleStringFromId } from "../src/utils/locale";
 
 import { AWTLogManager } from "../src/external/aria/webjs/AriaSDK";
@@ -2886,68 +2886,6 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             expect(IC3SDKProvider.getSDK.mock.calls[0][0].hostType).toBe(HostType.Page);
             expect(platform.isReactNative).toHaveBeenCalledTimes(1);
-        });
-
-        it('[LiveChatV1] ChatSDK.onNewMessage() with rehydrate flag should call ChatSDK.getMessages()', async () => {
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
-            chatSDK.getChatConfig = jest.fn();
-            chatSDK.getChatToken = jest.fn();
-            chatSDK.liveChatVersion = LiveChatVersion.V1;
-
-            await chatSDK.initialize();
-
-            chatSDK.OCClient.sessionInit = jest.fn();
-            chatSDK.IC3Client.initialize = jest.fn();
-            chatSDK.IC3Client.joinConversation = jest.fn();
-
-            const messages = [
-                {clientmessageid: 2},
-                {clientmessageid: 1},
-                {clientmessageid: 1},
-                {clientmessageid: 0}
-            ]
-
-            await chatSDK.startChat();
-
-            chatSDK.conversation = {
-                registerOnNewMessage: jest.fn(),
-                getMessages: jest.fn()
-            };
-
-            jest.spyOn(chatSDK, 'getMessages').mockResolvedValue(messages);
-
-            await chatSDK.onNewMessage(() => {}, {rehydrate: true});
-
-            expect(chatSDK.getMessages).toHaveBeenCalledTimes(1);
-            expect(chatSDK.conversation.registerOnNewMessage).toHaveBeenCalledTimes(1);
-        });
-
-        it('[LiveChatV1] ChatSDK.onNewMessage() with rehydrate flag & with no messages should not break', async () => {
-            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
-            chatSDK.getChatConfig = jest.fn();
-            chatSDK.getChatToken = jest.fn();
-            chatSDK.liveChatVersion = LiveChatVersion.V1;
-
-            await chatSDK.initialize();
-
-            chatSDK.OCClient.sessionInit = jest.fn();
-            chatSDK.IC3Client.initialize = jest.fn();
-            chatSDK.IC3Client.joinConversation = jest.fn();
-
-            const messages = undefined;
-            await chatSDK.startChat();
-
-            chatSDK.conversation = {
-                registerOnNewMessage: jest.fn(),
-                getMessages: jest.fn()
-            };
-
-            jest.spyOn(chatSDK, 'getMessages').mockResolvedValue(messages);
-
-            await chatSDK.onNewMessage(() => {}, {rehydrate: true});
-
-            expect(chatSDK.getMessages).toHaveBeenCalledTimes(1);
-            expect(chatSDK.conversation.registerOnNewMessage).toHaveBeenCalledTimes(1);
         });
 
         it('ChatSDK.onNewMessage() should call conversation.registerOnNewMessage()', async() => {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1276,9 +1276,6 @@ class OmnichannelChatSDK {
         }
 
         if (this.liveChatVersion === LiveChatVersion.V2) {
-
-            console.log("onNewMessageCallback :: 1");
-
             const postedMessages = new Set();
 
             if ((optionalParams as OnNewMessageOptionalParams).rehydrate) {
@@ -1287,7 +1284,6 @@ class OmnichannelChatSDK {
                 for (const message of messages.reverse()) {
                     const { id } = message;
                     if (postedMessages.has(id)) {
-                        console.log("Message removed :: ", id);
                         continue;
                     }
 
@@ -1297,24 +1293,17 @@ class OmnichannelChatSDK {
             }
 
             try {
-                console.log("ELOPEZANAYA ::: 3");
                 (this.conversation as ACSConversation)?.registerOnNewMessage((event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
-                    console.log("ELOPEZANAYA ::: 4, event:: ");
                     const { id } = event;
-
                     const omnichannelMessage = createOmnichannelMessage(event, {
                         liveChatVersion: this.liveChatVersion,
                         debug: this.debug
                     });
 
-                    console.log("ELOPEZANAYA ::: 5, messageid:: ", id);
                     if (!postedMessages.has(id)) {
-                        console.log("ELOPEZANAYA ::: 6, notify new messageid:: ", id);
                         onNewMessageCallback(omnichannelMessage);
                         postedMessages.add(id);
                     }
-                    console.log("ELOPEZANAYA ::: 7, messageid:: ", id);
-
                 });
 
                 this.scenarioMarker.completeScenario(TelemetryEvent.OnNewMessage, {

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -191,7 +191,7 @@ export class ACSConversation {
                                 postedMessageIds.add(id);
                             }
                         } catch {
-                            console.warn('[ACSClient][registerOnNewMessage] Error occurred while processing messages with id : ', id);
+                            console.warn('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
                         }
 
                     }

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -170,27 +170,46 @@ export class ACSConversation {
         try {
             const pollForMessages = async (delay: number) => {
                 if (isReceivingNotifications) {
+                    console.error("ACS Return");
                     return;
                 }
 
                 try {
                     const messages = await this.getMessages();
+                    console.log('ACS Mmessages:');
+                    console.table(messages);
                     for (const message of messages.reverse()) {
-                        const { id, sender } = message;
-                        const customerMessageCondition = sender.displayName === ACSParticipantDisplayName.Customer;
+                        try {
 
-                        // Filter out customer messages
-                        if (customerMessageCondition) {
-                            continue;
+                            const { id, sender } = message;
+
+                            console.log('ACS Message:', message);
+                            console.log('ACS Sender id:', id);
+                            console.log('ACS Sender message:', sender.displayName);
+                            const customerMessageCondition = sender.displayName === ACSParticipantDisplayName.Customer;
+
+                            // Filter out customer messages
+                            if (customerMessageCondition) {
+                                console.error('ACS Baygon:', id);
+                                continue;
+                            }
+
+                            console.log("ACS PostMessageIds:");
+                            console.table(postedMessageIds);
+                            // Filter out duplicate messages
+                            console.log('ACS postedMessageIds:', id, postedMessageIds.has(id));
+                            if (!postedMessageIds.has(id)) {
+                                console.log("ACS New message:", message);
+                                onNewMessageCallback(message);
+                                postedMessageIds.add(id);
+                            }
+                        } catch (error) {
+                            console.error('ACS Iinternal FOR:', error);
                         }
 
-                        // Filter out duplicate messages
-                        if (!postedMessageIds.has(id)) {
-                            onNewMessageCallback(message);
-                            postedMessageIds.add(id);
-                        }
                     }
-                } catch {
+                } catch (error) {
+                    console.warn('ACS Polling error:', error);
                     // Ignore polling failures
                 }
 
@@ -205,21 +224,31 @@ export class ACSConversation {
             const listener = (event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
                 isReceivingNotifications = true;
 
+                console.log('ACS listener:');
+
                 const { id, sender } = event;
 
                 const customerMessageCondition = ((sender as CommunicationUserIdentifier).communicationUserId === (this.sessionInfo?.id as string));
                 const isChatMessageEditedEvent = Object.keys(event).includes("editedOn");
 
+                console.log('ACS listener: customerMessageCondition: ', customerMessageCondition);
+
                 // Filter out customer messages
                 if (customerMessageCondition) {
+                    console.log('ACS listener: customerMessageCondition: RETURN');
                     return;
                 }
+
+                console.log('ACS listener: postedMessageIds:');
+                console.table(postedMessageIds);
 
                 // Filter out duplicate messages
                 if (postedMessageIds.has(id) && !isChatMessageEditedEvent) {
+                    console.log('ACS listener: customerMessageCondition: RETURN 2 : , id:', id);
                     return;
                 }
 
+                console.log('ACS listener: New message:', id);
                 onNewMessageCallback(event);
                 postedMessageIds.add(id);
             }

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -191,7 +191,7 @@ export class ACSConversation {
                                 postedMessageIds.add(id);
                             }
                         } catch {
-                            // Ignore message processing failures
+                            console.warn('[ACSClient][registerOnNewMessage] Error occurred while processing messages with id : ', id);
                         }
 
                     }

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -48,12 +48,12 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
             }
         }
 
-        if (metadata && metadata.amsMetadata && metadata.amsReferences || metadata.amsreferences) {
+        if (metadata && metadata.amsMetadata && metadata.amsReferences || metadata?.amsreferences) {
             try {
                 const data = JSON.parse(metadata.amsMetadata);
 
                 // "amsreferences" takes precedence
-                const references = JSON.parse(metadata.amsreferences || metadata.amsReferences);
+                const references = JSON.parse(metadata.amsreferences || metadata?.amsReferences);
                 const { fileName, contentType } = data[0];
 
                 // fileMetadata should be defined only when there's an attachment


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

Under certain scenarios, messages coming from PVA are not passed to the callback function , due to an exception while iterating messages.

_Include a description of the problem to be solved_

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Ensure an exception during iteration of messages doesnt disrupt the iteration.
additional it was removed code related to V1.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

- Messages are always presents and callback is executed when subscribed to onNewMessage
- V1 code is removed and tests updated

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
#### Messages received and callback executed
![image](https://github.com/user-attachments/assets/c8160d9b-e808-4720-9bb1-ae4d3a38dd86)


#### Messages received under slow network
![image](https://github.com/user-attachments/assets/c1ac7e3a-c6a1-471c-8538-9efe67b4b465)


### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
