### PR TITLE
Update Message Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Added exception details for telemetry for SendMessage
+- Expose `OriginalMessageId` to `ChatSDK.onNewMessage()` to handle message ordering
 
 ### Changed
 - Uptake [@microsoft/ocsdk@0.5.13](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.13)

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -248,4 +248,56 @@ describe('createOmnichannelMessage', () => {
             url: ''
         });
     });
+
+    it('createOmnichannelMessage with LiveChatV2 messaging contracts with \'OriginalMessageId\' should return OmnichannelMessage contracts', () => {
+        const amsReferences = ['id'];
+        const amsMetadata = [{fileName: 'fileName.ext', size: 0, contentType: 'type'}]
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: 'tags',
+                amsMetadata: JSON.stringify(amsMetadata),
+                amsReferences: JSON.stringify(amsReferences),
+                OriginalMessageId: 'originalMessageId'
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        const omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+            liveChatVersion: LiveChatVersion.V2
+        });
+
+        expect(omnichannelMessage.id).toBeDefined();
+        expect(omnichannelMessage.messageid).toBe(undefined);
+        expect(omnichannelMessage.clientmessageid).toBe(undefined);
+        expect(omnichannelMessage.deliveryMode).toBe(undefined);
+        expect(omnichannelMessage.content).toBe(sampleMessage.content);
+        expect(omnichannelMessage.properties).toBeDefined();
+        expect(omnichannelMessage.tags).toEqual(sampleMessage.metadata.tags.split(','));
+        expect(omnichannelMessage.timestamp).toBe(sampleMessage.createdOn);
+        expect(omnichannelMessage.messageType).toBe(MessageType.UserMessage);
+        expect(omnichannelMessage.sender).toEqual({
+            id: sampleMessage.sender.communicationUserId,
+            displayName: sampleMessage.senderDisplayName,
+            type: PersonType.Bot
+        });
+        expect(omnichannelMessage.fileMetadata).toEqual({
+            fileSharingProtocolType: 0,
+            id: amsReferences[0],
+            name: amsMetadata[0].fileName,
+            size: 0,
+            type: amsMetadata[0].contentType,
+            url: ''
+        });
+
+        if (omnichannelMessage.properties) {
+            expect(omnichannelMessage.properties.originalMessageId).toEqual(sampleMessage.metadata.OriginalMessageId);
+        }
+    });
 });

--- a/src/core/messaging/OmnichannelMessage.ts
+++ b/src/core/messaging/OmnichannelMessage.ts
@@ -31,7 +31,8 @@ export interface IPerson {
 }
 
 export interface IMessageProperties {
-    [id: string]: string;
+    OriginalMessageId?: string; // Original message id from the source messaging channel before bridging and any retries
+    [id: string]: string | undefined;
 }
 
 export enum FileSharingProtocolType {

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -68,6 +68,12 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
                 // Suppress errors to keep chat flowing
             }
         }
+
+        // OriginalMessageId is used to track the original message id from the source messaging channel before bridging and any retries
+        if (metadata && metadata.OriginalMessageId) {
+            omnichannelMessage.properties.originalMessageId = metadata.OriginalMessageId;
+        }
+
     } else {
         const { clientmessageid } = message as IRawMessage;
         omnichannelMessage.id = clientmessageid as string;


### PR DESCRIPTION
- Expose `OriginalMessageId` on `ChatSDK.onNewMessage()` to handle message ordering