### PR TITLE
Adding mechanism for better fetching of messages while waiting for websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## Added
 
-- Adding mechanism to fetch messages with incremental backoff time to avoid throttling while waiting for websocket to be ready.
+- Reduce polling interval with exponential backoff
 
 ## [1.10.10] - 2025-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Added
+
+- Adding mechanism to fetch messages with incremental backoff time to avoid throttling while waiting for websocket to be ready.
+
 ## [1.10.10] - 2025-02-18
 
 ### Changed

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -5,6 +5,7 @@ import { ChatMessageEditedEvent, ChatMessageReceivedEvent, ParticipantsRemovedEv
 import ACSChatMessageType from "./ACSChatMessageType";
 import ACSClientConfig from "./ACSClientConfig";
 import { ACSClientLogger } from "../../utils/loggers";
+import ACSGetMessagesOptionalParams from "./ACSClientGetMessagesOptionParams";
 import ACSParticipantDisplayName from "./ACSParticipantDisplayName";
 import ACSSessionInfo from "./ACSSessionInfo";
 import ChatSDKMessage from "./ChatSDKMessage";
@@ -13,7 +14,6 @@ import LiveChatVersion from "../LiveChatVersion";
 import OmnichannelMessage from "./OmnichannelMessage";
 import createOmnichannelMessage from "../../utils/createOmnichannelMessage";
 import { defaultMessageTags } from "./MessageTags";
-import ACSGetMessagesOptionalParams from "./ACSClientGetMessagesOptionParams";
 
 enum ACSClientEvent {
     InitializeACSClient = 'InitializeACSClient',
@@ -36,6 +36,9 @@ export interface ParticipantMapping {
     [key: string]: ChatParticipant;
 }
 
+function* nextDelay() {
+    yield* [1000, 1000, 2000, 3000, 5000, 8000, 10000];
+}
 export class ACSConversation {
     private logger: ACSClientLogger | null = null;
     private tokenCredential: AzureCommunicationTokenCredential;
@@ -171,11 +174,11 @@ export class ACSConversation {
         const postedMessageIds = new Set();
 
         try {
-            const pollForMessages = async (delay: number) => {
+            const pollForMessages = async (delayGenerator: Generator<number, void, unknown>) => {
                 if (isReceivingNotifications) {
+                    console.log("Not receiving notifications, skipping polling");
                     return;
                 }
-
                 try {
                     const messages = await this.getMessages({skipConversion: true});
                     for (const message of messages.reverse()) {
@@ -201,13 +204,15 @@ export class ACSConversation {
                     // Ignore polling failures
                 }
 
+                const delay = delayGenerator.next();
                 setTimeout(() => {
-                    pollForMessages(delay);
-                }, delay);
+                    pollForMessages(delayGenerator);
+                }, delay.done === true ? 10000 : delay.value);
             };
 
             // Poll messages until WS established connection
-            await pollForMessages(this.sessionInfo?.pollingInterval as number);
+            const delayGenerator = nextDelay();
+            await pollForMessages(delayGenerator);
             const listener = (event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
                 isReceivingNotifications = true;
 

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -39,6 +39,7 @@ export interface ParticipantMapping {
 function* nextDelay() {
     yield* [1000, 1000, 2000, 3000, 5000, 8000, 10000];
 }
+
 export class ACSConversation {
     private logger: ACSClientLogger | null = null;
     private tokenCredential: AzureCommunicationTokenCredential;


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description
_Include a description of the problem to be solved_

Complains over possible scenarios due to latencies with websocket creation, causing the first message from copilot to do not be ready to be presented after 30 seconds, due to our internal clock for fetching.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Adding a mechanism for fetching from 1sec to max 10 secs while waiting for websocket to be ready.

This mechanism is only for users not using webchat adapter.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
### Testing with low numbers

![image](https://github.com/user-attachments/assets/4aaa8d2f-5044-4dac-8d72-3c5261b1be37)

### official numbers, high speed

![image](https://github.com/user-attachments/assets/082b1d72-107f-46d8-a747-d5097427d627)

### Official number, slow 4G
![image](https://github.com/user-attachments/assets/a326b14b-ed64-4172-a929-cf43043dbcb1)




_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
