### PR TITLE
Support custom event metadata propagation to mobile SDKs (Android/iOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Add `customEvent` property to `OmnichannelMessage` to support custom event metadata propagation to mobile SDKs (Android/iOS).
+
 ## [1.11.4] 2025-07-17
 
 ### Changed

--- a/src/core/messaging/OmnichannelMessage.ts
+++ b/src/core/messaging/OmnichannelMessage.ts
@@ -80,6 +80,11 @@ interface OmnichannelMessage {
     fileMetadata?: IFileMetadata;
     resourceType?: ResourceType;
     role?: string;
+    customEvent?: {
+        isCustomEvent: boolean;
+        customEventName: string;
+        customEventValue: string;
+    };
 }
 
 export default OmnichannelMessage;

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -77,6 +77,15 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
             omnichannelMessage.properties.originalMessageId = id;
         }
 
+        // Handle custom event metadata
+        if (metadata && metadata.customEvent && metadata.customEventName && metadata.customEventValue) {
+            omnichannelMessage.customEvent = {
+                isCustomEvent: Boolean(metadata.customEvent),
+                customEventName: metadata.customEventName,
+                customEventValue: metadata.customEventValue
+            };
+        }
+
         omnichannelMessage.role = getMessageRole(omnichannelMessage);
     } else {
         const { clientmessageid } = message as IRawMessage;


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

This change introduces a mechanism for customers to send event information from their mobile application to a bot via ACS chat. These events can represent in-app actions that the bot may need to respond to in real time.

For example, imagine a customer interacting with a support bot inside a shopping app. If the customer adds a product to their cart that doesn’t align with their stated preferences, the bot can detect this event, provide a helpful suggestion, and recommend a more suitable product—all based on the custom event data received from the app.

## Solution Proposed

To enable this behavior, we’re introducing support for invisible (non-rendered) messages in the ACS chat thread that contain custom event metadata. These messages include three optional fields in the metadata:

- `customEvent`: A flag to indicate that this is a custom event message
- `customEventName`: A string representing the type of event (e.g., “product_mismatch”)
- `customEventValue`: A JSON string with event-specific data

If these fields are present, the message is treated as a custom event. The native SDKs can then listen for these events and take appropriate action based on the event type and payload.

### Acceptance criteria

Ensure:
- [x] Send Message from C1 to C2 (Android Sample App) over ACS WebSocket
- [x] Send Message from C2 (Android Sample App) to Bot (and have bot act on passed event)  
- [x] Send Message from C2 (Android Sample App) to C1 
- [ ] Send Message from C1 to C2 (iOS Sample App) over ACS WebSocket
- [ ] Send Message from C2 (iOS Sample App) to Bot (and have bot act on passed event)  
- [ ] Send Message from C2 (iOS Sample App) to C1 

## Test cases and evidence

**Send Message from C1 to C2 (Android Sample App) over ACS WebSocket**
<img width="975" height="488" alt="image" src="https://github.com/user-attachments/assets/374ed58f-92d7-43d2-88f2-1f9b06d5ad86" />

**Send Message from C2 (Android Sample App) to Bot (and have bot act on passed event)**
<img width="787" height="1350" alt="image" src="https://github.com/user-attachments/assets/27460880-7a70-4493-9f71-5a1b55137349" />

**Send Message from C2 (Android Sample App) to C1** 
<img width="975" height="337" alt="image" src="https://github.com/user-attachments/assets/606d8f7a-aecf-4319-a7f5-2e59c0f830d0" />


### Sanity Tests
- [ ] You have tested all changes in Popout mode
- [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
