### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/omnichannel-chat-sdk/security/code-scanning/9](https://github.com/microsoft/omnichannel-chat-sdk/security/code-scanning/9)

To fix the issue, we will add an explicit `permissions` block at the root of the workflow file. Since the workflow is primarily for building, testing, and linting, it does not require `write` permissions. The `contents: read` permission is sufficient for reading the code from the repository. 

While additional permissions may be necessary if new steps are added in the future, starting with the minimal `contents: read` ensures security and adheres to best practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
