### PR TITLE
added error message to endchatfailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added additions details to endChat ExceptionDetails
+- Splited sessionInit promize to its own to avoid ACS initialize 
+
 ## [1.10.19] - 2025-05-02
 
 ### Added

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -861,10 +861,10 @@ class OmnichannelChatSDK {
 
         if (!this.chatSDKConfig.useCreateConversation?.disable) {
             await createConversationPromise();
-            await Promise.all([messagingClientPromise(),attachmentClientPromise()]);
         } else {
-            await Promise.all([sessionInitPromise(), messagingClientPromise(), attachmentClientPromise()]);
+            await sessionInitPromise(); // Await the session initialization
         }
+        await Promise.all([messagingClientPromise(),attachmentClientPromise()]);
 
         if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
             this.refreshTokenTimer = setInterval(async () => {
@@ -968,6 +968,9 @@ class OmnichannelChatSDK {
                 RequestId: this.requestId,
                 ChatId: this.chatToken.chatId as string
             };
+            if (error instanceof ChatSDKError) {
+                exceptionThrowers.throwConversationClosureFailure(new Error(JSON.stringify(error.exceptionDetails)), this.scenarioMarker, TelemetryEvent.EndChat, telemetryData);
+            }
             exceptionThrowers.throwConversationClosureFailure(error, this.scenarioMarker, TelemetryEvent.EndChat, telemetryData);
         }
     }


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

_Include a description of the problem to be solved_

## Solution Proposed

EndChat exceptionDetails missing the error message from the oc-sdk sessionclose api call
Also need to split request in promiseAll because eve if sessionInit fails ,other promises where continuing in background causing ACS connection created without a successfull sesionInit

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
