### PR TITLE
Integration Test- Verify 'useCreateConversation.disable: false' triggers Create Conversation flow

### DIFF
--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -795,7 +795,7 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         expect(liveChatContextConversationDetails.canRenderPostChat).toBeDefined();
     });
 
-    test('Verify `useCreateConversation.disable: false` triggers Create Conversation flow', async ({ page }) => {
+    test('ChatSDK.initialize() with ChatSDK Configuration "useCreateConversation" enabled should perform create conversation call', async ({ page }) => {
         await page.goto(testPage);
 
         const [conversationRequest, conversationResponse, runtimeContext] = await Promise.all([

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -794,4 +794,43 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         expect(liveChatContextConversationDetails.conversationId).toBeDefined();
         expect(liveChatContextConversationDetails.canRenderPostChat).toBeDefined();
     });
+
+    test('Verify `useCreateConversation.disable: false` triggers Create Conversation flow', async ({ page }) => {
+        await page.goto(testPage);
+
+        const [conversationRequest, conversationResponse, runtimeContext] = await Promise.all([
+            page.waitForRequest(request => {
+                return request.url().includes(OmnichannelEndpoints.LiveChatOrganization);
+            }),
+            page.waitForResponse(response => {
+                return response.url().includes(OmnichannelEndpoints.LiveChatOrganization);
+            }),
+            await page.evaluate(async ({ omnichannelConfig }) => {
+                const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, {
+                    useCreateConversation: {
+                        disable: false,
+                    }
+                });
+
+                await chatSDK.initialize();
+
+                const runtimeContext = {
+                    orgUrl: chatSDK.omnichannelConfig.orgUrl,
+                    requestId: chatSDK.requestId
+                };
+
+                await chatSDK.startChat();
+
+                await chatSDK.endChat();
+
+                return runtimeContext;
+            }, { omnichannelConfig })
+        ]);
+
+        const conversationRequestUrl = `${runtimeContext.orgUrl}/${OmnichannelEndpoints.LiveChatOrganization}/${omnichannelConfig.orgId}/widgetApp/${omnichannelConfig.widgetId}/conversation`;
+
+        expect(conversationRequest.url() === conversationRequestUrl).toBe(true);
+        expect(conversationResponse.status()).toBe(200);
+    });
 });

--- a/playwright/utils/OmnichannelEndpoints.ts
+++ b/playwright/utils/OmnichannelEndpoints.ts
@@ -18,4 +18,5 @@ export default class OmnichannelEndpoints {
     public static readonly LiveChatAuthReconnectableChats = "livechatconnector/auth/reconnectablechats";
     public static readonly LiveChatAuthSessionClosePath = "livechatconnector/auth/sessionclose";
     public static readonly LiveChatAuthTranscriptEmailRequestPath = "livechatconnector/auth/createemailrequest";
+    public static readonly LiveChatOrganization = "livechatconnector/organization";
 }


### PR DESCRIPTION
This PR includes the following scenario,

1. Verify `useCreateConversation.disable: false` triggers Create Conversation flow