### PR TITLE
Validate getSurveyInviteLink request payload.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '*'
 
+permission:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*'
 
+permission:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Validate request payload passed to `OCClient.getSurveyInviteLink` in `ChatSDK.getPostChatSurveyContext()`
+
 ## [1.11.4] 2025-07-17
 
 ### Changed

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -4581,6 +4581,83 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             expect(postChatContext.participantType).toBe("Bot");
         });
 
+        it("ChatSDK.getPostChatSurveyContext() should reject without calling OCClient.getSurveyInviteLink if provider is Customer Voice and msfp_sourcesurveyidentifier is empty", async () => {
+            const chatSDKConfig = {
+                telemetry: {
+                    disable: true
+                },
+                chatReconnect: {
+                    disable: false,
+                }
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            jest.spyOn(chatSDK, 'getChatConfig').mockImplementation(() => {});
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            chatSDK.liveChatConfig = {
+                LiveWSAndLiveChatEngJoin: {
+                    msdyn_postconversationsurveyenable: "true",
+                    msfp_sourcesurveyidentifier: "",
+                    postConversationSurveyOwnerId: "",
+                    msdyn_surveyprovider: "600990000"
+                },
+                ChatWidgetLanguage: {
+                    msdyn_localeid: "1033"
+                }
+            };
+
+            jest.spyOn(chatSDK, 'getConversationDetails').mockResolvedValue({
+                state: "Active",
+                conversationId: "convId",
+                canRenderPostChat: "True"
+            });
+            const getSurveyInviteLinkSpy = jest.spyOn(chatSDK.OCClient, 'getSurveyInviteLink');
+
+            await expect(chatSDK.getPostChatSurveyContext()).rejects.toMatch("GetPostChatSurveyContext : msfp_sourcesurveyidentifier is mandatory for survey provider 600990000.");
+            expect(getSurveyInviteLinkSpy).not.toHaveBeenCalled();
+        });
+
+        it("ChatSDK.getPostChatSurveyContext() should reject without calling OCClient.getSurveyInviteLink if conversation ID is empty", async () => {
+            const chatSDKConfig = {
+                telemetry: {
+                    disable: true
+                },
+                chatReconnect: {
+                    disable: false,
+                }
+            };
+
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+            jest.spyOn(chatSDK, 'getChatConfig').mockImplementation(() => {});
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            chatSDK.liveChatConfig = {
+                LiveWSAndLiveChatEngJoin: {
+                    msdyn_postconversationsurveyenable: "true",
+                    msfp_sourcesurveyidentifier: "",
+                    postConversationSurveyOwnerId: ""
+                },
+                ChatWidgetLanguage: {
+                    msdyn_localeid: "1033"
+                }
+            };
+
+            jest.spyOn(chatSDK, 'getConversationDetails').mockResolvedValue({
+                state: "Active",
+                conversationId: "",
+                canRenderPostChat: "True"
+            });
+            const getSurveyInviteLinkSpy = jest.spyOn(chatSDK.OCClient, 'getSurveyInviteLink');
+
+            await expect(chatSDK.getPostChatSurveyContext()).rejects.toMatch("GetPostChatSurveyContext : Conversation ID is mandatory.");
+            expect(getSurveyInviteLinkSpy).not.toHaveBeenCalled();
+        });
+
         it('ChatSDK.getAgentAvailability() should throw error if conversation already started', async () => {
             const chatSDKConfig = {
                 telemetry: {

--- a/src/core/SurveyProvider.ts
+++ b/src/core/SurveyProvider.ts
@@ -1,0 +1,4 @@
+export enum SurveyProvider {
+    CustomerVoice = 600990000,
+    MicrosoftCopilotStudio = 600990001
+}


### PR DESCRIPTION
# PR Details
## Thank you for your contribution. Before submitting this PR, please include:
**Id of the task, bug, story or other reference**
### Description
*Include a description of the problem to be solved*

When calling `OCClient.getSurveyInviteLink`, the `FormId` property in the request body is required if `SurveyProvider` is `600990000` (Customer Voice). `ConversationId` is required regardless of the value of `SurveyProvider`. Currently, we don't validate either of these properties when `OCClient.getSurveyInviteLink` is called in the `getPostChatSurveyContext` method.

## Solution Proposed

In `getPostChatSurveyContext`, reject and skip the request to `OCClient.getSurveyInviteLink` if either:
- `msfp_sourcesurveyidentifier` is empty and `msdyn_surveyprovider` is `600990000`
- Response payload from `OCClient.getLWIDetails` contains no valid conversation ID.

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

Sanity - verified that Customer Voice post-chat survey loads
<img width="557" height="857" alt="image" src="https://github.com/user-attachments/assets/e7e44e85-1044-4434-af6d-b7774c947deb" />

Sanity - verified that Microsoft Copilot Studio post-chat survey loads
<img width="551" height="858" alt="image" src="https://github.com/user-attachments/assets/e397aac2-5a85-4269-bf7b-563b2ba48c23" />



### Sanity Tests

- [x] You have tested all changes in Popout mode
- [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues (NA)

***Please provide justification if any of the validations has been skipped.***
