### PR TITLE
checking for conversationState when participants is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add check for getConversation details before call onAgentEndSession call back since participant removed is not reliable
+
 ## [1.10.13] - 2025-03-04
 
 ### Added

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1463,6 +1463,7 @@ class OmnichannelChatSDK {
                     const liveWorkItemDetails = await this.getConversationDetails();
                     if (Object.keys(liveWorkItemDetails).length === 0 || liveWorkItemDetails.state == LiveWorkItemState.WrapUp || liveWorkItemDetails.state == LiveWorkItemState.Closed) {
                         onAgentEndSessionCallback(event);
+                        this.stopPolling();
                     }
                 });
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1459,8 +1459,11 @@ class OmnichannelChatSDK {
 
         if (this.liveChatVersion === LiveChatVersion.V2) {
             try {
-                (this.conversation as ACSConversation).registerOnThreadUpdate((event: ParticipantsRemovedEvent) => {
-                    onAgentEndSessionCallback(event);
+                (this.conversation as ACSConversation).registerOnThreadUpdate(async (event: ParticipantsRemovedEvent) => {
+                    const liveWorkItemDetails = await this.getConversationDetails();
+                    if (Object.keys(liveWorkItemDetails).length === 0 || liveWorkItemDetails.state == LiveWorkItemState.WrapUp || liveWorkItemDetails.state == LiveWorkItemState.Closed) {
+                        onAgentEndSessionCallback(event);
+                    }
                 });
 
                 this.scenarioMarker.completeScenario(TelemetryEvent.OnAgentEndSession, {


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

Checking if conversation ended when onAgentEndSession call back is fired, 

## Solution Proposed

_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
