### PR TITLE
updated getLiveChatTranscript for persistent chat livechatcontext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Updated getLivechatTranscript livechatcontect check for persistent chat
 - Updake [@microsoft/botframework-webchat-adapter-azure-communication-chat@0.0.1-beta.2](https://www.npmjs.com/package/@microsoft/botframework-webchat-adapter-azure-communication-chat/v/0.0.1-beta.2)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated getLivechatTranscript livechatcontect check for persistent chat
+
 ## [1.10.13] - 2025-03-04
 
 ### Added
@@ -12,7 +16,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Updated getLivechatTranscript livechatcontect check for persistent chat
 - Updake [@microsoft/botframework-webchat-adapter-azure-communication-chat@0.0.1-beta.2](https://www.npmjs.com/package/@microsoft/botframework-webchat-adapter-azure-communication-chat/v/0.0.1-beta.2)
 
 ### Fixed

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1740,8 +1740,13 @@ class OmnichannelChatSDK {
         let sessionId = this.sessionId;
 
         if (optionalParams.liveChatContext) {
-            requestId = optionalParams.liveChatContext.requestId;
-            chatToken = optionalParams.liveChatContext.chatToken;
+            if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
+                requestId = this.requestId || optionalParams.liveChatContext.requestId;
+                chatToken = this.chatToken && Object.keys(this.chatToken).length > 0 ? this.chatToken : optionalParams.liveChatContext.chatToken;
+            } else {
+                requestId = optionalParams.liveChatContext.requestId;
+                chatToken = optionalParams.liveChatContext.chatToken;
+            }
             chatId = chatToken.chatId as string;
         }
 


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

BUG 4729209

### Description

getLiveChatTranscript failed if download transcript happens after endChat for persistent chat

## Solution Proposed

added additional check for persistent chat with livechatcontext if download transcript happens after endChat 

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
