### PR TITLE
Added exception details for sendMessage telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added exception details for telemetry for SendMessage
+
 ## [1.10.15] - 2025-03-11
 
 ### Security

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -394,7 +394,7 @@ describe('ACSClient', () => {
                 done: jest.fn()
             })),
         }));
-        chatThreadClient.sendMessage = jest.fn(() => Promise.reject());
+        chatThreadClient.sendMessage = jest.fn(() => Promise.reject(new Error('SendMessageFailed')));
 
         client.chatClient = {};
         client.chatClient.getChatThreadClient = jest.fn(() => chatThreadClient);

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1295,12 +1295,17 @@ class OmnichannelChatSDK {
                     ChatId: this.chatToken.chatId as string
                 });
             } catch (error) {
+                const exceptionDetails = {
+                    response: ChatSDKErrorName.ChatSDKSendMessageFailed,
+                    errorObject: `${error}`
+                };
                 this.scenarioMarker.failScenario(TelemetryEvent.SendMessages, {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string,
+                    ExceptionDetails: JSON.stringify(exceptionDetails)
                 });
 
-                throw new Error('ChatSDKSendMessageFailed');
+                throw new Error(ChatSDKErrorName.ChatSDKSendMessageFailed);
             }
         } else {
             const messageToSend: IRawMessage = {
@@ -1333,13 +1338,18 @@ class OmnichannelChatSDK {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string
                 });
-            } catch {
+            } catch (error) {
+                const exceptionDetails = {
+                    response: ChatSDKErrorName.ChatSDKSendMessageFailed,
+                    errorObject: `${error}`
+                };
                 this.scenarioMarker.failScenario(TelemetryEvent.SendMessages, {
                     RequestId: this.requestId,
-                    ChatId: this.chatToken.chatId as string
+                    ChatId: this.chatToken.chatId as string,
+                    ExceptionDetails: JSON.stringify(exceptionDetails)
                 });
 
-                throw new Error('ChatSDKSendMessageFailed');
+                throw new Error(ChatSDKErrorName.ChatSDKSendMessageFailed);
             }
         }
     }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1295,7 +1295,7 @@ class OmnichannelChatSDK {
                     ChatId: this.chatToken.chatId as string
                 });
             } catch (error) {
-                const exceptionDetails = {
+                const exceptionDetails: ChatSDKExceptionDetails = {
                     response: ChatSDKErrorName.ChatSDKSendMessageFailed,
                     errorObject: `${error}`
                 };
@@ -1339,7 +1339,7 @@ class OmnichannelChatSDK {
                     ChatId: this.chatToken.chatId as string
                 });
             } catch (error) {
-                const exceptionDetails = {
+                const exceptionDetails: ChatSDKExceptionDetails = {
                     response: ChatSDKErrorName.ChatSDKSendMessageFailed,
                     errorObject: `${error}`
                 };

--- a/src/core/ChatSDKError.ts
+++ b/src/core/ChatSDKError.ts
@@ -56,6 +56,8 @@ export enum ChatSDKErrorName {
     UndefinedAuthToken = "UndefinedAuthToken",
 
     UnknownAMSLoadState = "UnknownAMSLoadState",
+     /** Send message failure */
+    ChatSDKSendMessageFailed = "ChatSDKSendMessageFailed",
 
 }
 

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -345,7 +345,7 @@ export class ACSConversation {
                 ExceptionDetails: JSON.stringify(exceptionDetails)
             });
 
-            throw new Error('SendMessageFailed');
+            throw error;
         }
     }
 


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference
[BUG 4787637](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4787637)

### Description
Ensure exception details contains propagated data

## Solution Proposed
Add exception details for sendMessage calls for telemetry with propagated data.

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

Verified locally and able to see exception details in telemetry for sendMessagesFailed event of ocsdk.

<img width="1304" alt="Screenshot 2025-03-19 at 2 49 06 PM" src="https://github.com/user-attachments/assets/58363ab2-4e71-422a-8d53-6ce32db528de" />


### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
