### PR TITLE
Added 'role' attribute for bot messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added "role" attribute for bot messages in onNewMessageCallback
+- Added "role" attribute for received messages
 
 ## [1.10.18] 2025-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added "role" attribute for bot messages in onNewMessageCallback
+
 ## [1.10.18] 2025-04-09
 
 ### Added

--- a/__tests__/utils/utilities.spec.ts
+++ b/__tests__/utils/utilities.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { getRuntimeId, isNotEmpty } from "../../src/utils/utilities";
-import { isClientIdNotFoundErrorMessage, isCustomerMessage, isSystemMessage } from "../../src/utils/utilities";
+import { isClientIdNotFoundErrorMessage, isCustomerMessage, isSystemMessage, isBotMessage} from "../../src/utils/utilities";
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { MessageType } = require("../../src");
@@ -135,4 +135,61 @@ describe('Utilities', () => {
         expect(getRuntimeId(externalRuntimeId)).not.toBe(externalRuntimeId);
     });
 
+    it('utilities.isBotMessage() should return false if message is a system message', () => {
+        const message = {
+            content: 'system content',
+            messageType: MessageType.UserMessage,
+            properties: {
+                tags: ['system']
+            }
+        };
+        expect(isBotMessage(message)).toBe(false);
+    });
+
+    it('utilities.isBotMessage() should return false if message is a live agent message', () => {
+        const message = {
+            content: 'test content',
+            messageType: MessageType.UserMessage,
+            properties: {
+                tags: ['public']
+            }
+        };
+        expect(isBotMessage(message)).toBe(false);
+    });
+
+    it('utilities.isBotMessage() should return true if properties.tags is an empty', () => {
+        const message = {
+            messageType: MessageType.UserMessage,
+            properties: {
+                tags: ''
+            },
+            tags: ['random']
+        };
+
+        expect(isBotMessage(message)).toBe(true);
+    });
+
+    it('utilities.isBotMessage() should return true if message.tags is an empty', () => {
+        const message = {
+            messageType: MessageType.UserMessage,
+            properties: {
+                tags: ''
+            },
+            tags: []
+        };
+
+        expect(isBotMessage(message)).toBe(true);
+    });
+
+    it('utilities.isBotMessage() should not break if `properties.tags` property does not exist', () => {
+        const message = {
+            content: 'test',
+            messageType: MessageType.UserMessage,
+            properties: {}
+        }
+
+        const result = isBotMessage(message);
+        expect(result).toBeDefined();
+
+    });
 });

--- a/src/core/messaging/OmnichannelMessage.ts
+++ b/src/core/messaging/OmnichannelMessage.ts
@@ -25,7 +25,11 @@ export enum PersonType {
 }
 
 export enum Role {
-    Bot = "bot"
+    Bot = "bot",
+    Agent = "agent",
+    System = "system",
+    User = "user",
+    Unknown = "unknown"
 }
 
 export interface IPerson {

--- a/src/core/messaging/OmnichannelMessage.ts
+++ b/src/core/messaging/OmnichannelMessage.ts
@@ -24,6 +24,10 @@ export enum PersonType {
     Bot = 2
 }
 
+export enum Role {
+    Bot = "bot"
+}
+
 export interface IPerson {
     displayName: string;
     id: string;
@@ -71,6 +75,7 @@ interface OmnichannelMessage {
     tags?: string[];
     fileMetadata?: IFileMetadata;
     resourceType?: ResourceType;
+    role?: string;
 }
 
 export default OmnichannelMessage;

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -1,10 +1,10 @@
 import { ChatMessageEditedEvent, ChatMessageReceivedEvent } from '@azure/communication-signaling';
-import OmnichannelMessage, { IFileMetadata, IPerson, MessageType, PersonType, Role } from "../core/messaging/OmnichannelMessage";
+import OmnichannelMessage, { IFileMetadata, IPerson, MessageType, PersonType } from "../core/messaging/OmnichannelMessage";
 
 import { ChatMessage } from "@azure/communication-chat";
 import IRawMessage from "@microsoft/omnichannel-ic3core/lib/model/IRawMessage";
 import LiveChatVersion from '../core/LiveChatVersion';
-import { isBotMessage } from './utilities';
+import { getMessageRole } from './utilities';
 
 interface CreateOmnichannelMessageOptionalParams {
     liveChatVersion: LiveChatVersion;
@@ -75,10 +75,7 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
             omnichannelMessage.properties.originalMessageId = metadata.OriginalMessageId;
         }
 
-        if(isBotMessage(omnichannelMessage)) {
-            omnichannelMessage.role =  Role.Bot;
-        }
-
+        omnichannelMessage.role = getMessageRole(omnichannelMessage);
     } else {
         const { clientmessageid } = message as IRawMessage;
         omnichannelMessage.id = clientmessageid as string;

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -1,9 +1,10 @@
 import { ChatMessageEditedEvent, ChatMessageReceivedEvent } from '@azure/communication-signaling';
-import OmnichannelMessage, { IFileMetadata, IPerson, MessageType, PersonType } from "../core/messaging/OmnichannelMessage";
+import OmnichannelMessage, { IFileMetadata, IPerson, MessageType, PersonType, Role } from "../core/messaging/OmnichannelMessage";
 
 import { ChatMessage } from "@azure/communication-chat";
 import IRawMessage from "@microsoft/omnichannel-ic3core/lib/model/IRawMessage";
 import LiveChatVersion from '../core/LiveChatVersion';
+import { isBotMessage } from './utilities';
 
 interface CreateOmnichannelMessageOptionalParams {
     liveChatVersion: LiveChatVersion;
@@ -72,6 +73,10 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
         // OriginalMessageId is used to track the original message id from the source messaging channel before bridging and any retries
         if (metadata && metadata.OriginalMessageId) {
             omnichannelMessage.properties.originalMessageId = metadata.OriginalMessageId;
+        }
+
+        if(isBotMessage(omnichannelMessage)) {
+            omnichannelMessage.role =  Role.Bot;
         }
 
     } else {

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -23,6 +23,15 @@ export const isCustomerMessage = (message: any): boolean => { // eslint-disable-
     return conditionV1 || conditionV2 || false;
 }
 
+export const isBotMessage = (message: any): boolean => { // eslint-disable-line @typescript-eslint/no-explicit-any,  @typescript-eslint/explicit-module-boundary-types
+    const {messageType, properties} = message;
+
+    const conditionV1 = messageType === MessageType.UserMessage && (!properties.tags || Object.keys(properties.tags).length === 0);
+
+    const conditionV2 = message.tags && message.tags.length == 0;
+    return conditionV1 || conditionV2 || false;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export const isClientIdNotFoundErrorMessage = (e: any): boolean => {
     return e?.response?.status === 401


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

Added role attribute for bot message in onNewMessageCallback

## Solution Proposed

Added role attribute for bot message to identify message received from bot.

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
verified locally
<img width="772" alt="Screenshot 2025-05-01 at 12 32 14 AM" src="https://github.com/user-attachments/assets/5d802c0d-7be5-41cf-bccb-d2657f0ae074" />


### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
