### PR TITLE
backward compatibility for original message id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Mapped id to OriginalMessage ID for backward compatibility once the bridging is removed
 - Added additions details to endChat ExceptionDetails
 - Splited sessionInit promize to its own to avoid ACS initialize 
 

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -73,6 +73,8 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
         // OriginalMessageId is used to track the original message id from the source messaging channel before bridging and any retries
         if (metadata && metadata.OriginalMessageId) {
             omnichannelMessage.properties.originalMessageId = metadata.OriginalMessageId;
+        } else {
+            omnichannelMessage.properties.originalMessageId = id;
         }
 
         omnichannelMessage.role = getMessageRole(omnichannelMessage);


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

_Include a description of the problem to be solved_

## Solution Proposed

To support clients who are depending on originalMessageId for rendering , we need to map ID to original message id property

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
