### PR TITLE
Added code to synchronise start and endchat call

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,12 @@
 # GitHub Copilot Instructions for Omnichannel Chat SDK
 
+## Build Process    
+To build the Omnichannel Chat SDK, follow these steps:
+1. **Install Dependencies**: Run `npm install` to install all required dependencies
+2. **Build the SDK**: Run `npm run build:tsc` to build the SDK
+3. **Run Tests**: Execute `npm run test` to run all unit tests and ensure everything is functioning correctly
+4. **Linting**: Run `npm run lint` to check for any code style
+
 ## Pull Request Guidelines
 
 When creating pull requests, follow these guidelines:

--- a/__tests__/OmnichannelChatSDKMutex.web.spec.ts
+++ b/__tests__/OmnichannelChatSDKMutex.web.spec.ts
@@ -1,0 +1,308 @@
+import OmnichannelChatSDK from '../src/OmnichannelChatSDK';
+
+describe('OmnichannelChatSDK Mutex Tests', () => {
+    let omnichannelChatSDK: OmnichannelChatSDK;
+    let omnichannelConfig: any;
+    let chatSDKConfig: any;
+
+    beforeEach(() => {
+        omnichannelConfig = {
+            orgId: 'testOrgId',
+            orgUrl: 'https://test.dynamics.com',
+            widgetId: 'testWidgetId'
+        };
+
+        chatSDKConfig = {
+            telemetry: {
+                disable: true
+            }
+        };
+
+        omnichannelChatSDK = new OmnichannelChatSDK(omnichannelConfig, chatSDKConfig);
+        
+        // Mock the initialization state
+        (omnichannelChatSDK as any).isInitialized = true;
+        
+        // Mock the telemetry and scenario marker
+        (omnichannelChatSDK as any).scenarioMarker = {
+            startScenario: jest.fn(),
+            completeScenario: jest.fn(),
+            failScenario: jest.fn()
+        };
+        
+        // Mock the chatToken to avoid initialization issues
+        (omnichannelChatSDK as any).chatToken = { chatId: 'test-chat-id' };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    describe('Mutex Implementation - executeWithLock', () => {
+        it('should execute operation immediately when no operation is in progress', async () => {
+            const mockOperation = jest.fn().mockResolvedValue('result');
+            
+            const result = await (omnichannelChatSDK as any).executeWithLock(mockOperation);
+            
+            expect(result).toBe('result');
+            expect(mockOperation).toHaveBeenCalledTimes(1);
+            expect((omnichannelChatSDK as any).chatOperationInProgress).toBe(false);
+            expect((omnichannelChatSDK as any).pendingOperations).toHaveLength(0);
+        });
+
+        it('should queue operation when another operation is in progress', async () => {
+            const firstOperation = jest.fn().mockImplementation(() =>
+                new Promise(resolve => setTimeout(() => resolve('first'), 100))
+            );
+            const secondOperation = jest.fn().mockResolvedValue('second');
+            
+            // Start first operation
+            const firstPromise = (omnichannelChatSDK as any).executeWithLock(firstOperation);
+            
+            // Verify operation is in progress
+            expect((omnichannelChatSDK as any).chatOperationInProgress).toBe(true);
+            
+            // Start second operation (should be queued)
+            const secondPromise = (omnichannelChatSDK as any).executeWithLock(secondOperation);
+            
+            // Verify second operation is queued and not executed yet
+            expect((omnichannelChatSDK as any).pendingOperations).toHaveLength(1);
+            expect(secondOperation).not.toHaveBeenCalled();
+            
+            // Wait for both operations to complete
+            const [firstResult, secondResult] = await Promise.all([firstPromise, secondPromise]);
+            
+            expect(firstResult).toBe('first');
+            expect(secondResult).toBe('second');
+            expect(firstOperation).toHaveBeenCalledTimes(1);
+            expect(secondOperation).toHaveBeenCalledTimes(1);
+            expect((omnichannelChatSDK as any).chatOperationInProgress).toBe(false);
+            expect((omnichannelChatSDK as any).pendingOperations).toHaveLength(0);
+        });
+
+        it('should handle operation failures correctly', async () => {
+            const errorMessage = 'Operation failed';
+            const failingOperation = jest.fn().mockRejectedValue(new Error(errorMessage));
+            
+            await expect((omnichannelChatSDK as any).executeWithLock(failingOperation))
+                .rejects.toThrow(errorMessage);
+            
+            expect(failingOperation).toHaveBeenCalledTimes(1);
+            expect((omnichannelChatSDK as any).chatOperationInProgress).toBe(false);
+            expect((omnichannelChatSDK as any).pendingOperations).toHaveLength(0);
+        });
+
+        it('should process queued operations after failure', async () => {
+            const failingOperation = jest.fn().mockRejectedValue(new Error('First failed'));
+            const successfulOperation = jest.fn().mockResolvedValue('success');
+            
+            // Start failing operation
+            const failingPromise = (omnichannelChatSDK as any).executeWithLock(failingOperation);
+            
+            // Queue successful operation
+            const successPromise = (omnichannelChatSDK as any).executeWithLock(successfulOperation);
+            
+            // Wait for failing operation to complete
+            await expect(failingPromise).rejects.toThrow('First failed');
+            
+            // Successful operation should still execute
+            const result = await successPromise;
+            expect(result).toBe('success');
+            expect(successfulOperation).toHaveBeenCalledTimes(1);
+            expect((omnichannelChatSDK as any).chatOperationInProgress).toBe(false);
+        });
+
+        it('should maintain operation order in queue', async () => {
+            const executionOrder: number[] = [];
+            
+            const createOperation = (id: number, delay: number) =>
+                jest.fn().mockImplementation(() =>
+                    new Promise(resolve =>
+                        setTimeout(() => {
+                            executionOrder.push(id);
+                            resolve(`result${id}`);
+                        }, delay)
+                    )
+                );
+            
+            const op1 = createOperation(1, 50);
+            const op2 = createOperation(2, 30);
+            const op3 = createOperation(3, 10);
+            
+            // Start all operations
+            const promises = [
+                (omnichannelChatSDK as any).executeWithLock(op1),
+                (omnichannelChatSDK as any).executeWithLock(op2),
+                (omnichannelChatSDK as any).executeWithLock(op3)
+            ];
+            
+            await Promise.all(promises);
+            
+            // Operations should execute in order they were queued, not by delay
+            expect(executionOrder).toEqual([1, 2, 3]);
+        });
+    });
+
+    describe('startChat and endChat serialization', () => {
+        beforeEach(() => {
+            // Mock internal methods to avoid full initialization
+            (omnichannelChatSDK as any).internalStartChat = jest.fn().mockImplementation(() =>
+                new Promise<void>(resolve => setTimeout(resolve, 100))
+            );
+            (omnichannelChatSDK as any).internalEndChat = jest.fn().mockImplementation(() =>
+                new Promise<void>(resolve => setTimeout(resolve, 100))
+            );
+        });
+
+        it('should serialize multiple startChat calls', async () => {
+            const startTime = Date.now();
+            
+            // Start multiple startChat operations
+            const promises = [
+                omnichannelChatSDK.startChat(),
+                omnichannelChatSDK.startChat(),
+                omnichannelChatSDK.startChat()
+            ];
+            
+            await Promise.all(promises);
+            
+            const endTime = Date.now();
+            const duration = endTime - startTime;
+            
+            // Should take at least 250ms due to serialization (allowing some tolerance)
+            expect(duration).toBeGreaterThan(250);
+            expect((omnichannelChatSDK as any).internalStartChat).toHaveBeenCalledTimes(3);
+        });
+
+        it('should serialize mixed startChat and endChat calls', async () => {
+            const executionOrder: string[] = [];
+            
+            (omnichannelChatSDK as any).internalStartChat = jest.fn().mockImplementation(() => {
+                return new Promise<void>(resolve => {
+                    setTimeout(() => {
+                        executionOrder.push('startChat');
+                        resolve();
+                    }, 50);
+                });
+            });
+            
+            (omnichannelChatSDK as any).internalEndChat = jest.fn().mockImplementation(() => {
+                return new Promise<void>(resolve => {
+                    setTimeout(() => {
+                        executionOrder.push('endChat');
+                        resolve();
+                    }, 50);
+                });
+            });
+            
+            // Start mixed operations
+            const promises = [
+                omnichannelChatSDK.startChat(),
+                omnichannelChatSDK.endChat(),
+                omnichannelChatSDK.startChat(),
+                omnichannelChatSDK.endChat()
+            ];
+            
+            await Promise.all(promises);
+            
+            // Operations should execute in the order they were called
+            expect(executionOrder).toEqual(['startChat', 'endChat', 'startChat', 'endChat']);
+        });
+
+        it('should handle exceptions in operations without breaking the queue', async () => {
+            (omnichannelChatSDK as any).internalStartChat = jest.fn()
+                .mockRejectedValueOnce(new Error('First start failed'))
+                .mockResolvedValueOnce(undefined);
+            
+            (omnichannelChatSDK as any).internalEndChat = jest.fn()
+                .mockResolvedValue(undefined);
+            
+            // First startChat should fail
+            await expect(omnichannelChatSDK.startChat()).rejects.toThrow('First start failed');
+            
+            // Subsequent operations should still work
+            await expect(omnichannelChatSDK.startChat()).resolves.toBeUndefined();
+            await expect(omnichannelChatSDK.endChat()).resolves.toBeUndefined();
+            
+            expect((omnichannelChatSDK as any).internalStartChat).toHaveBeenCalledTimes(2);
+            expect((omnichannelChatSDK as any).internalEndChat).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Race condition prevention', () => {
+        it('should prevent startChat from being corrupted by endChat cleanup', async () => {
+            const mockConversation = { disconnect: jest.fn() };
+            const mockChatToken = { chatId: 'test123' };
+            
+            // Set up initial state
+            (omnichannelChatSDK as any).conversation = mockConversation;
+            (omnichannelChatSDK as any).chatToken = mockChatToken;
+            
+            let startChatCompleted = false;
+            let endChatCompleted = false;
+            
+            (omnichannelChatSDK as any).internalStartChat = jest.fn().mockImplementation(async () => {
+                // Simulate startChat setting up resources
+                (omnichannelChatSDK as any).conversation = { id: 'new-conversation' };
+                (omnichannelChatSDK as any).chatToken = { chatId: 'new123' };
+                await new Promise<void>(resolve => setTimeout(resolve, 50));
+                startChatCompleted = true;
+            });
+            
+            (omnichannelChatSDK as any).internalEndChat = jest.fn().mockImplementation(async () => {
+                // Simulate endChat cleanup
+                await new Promise<void>(resolve => setTimeout(resolve, 30));
+                if ((omnichannelChatSDK as any).conversation) {
+                    (omnichannelChatSDK as any).conversation.disconnect?.();
+                    (omnichannelChatSDK as any).conversation = null;
+                }
+                (omnichannelChatSDK as any).chatToken = {};
+                endChatCompleted = true;
+            });
+            
+            // Start endChat, then immediately start startChat
+            const endChatPromise = omnichannelChatSDK.endChat();
+            const startChatPromise = omnichannelChatSDK.startChat();
+            
+            await Promise.all([endChatPromise, startChatPromise]);
+            
+            // Verify both operations completed
+            expect(endChatCompleted).toBe(true);
+            expect(startChatCompleted).toBe(true);
+            
+            // Verify startChat resources were not corrupted by endChat
+            // Because of serialization, startChat should execute after endChat
+            expect((omnichannelChatSDK as any).conversation).toEqual({ id: 'new-conversation' });
+            expect((omnichannelChatSDK as any).chatToken).toEqual({ chatId: 'new123' });
+        });
+
+        it('should handle rapid successive calls without race conditions', async () => {
+            let chatState = 'idle';
+            
+            (omnichannelChatSDK as any).internalStartChat = jest.fn().mockImplementation(async () => {
+                expect(chatState).toBe('idle'); // Should only start from idle state
+                chatState = 'starting';
+                await new Promise<void>(resolve => setTimeout(resolve, 10));
+                chatState = 'active';
+            });
+            
+            (omnichannelChatSDK as any).internalEndChat = jest.fn().mockImplementation(async () => {
+                expect(chatState).toBe('active'); // Should only end from active state
+                chatState = 'ending';
+                await new Promise<void>(resolve => setTimeout(resolve, 10));
+                chatState = 'idle';
+            });
+            
+            // Rapid successive calls
+            await omnichannelChatSDK.startChat();
+            await omnichannelChatSDK.endChat();
+            await omnichannelChatSDK.startChat();
+            await omnichannelChatSDK.endChat();
+            
+            expect(chatState).toBe('idle');
+            expect((omnichannelChatSDK as any).internalStartChat).toHaveBeenCalledTimes(2);
+            expect((omnichannelChatSDK as any).internalEndChat).toHaveBeenCalledTimes(2);
+        });
+    });
+});


### PR DESCRIPTION
# PR Details
Issue: Race condition between startChat() and endChat() operations causing state corruption and inconsistent chat behavior.

Description
Problem to be solved: Race conditions occur when startChat() and endChat() operations execute concurrently, leading to:

State corruption where resources are cleaned up while still being initialized
Inconsistent chat session states that can leave conversations in undefined conditions
Resource leaks where conversations are not properly cleaned up
Unpredictable user experience in scenarios involving rapid successive chat operations
The core issue is that both operations modify shared state (conversation objects, chat tokens, timers) without proper synchronization, creating a window for interference between operations.

Solution Proposed
Mutex Pattern with Operation Queue Implementation:

Implemented a comprehensive operation serialization mechanism that ensures startChat() and endChat() operations execute in a mutually exclusive manner:

Core Components:

chatOperationInProgress: boolean - Tracks if an operation is currently executing
pendingOperations: Array<() => void> - Queue for pending operations
executeWithLock<T>() - Core mutex method that wraps operations
processNextOperation() - Queue processor for pending operations
Implementation Pattern:

Modified public startChat() and endChat() methods to use executeWithLock()
Created internal internalStartChat() and internalEndChat() methods for actual implementation
Operations are queued when another operation is in progress
Queue processes in FIFO order maintaining operation sequence
Error Handling:

Failed operations don't break the mutex state
Queue continues processing subsequent operations after failures
Proper cleanup ensures mutex is released in all scenarios

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
