### PR TITLE
Parallelize calls calls to getSurveyInviteLink in getPostChatSurveyContext method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Parallelize survey invite link requests in getPostChatSurveyContext method for improved performance
+
 ## [1.11.6] - 2025-08-08
 
 ### Fixed

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2238,9 +2238,12 @@ class OmnichannelChatSDK {
                     optionalParams.authenticatedUserToken = this.authenticatedUserToken;
                 }
 
-                const agentSurveyInviteLinkResponse = await this.OCClient.getSurveyInviteLink(postConversationSurveyOwnerId, agentSurveyInviteLinkRequest, optionalParams);
-                const botSurveyInviteLinkResponse = postConversationBotSurveyOwnerId && msfp_botsourcesurveyidentifier &&
-                    await this.OCClient.getSurveyInviteLink(postConversationBotSurveyOwnerId, botSurveyInviteLinkRequest, optionalParams);
+                const [agentSurveyInviteLinkResponse, botSurveyInviteLinkResponse] = await Promise.all([
+                    this.OCClient.getSurveyInviteLink(postConversationSurveyOwnerId, agentSurveyInviteLinkRequest, optionalParams),
+                    (postConversationBotSurveyOwnerId && msfp_botsourcesurveyidentifier)
+                        ? this.OCClient.getSurveyInviteLink(postConversationBotSurveyOwnerId, botSurveyInviteLinkRequest, optionalParams)
+                        : Promise.resolve(null)
+                ]);
 
                 let agentSurveyInviteLink, agentFormsProLocale, botSurveyInviteLink, botFormsProLocale;
                 if (agentSurveyInviteLinkResponse != null) {


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

5499555

### Description

In getPostChatSurveyContext, up to two calls are made to getSurveyInviteLink (one for the agent survey and one for the bot survey if enabled). Currently these calls are made sequentially. There is an opportunity to improve performance here by parallelizing the calls.

## Solution Proposed

Use Promise.all to await both calls to getSurveyInviteLink in parallel.

### Acceptance criteria

If post-conversation survey is disabled, getPostChatSurveyContext should not call getSurveyInviteLink.
If post-conversation survey is enabled and bot survey is disabled, getPostChatSurveyContext should call getSurveyInviteLink once.
If post-conversation survey and bot survey are enabled, getPostChatSurveyContext should make two parallel calls to getSurveyInviteLink.
Behavior otherwise should not change.

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
Manually tested with post-conversation survey and bot survey enabled and disabled. No new test cases were introduced because this change does not modify any external behavior.

### Sanity Tests

- [x] You have tested all changes in Popout mode
- [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [x] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
