### PR TITLE
Implement continue pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Enabling LongPooling to continue 10 secs after websocket is set, to prevent messages lost.
-- Added stopPooling method to stop the long polling when ending the chat.
+- Enabling LongPolling to continue 10 secs after websocket is set, to prevent messages lost.
+- Added stopPolling method to stop the long polling when ending the chat.
 
 ## [1.10.11] - 2025-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Enabling LongPooling to continue 10 secs after websocket is set, to prevent messages lost.
+- Added stopPooling method to stop the long polling when ending the chat.
+
 ## [1.10.11] - 2025-02-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Enabling LongPolling to continue 10 secs after websocket is set, to prevent messages lost.
+- Enabling LongPolling to continue after websocket is set, to prevent messages lost. Polling will stop when conversation ends.
 - Added stopPolling method to stop the long polling when ending the chat.
 
 ## [1.10.11] - 2025-02-20

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3048,7 +3048,8 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3079,7 +3080,8 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3108,7 +3110,8 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3139,7 +3142,8 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3170,7 +3174,8 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3200,6 +3205,9 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             chatSDK.AMSClient.initialize = jest.fn();
 
             await chatSDK.startChat();
+            chatSDK.conversation = {
+                stopPooling: jest.fn()
+            };
 
             try {
                 await chatSDK.endChat();
@@ -3250,7 +3258,8 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             chatSDK.authenticatedUserToken = optionalParams.authenticatedUserToken;
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling: jest.fn()
             };
 
             const sessionCloseOptionalParams = {

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -3049,7 +3049,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3081,7 +3081,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3111,7 +3111,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3143,7 +3143,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3175,7 +3175,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -3206,7 +3206,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             await chatSDK.startChat();
             chatSDK.conversation = {
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             try {
@@ -3259,7 +3259,7 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             chatSDK.authenticatedUserToken = optionalParams.authenticatedUserToken;
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             const sessionCloseOptionalParams = {

--- a/__tests__/OmnichannelChatSDKParallel.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.spec.ts
@@ -2354,7 +2354,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling : jest.fn()
+                stopPolling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2391,7 +2391,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling : jest.fn()
+                stopPolling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2430,7 +2430,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling : jest.fn()
+                stopPolling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2470,7 +2470,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling : jest.fn()
+                stopPolling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2508,7 +2508,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling : jest.fn()
+                stopPolling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2603,7 +2603,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             chatSDK.authenticatedUserToken = optionalParams.authenticatedUserToken;
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling: jest.fn()
+                stopPolling: jest.fn()
             };
 
             const sessionCloseOptionalParams = {
@@ -2639,7 +2639,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             chatSDK.conversation = {
                 disconnect: jest.fn(),
-                stopPooling : jest.fn()
+                stopPolling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');

--- a/__tests__/OmnichannelChatSDKParallel.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.spec.ts
@@ -2303,7 +2303,9 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
 
-            await chatSDK.initialize({ useParallelLoad: true }); while (chatSDK.AMSClient === null) {
+            await chatSDK.initialize({ useParallelLoad: true });
+
+            while (chatSDK.AMSClient === null) {
                 await new Promise(resolve => setTimeout(resolve, 2000));
             }
 
@@ -2328,6 +2330,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
         });
 
         it('ChatSDK.endChat() should end conversation', async () => {
+
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2350,7 +2353,8 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2386,7 +2390,8 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2424,7 +2429,8 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2440,6 +2446,7 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
         });
 
         it('ChatSDK.endChat() with optional params set as empty should call sessionClose', async () => {
+            //
             const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
@@ -2462,10 +2469,12 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
+
             await chatSDK.endChat({});
 
             expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
@@ -2498,7 +2507,8 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');
@@ -2592,7 +2602,8 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             chatSDK.authenticatedUserToken = optionalParams.authenticatedUserToken;
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling: jest.fn()
             };
 
             const sessionCloseOptionalParams = {
@@ -2627,7 +2638,8 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             await chatSDK.startChat();
 
             chatSDK.conversation = {
-                disconnect: jest.fn()
+                disconnect: jest.fn(),
+                stopPooling : jest.fn()
             };
 
             const conversationDisconnectFn = jest.spyOn(chatSDK.conversation, 'disconnect');

--- a/playwright/public/index.html
+++ b/playwright/public/index.html
@@ -9,6 +9,7 @@
     <script>var exports = {};</script> <!-- Fix for "Uncaught ReferenceError: exports is not defined" -->
     <script src="./scripts/globals.js"></script>
     <script src='../dist/lib.js'></script>
+    <!--<script src="./scripts/sdk.js"></script>-->
 </head>
 <body>
 </body>

--- a/playwright/public/scripts/sdk.js
+++ b/playwright/public/scripts/sdk.js
@@ -1,0 +1,60 @@
+/**
+ * This is a test JS file to test the SDK simulating an scenario, this is to test the SDK locally
+ *  1.- Enable the JS in the ../index.html file
+ *  2.- go to server and run `node app.js`
+ *  3.- go to localhost:3000 and open the console
+ *
+ * important : index.html wont run locally in the browser without a server behind , because there are security validations for AMS iframe.
+ */
+
+const run = async () => {
+
+    // cpsBotId if needed, add it here 
+    const omnichannelConfig = {
+        orgId: "",
+        orgUrl: "",
+        widgetId: "",
+    }
+
+    const { sleep } = window;
+    const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+    const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+
+    await chatSDK.initialize();
+
+    await chatSDK.startChat();
+
+    console.table(await chatSDK.getMessages());
+
+    const messages = [];
+
+    try {
+        chatSDK.onNewMessage((message) => {
+            console.log("*************** New Message Alert ************************", JSON.stringify(message));
+
+            messages.push(message);
+        }, { rehydrate: true });
+    } catch (err) {
+        runtimeContext.errorMessage = `${err.message}`;
+        runtimeContext.errorObject = `${err}`;
+    }
+
+    await chatSDK.sendMessage({ "content": "help" });
+    await sleep(30000);
+    console.log("*************** ALL MESSAGES ************************");
+    console.table(await chatSDK.getMessages());
+
+    console.log("*************** Pushed Messages ************************");
+    console.table(messages);
+    console.log("*************** ENDING CHAT MID FLY ************************");
+
+    await chatSDK.endChat();
+
+
+    await sleep(30000);
+    console.log("*************** ALL MESSAGES BEFORE END CHAT ************************");
+    console.table(await chatSDK.getMessages());
+
+};
+
+run();

--- a/playwright/public/scripts/sdk.js
+++ b/playwright/public/scripts/sdk.js
@@ -2,7 +2,7 @@
  * This is a test JS file to test the SDK simulating an scenario, this is to test the SDK locally
  *  1.- Enable the JS in the ../index.html file
  *  2.- go to server and run `node app.js`
- *  3.- go to localhost:3000 and open the console
+ *  3.- go to localhost:8080 and open the console
  *
  * important : index.html wont run locally in the browser without a server behind , because there are security validations for AMS iframe.
  */

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -855,7 +855,7 @@ class OmnichannelChatSDK {
         }
 
         try {
-            await (this.conversation as ACSConversation)?.stopPooling();
+            await (this.conversation as ACSConversation)?.stopPolling();
 
             // calling close chat, internally will handle the session close
             await this.closeChat(endChatOptionalParams);

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -855,6 +855,7 @@ class OmnichannelChatSDK {
         }
 
         try {
+            await (this.conversation as ACSConversation)?.stopPooling();
 
             // calling close chat, internally will handle the session close
             await this.closeChat(endChatOptionalParams);

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -57,7 +57,7 @@ export class ACSConversation {
         this.eventListeners = {};
     }
 
-    public async stopPooling() : Promise<void>  {
+    public async stopPolling() : Promise<void>  {
         this.conversationEnded = true;
     }
 

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -175,12 +175,12 @@ export class ACSConversation {
 
     public async registerOnNewMessage(onNewMessageCallback: CallableFunction): Promise<void> {
         this.logger?.startScenario(ACSClientEvent.RegisterOnNewMessage);
-
+        let isReceivingNotifications = false;
         const postedMessageIds = new Set();
 
         try {
             const pollForMessages = async (delayGenerator: Generator<number, void, unknown>) => {
-                if (this.conversationEnded === true) {
+                if (isReceivingNotifications || this.conversationEnded === true) {
                     return;
                 }
 
@@ -219,6 +219,8 @@ export class ACSConversation {
             const delayGenerator = nextDelay();
             await pollForMessages(delayGenerator);
             const listener = (event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
+                isReceivingNotifications = true;
+
                 const { id, sender } = event;
 
                 const customerMessageCondition = ((sender as CommunicationUserIdentifier).communicationUserId === (this.sessionInfo?.id as string));

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -175,12 +175,11 @@ export class ACSConversation {
 
     public async registerOnNewMessage(onNewMessageCallback: CallableFunction): Promise<void> {
         this.logger?.startScenario(ACSClientEvent.RegisterOnNewMessage);
-        let isReceivingNotifications = false;
         const postedMessageIds = new Set();
 
         try {
             const pollForMessages = async (delayGenerator: Generator<number, void, unknown>) => {
-                if (isReceivingNotifications || this.conversationEnded === true) {
+                if ( this.conversationEnded === true) {
                     return;
                 }
 
@@ -219,8 +218,6 @@ export class ACSConversation {
             const delayGenerator = nextDelay();
             await pollForMessages(delayGenerator);
             const listener = (event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
-                isReceivingNotifications = true;
-
                 const { id, sender } = event;
 
                 const customerMessageCondition = ((sender as CommunicationUserIdentifier).communicationUserId === (this.sessionInfo?.id as string));

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -220,8 +220,8 @@ export class ACSConversation {
             await pollForMessages(delayGenerator);
             const listener = (event: ChatMessageReceivedEvent | ChatMessageEditedEvent) => {
 
-                // Stop polling after 30 seconds to ensure no message is lost
-                setTimeout(()=>isReceivingNotifications = true, 30000);
+                // Stop polling after 10 seconds to ensure no message is lost
+                setTimeout(()=>isReceivingNotifications = true, 10000);
 
                 const { id, sender } = event;
 

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -57,7 +57,7 @@ export class ACSConversation {
         this.eventListeners = {};
     }
 
-    public async stopPooling(){
+    public async stopPooling() : Promise<void>  {
         this.conversationEnded = true;
     }
 


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description
_Include a description of the problem to be solved_
In some scenarios, customer states first message from copilot is "lost", it seems this is due to an off-sync when websocket is initializing and pooling stops.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

- Enable Pooling to continue for 10 secs after websocket has initialized, as backup , to prevent messages in transit being lost
- When endchat is called, ensure pooling is stop as well


### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Endchat in the middle of the conversation and long pool must stop
![image](https://github.com/user-attachments/assets/a2184c22-cde5-4783-af7f-5d931bf5c243)

### Normal flow
![image](https://github.com/user-attachments/assets/86accac2-85ff-4b58-b471-80819238dd27)
#### no more pooling after session close
![image](https://github.com/user-attachments/assets/56a8a6b3-6b68-41ad-af58-cfca647f42db)

### Slow 4G
![image](https://github.com/user-attachments/assets/e45231e6-57ec-40aa-a216-6e8fb1e63572)
#### no more pooling after session close
![image](https://github.com/user-attachments/assets/100717e1-4206-4e8b-8e50-915b5310606c)


### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
