### PR TITLE
Fix Integration Tests- ChatSDK.initialize() with ChatSDK Configuration "useCreateConversation" disabled

### DIFF
--- a/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
@@ -94,6 +94,9 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
                     persistentChat: {
                         disable: false,
                     },
+                    useCreateConversation: {
+                        disable: true,
+                    }
                 };
 
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
@@ -137,6 +140,9 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
                     persistentChat: {
                         disable: false
                     },
+                    useCreateConversation: {
+                        disable: true,
+                    }
                 };
 
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);

--- a/playwright/integrations/authenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-prechat.spec.ts
@@ -40,7 +40,10 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPrechat', () => {
                 const authToken = await response.text();
 
                 const chatSDKConfig = {
-                    getAuthToken: () => authToken
+                    getAuthToken: () => authToken,
+                    useCreateConversation: {
+                        disable: true,
+                    }
                 };
 
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);

--- a/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-reconnect.spec.ts
@@ -187,6 +187,9 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
                     chatReconnect: {
                         disable: false,
                     },
+                    useCreateConversation: {
+                        disable: true,
+                    }
                 };
 
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
@@ -224,6 +227,9 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithChatReconnect', () => {
                     chatReconnect: {
                         disable: false,
                     },
+                    useCreateConversation: {
+                        disable: true,
+                    }
                 };
 
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);

--- a/playwright/integrations/authenticated-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat.spec.ts
@@ -40,7 +40,10 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
                 const authToken = await response.text();
 
                 const chatSDKConfig = {
-                    getAuthToken: () => authToken
+                    getAuthToken: () => authToken,
+                    useCreateConversation: {
+                        disable: true,
+                    }
                 };
 
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);
@@ -100,7 +103,10 @@ test.describe('AuthenticatedChat @AuthenticatedChat', () => {
                 const authToken = await response.text();
 
                 const chatSDKConfig = {
-                    getAuthToken: () => authToken
+                    getAuthToken: () => authToken,
+                    useCreateConversation: {
+                        disable: true,
+                    }
                 };
 
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);

--- a/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-prechat.spec.ts
@@ -27,10 +27,13 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
             page.waitForResponse(response => {
                 return response.url().includes(OmnichannelEndpoints.LiveChatSessionInitPath);
             }),
-            await page.evaluate(async ({ omnichannelConfig, optionalParams, chatDuration }) => {
-                const { sleep } = window;
+            await page.evaluate(async ({ omnichannelConfig, optionalParams }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
-                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, {
+                    useCreateConversation: {
+                        disable: true,
+                    }
+                });
                 const runtimeContext = {};
 
                 await chatSDK.initialize();
@@ -44,15 +47,13 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithPrechat', () => {
 
                 runtimeContext.preChatSurvey = preChatSurveyRes;
 
-                await sleep(chatDuration);
-
                 await chatSDK.endChat();
 
                 return runtimeContext;
             }, { omnichannelConfig, optionalParams, chatDuration: testSettings.chatDuration })
         ]);
 
-        const { requestId, preChatSurvey } = runtimeContext;
+        const { requestId } = runtimeContext;
         const sessionInitRequestUrl = `${runtimeContext.orgUrl}/${OmnichannelEndpoints.LiveChatSessionInitPath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw`;
         const prechatSurveyBody = JSON.parse(optionalParams.preChatResponse.Survey);
         expect(prechatSurveyBody.Name).toEqual('OmnichannelSurvey');

--- a/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
+++ b/playwright/integrations/unauthenticated-chat-with-reconnect.spec.ts
@@ -41,6 +41,9 @@ test.describe('UnauthenticatedChat @UnauthenticatedChatWithChatReconnect', () =>
                 const chatSDKConfig = {
                     chatReconnect: {
                         disable: false,
+                    },
+                    useCreateConversation: {
+                        disable: true,
                     }
                 }
                 const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, chatSDKConfig);

--- a/playwright/integrations/unauthenticated-chat.spec.ts
+++ b/playwright/integrations/unauthenticated-chat.spec.ts
@@ -106,7 +106,11 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
-                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, {
+                    useCreateConversation: {
+                        disable: true,
+                    }
+                });
 
                 await chatSDK.initialize();
 
@@ -154,7 +158,11 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             await page.evaluate(async ({ omnichannelConfig, customContext, chatDuration }) => {
                 const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
-                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, {
+                    useCreateConversation: {
+                        disable: true,
+                    }
+                });
 
                 await chatSDK.initialize();
 
@@ -239,7 +247,11 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
         const [_, liveWorkItemDetailsRequest, liveWorkItemDetailsResponse, runtimeContext] = await Promise.all([
             await page.evaluate(async ({ omnichannelConfig }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
-                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, {
+                    useCreateConversation: {
+                        disable: true,
+                    }
+                });
 
                 await chatSDK.initialize();
 
@@ -265,7 +277,11 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK, runtimeContext } = window;
-                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, {
+                    useCreateConversation: {
+                        disable: true,
+                    }
+                });
 
                 await chatSDK.initialize();
 
@@ -644,7 +660,11 @@ test.describe('UnauthenticatedChat @UnauthenticatedChat', () => {
             await page.evaluate(async ({ omnichannelConfig, chatDuration }) => {
                 const { sleep } = window;
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
-                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig);
+                const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig, {
+                    useCreateConversation: {
+                        disable: true,
+                    }
+                });
 
                 await chatSDK.initialize();
 


### PR DESCRIPTION
Modified the below scenarios,

1. ChatSDK.startChat() with preChatResponse should be part of session init payload
2. ChatSDK.startChat() should have a reconnect id if there's an existing chat session
3. ChatSDK.startChat() with liveChatContext should not perform session init & validate the live work item details & validate auth map record
4. ChatSDK.startChat() should fetch the chat token & perform session init
5. ChatSDK.startChat() with a valid reconnect id should reconnect to previous chat 
6. ChatSDK.startChat() with customContext should be part of session init payload 
7. ChatSDK.startChat() with sendDefaultInitContext should send default init contexts
8. ChatSDK.getChatReconnectContext() with invalid reconnect id & redirect URL should only return a redirect URL
9. ChatSDK.startChat() with a liveChatContext should validate the live work item details & should not perform session init call 
