### PR TITLE
Extend getchat token : pass Ms-Oc-Bot-Application-Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,47 @@ const optionalParams = {
 await chatSDK.initialize(optionalParams);
 ```
 
+## Passing cpsBotId on initialization
+
+cpsBotId in UUID format, when present will use v4 for GetchatToken. (Limited to enabled orgs) establishing the connection with Copilot Bot specified.
+
+### Scenarios
+
+- if bot id is present and valid, SDK will use `V4` for `GetchatToken` establishing the connection with the dessired Copilot Bot.
+- if bot Id is not present, flow will continue using `V2` for `GetchatToken`
+- if bot Id is not in valid format, expect a `400 HTTP Response Error Code`
+- if bot Id is not enabled for the workstream, expect `403 HTTP Response Error Code`
+
+```ts
+
+import OmnichannelChatSDK from '@microsoft/omnichannel-chat-sdk';
+
+const omnichannelConfig = {
+    orgUrl: "",
+    orgId: "",
+    widgetId: "",
+    cpsBotId: ""
+};
+
+const chatSDKConfig = { // Optional
+    dataMasking: {
+        disable: false,
+        maskingCharacter: '#'
+    }
+};
+
+const chatSDK = new OmnichannelChatSDK.OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+
+const optionalParams = {
+    getLiveChatConfigOptionalParams: {
+        sendCacheHeaders: false // Whether to send Cache-Control HTTP header to GetChatConfig call
+    }
+};
+
+await chatSDK.initialize(optionalParams);
+
+```
+
 ### Start Chat
 
 It starts an Omnichannel conversation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@azure/communication-chat": "1.5.4",
         "@azure/communication-common": "2.3.1",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.2",
-        "@microsoft/ocsdk": "^0.5.13",
+        "@microsoft/ocsdk": "^0.5.14",
         "@microsoft/omnichannel-amsclient": "^0.1.8",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
       },
@@ -1484,9 +1484,10 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.13.tgz",
-      "integrity": "sha512-t83WHZiIu7RLWpNw2u6TxnwX4qGhcg1Rqp11IIE3xoS1uk16mcs1cKZJmIs451f3tv1RZTUbiQU/BnjVVxH2sQ==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.14.tgz",
+      "integrity": "sha512-818znMFK5pm2aYjSR8UcqYk1DHGrgQs4RwZ0eDsakH9myBwzqu+Z+RwjfDLCGM0WLtZM9xzH0HUwPtnNi7hTPQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^22.13.10",
@@ -7448,9 +7449,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.13.tgz",
-      "integrity": "sha512-t83WHZiIu7RLWpNw2u6TxnwX4qGhcg1Rqp11IIE3xoS1uk16mcs1cKZJmIs451f3tv1RZTUbiQU/BnjVVxH2sQ==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.14.tgz",
+      "integrity": "sha512-818znMFK5pm2aYjSR8UcqYk1DHGrgQs4RwZ0eDsakH9myBwzqu+Z+RwjfDLCGM0WLtZM9xzH0HUwPtnNi7hTPQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^22.13.10",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@azure/communication-chat": "1.5.4",
     "@azure/communication-common": "2.3.1",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.2",
-    "@microsoft/ocsdk": "^0.5.13",
+    "@microsoft/ocsdk": "^0.5.14",
     "@microsoft/omnichannel-amsclient": "^0.1.8",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1153,7 +1153,7 @@ class OmnichannelChatSDK {
                     getChatTokenOptionalParams.refreshToken = optionalParams?.refreshToken;
                 }
 
-                if (this.botCSPId){
+                if (this.botCSPId) {
                     getChatTokenOptionalParams.MsOcBotApplicationId = this.botCSPId;
                 }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -146,6 +146,7 @@ class OmnichannelChatSDK {
     private AMSClientLoadCurrentState: AMSClientLoadStates = AMSClientLoadStates.NOT_LOADED;
     private isMaskingDisabled = false;
     private maskingCharacter = "#";
+    private botCSPId: string | null = null;
 
     constructor(omnichannelConfig: OmnichannelConfig, chatSDKConfig: ChatSDKConfig = defaultChatSDKConfig) {
         this.debug = false;
@@ -198,6 +199,10 @@ class OmnichannelChatSDK {
         if (this.chatSDKConfig.dataMasking) {
             this.isMaskingDisabled = this.chatSDKConfig.dataMasking.disable;
             this.maskingCharacter = this.chatSDKConfig.dataMasking.maskingCharacter;
+        }
+
+        if (omnichannelConfig.cpsBotId) {
+            this.botCSPId = omnichannelConfig.cpsBotId;
         }
 
         loggerUtils.setRequestId(this.requestId, this.ocSdkLogger, this.acsClientLogger, this.acsAdapterLogger, this.callingSdkLogger, this.amsClientLogger, this.ic3ClientLogger);
@@ -1074,6 +1079,10 @@ class OmnichannelChatSDK {
 
                 if (optionalParams?.refreshToken === true) {
                     getChatTokenOptionalParams.refreshToken = optionalParams?.refreshToken;
+                }
+
+                if (this.botCSPId){
+                    getChatTokenOptionalParams.MsOcBotApplicationId = this.botCSPId;
                 }
 
                 const chatToken = await this.OCClient.getChatToken(this.requestId, getChatTokenOptionalParams);

--- a/src/core/OmnichannelConfig.ts
+++ b/src/core/OmnichannelConfig.ts
@@ -2,4 +2,5 @@ export default interface OmnichannelConfig {
     orgId: string;
     orgUrl: string;
     widgetId: string;
+    cpsBotId?: string;
 }


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

_Include a description of the problem to be solved_

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Depends on https://github.com/microsoft/omnichannel-sdk/pull/135
## Passing cpsBotId on initialization

cpsBotId in UUID format, when present will use v4 for GetchatToken. (Limited to enabled orgs) establishing the connection with Copilot Bot specified.

### Scenarios

- if bot id is present and valid, SDK will use `V4` for `GetchatToken` establishing the connection with the dessired Copilot Bot.
- if bot Id is not present, flow will continue using `V2` for `GetchatToken`
- if bot Id is not in valid format, expect a `400 HTTP Response Error Code`
- if bot Id is not enabled for the workstream, expect `403 HTTP Response Error Code`

```ts

import OmnichannelChatSDK from '@microsoft/omnichannel-chat-sdk';

const omnichannelConfig = {
    orgUrl: "",
    orgId: "",
    widgetId: "",
    cpsBotId: ""
};

const chatSDKConfig = { // Optional
    dataMasking: {
        disable: false,
        maskingCharacter: '#'
    }
};

const chatSDK = new OmnichannelChatSDK.OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);

const optionalParams = {
    getLiveChatConfigOptionalParams: {
        sendCacheHeaders: false // Whether to send Cache-Control HTTP header to GetChatConfig call
    }
};

await chatSDK.initialize(optionalParams);

```


### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/user-attachments/assets/d35fcf23-8399-4c8d-ba5a-499d9ab391ac)

![image](https://github.com/user-attachments/assets/4473290d-9a28-4791-993e-ae21ea5c3cd6)


### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
