### PR TITLE
fix to prevent double load for AMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Issue when using setDebug leading to double load of AMS
+
 ## [1.10.15] - 2025-03-11
 
 ### Security

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -37,6 +37,7 @@ import ConversationMode from "./core/ConversationMode";
 import DeliveryMode from "@microsoft/omnichannel-ic3core/lib/model/DeliveryMode";
 import EmailLiveChatTranscriptOptionaParams from "./core/EmailLiveChatTranscriptOptionalParams";
 import EndChatOptionalParams from "./core/EndChatOptionalParams";
+import FetchChatTokenResponse from "@microsoft/ocsdk/lib/Model/FetchChatTokenResponse";
 import FileMetadata from "@microsoft/omnichannel-amsclient/lib/FileMetadata";
 import FileSharingProtocolType from "@microsoft/omnichannel-ic3core/lib/model/FileSharingProtocolType";
 import FramedClient from "@microsoft/omnichannel-amsclient/lib/FramedClient";
@@ -109,7 +110,6 @@ import startPolling from "./commands/startPolling";
 import stopPolling from "./commands/stopPolling";
 import urlResolvers from "./utils/urlResolvers";
 import validateOmnichannelConfig from "./validators/OmnichannelConfigValidator";
-import FetchChatTokenResponse from "@microsoft/ocsdk/lib/Model/FetchChatTokenResponse";
 
 class OmnichannelChatSDK {
     private debug: boolean;
@@ -276,15 +276,17 @@ class OmnichannelChatSDK {
         try {
             if (this.liveChatVersion === LiveChatVersion.V2) {
                 this.ACSClient = new ACSClient(this.acsClientLogger);
-                this.AMSClientLoadCurrentState = AMSClientLoadStates.LOADING;
+                if (this.AMSClientLoadCurrentState === AMSClientLoadStates.NOT_LOADED) {
 
-                this.AMSClient = await createAMSClient({
-                    framedMode: isBrowser(),
-                    multiClient: true,
-                    debug: false,
-                    logger: this.amsClientLogger as PluggableLogger
-                });
-                this.AMSClientLoadCurrentState = AMSClientLoadStates.LOADED;
+                    this.AMSClientLoadCurrentState = AMSClientLoadStates.LOADING;
+                    this.AMSClient = await createAMSClient({
+                        framedMode: isBrowser(),
+                        multiClient: true,
+                        debug: false,
+                        logger: this.amsClientLogger as PluggableLogger
+                    });
+                    this.AMSClientLoadCurrentState = AMSClientLoadStates.LOADED;
+                }
             } else if (this.liveChatVersion === LiveChatVersion.V1) {
                 this.IC3Client = await this.getIC3Client();
             }
@@ -298,7 +300,6 @@ class OmnichannelChatSDK {
 
     private async parallelInitialization(optionalParams: InitializeOptionalParams = {}) {
         try {
-
             this.scenarioMarker.startScenario(TelemetryEvent.InitializeChatSDKParallel);
 
             if (this.isInitialized) {
@@ -359,13 +360,18 @@ class OmnichannelChatSDK {
 
             if (this.liveChatVersion === LiveChatVersion.V2) {
                 this.ACSClient = new ACSClient(this.acsClientLogger);
-                this.AMSClient = await createAMSClient({
-                    framedMode: isBrowser(),
-                    multiClient: true,
-                    debug: false,
-                    logger: this.amsClientLogger as PluggableLogger
-                });
-                this.AMSClientLoadCurrentState = AMSClientLoadStates.LOADED;
+
+                if (this.AMSClientLoadCurrentState === AMSClientLoadStates.NOT_LOADED) {
+                    this.AMSClientLoadCurrentState = AMSClientLoadStates.LOADING;
+                    this.AMSClient = await createAMSClient({
+                        framedMode: isBrowser(),
+                        multiClient: true,
+                        debug: false,
+                        logger: this.amsClientLogger as PluggableLogger
+                    });
+                    this.AMSClientLoadCurrentState = AMSClientLoadStates.LOADED;
+                }
+
             } else if (this.liveChatVersion === LiveChatVersion.V1) {
                 this.IC3Client = await this.getIC3Client();
             }


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description
_Include a description of the problem to be solved_

under debug scenarios, AMS client is loaded twice , one for debug set and second for sdk initialization

## Solution Proposed

_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

![image](https://github.com/user-attachments/assets/77b19b1c-8887-461d-a3a6-a482a4383776)

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
