### PR TITLE
Sdk persistent history chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Parallelize survey invite link requests in getPostChatSurveyContext method for improved performance
 - Remove V1 logic for onAgentEndSession
-- Uptake ocsdk  "@microsoft/omnichannel-sdk": "^0.5.19"
+- Uptake ocsdk  "@microsoft/omnichannel-sdk": "^0.5.20-main.a3b9c5e"
 
 ## [1.11.6] - 2025-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `ChatSDK.getPersistentChatHistory()` to retrieve persistent chat history for authenticated chats
 
 ### Changed
+
 - Parallelize survey invite link requests in getPostChatSurveyContext method for improved performance
-- Remove V1 logic for onAgentEndSession 
+- Remove V1 logic for onAgentEndSession
+- Uptake ocsdk  "@microsoft/omnichannel-sdk": "^0.5.19"
+
 ## [1.11.6] - 2025-08-08
 
 ### Fixed
 
--  Implement mutex pattern to prevent race conditions between startChat() and endChat() operations that could lead to state corruption
+- Implement mutex pattern to prevent race conditions between startChat() and endChat() operations that could lead to state corruption
 
 ### Changed
 

--- a/__tests__/OmnichannelChatSDK.node.spec.ts
+++ b/__tests__/OmnichannelChatSDK.node.spec.ts
@@ -5,7 +5,10 @@
 
 import * as settings from '../src/config/settings';
 
+import { ChatSDKError, ChatSDKErrorName } from "../src/core/ChatSDKError";
+
 import { AWTLogManager } from "../src/external/aria/webjs/AriaSDK";
+import ConversationMode from '../src/core/ConversationMode';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
@@ -13,6 +16,10 @@ const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
 describe('Omnichannel Chat SDK (Node), Sequential', () => {
     (settings as any).ariaTelemetryKey = '';
     AWTLogManager.initialize = jest.fn();
+
+    function fail(message = 'Test Expected to Fail') {
+        throw new Error(message);
+    }
 
     const omnichannelConfig = {
         orgUrl: '[data-org-url]',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.6-0",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/omnichannel-chat-sdk",
-      "version": "1.11.6-0",
+      "version": "1.11.7",
       "license": "MIT",
       "dependencies": {
         "@azure/communication-chat": "1.5.4",
         "@azure/communication-common": "2.3.1",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.5",
-        "@microsoft/ocsdk": "^0.5.18",
+        "@microsoft/ocsdk": "0.5.19",
         "@microsoft/omnichannel-amsclient": "^0.1.11",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
       },
@@ -1533,9 +1533,9 @@
       "license": "0BSD"
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.18.tgz",
-      "integrity": "sha512-oC97/9Hc4kJDuuHABvBm1qnNYyeC9sW/QEcHjwD4yj2bIkMonbvDTeVhTMpxv6KL0P/4dHMgHkjpR2fADyYmGw==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.19.tgz",
+      "integrity": "sha512-sfYQF6IBCCffZLlml/NTSibEC4S2kXwKVijm3YOIJ6jbs9XyHm8qTXQGfwTsrwtqGSZEYFYO9i/QbhABWFxLGQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
@@ -7598,9 +7598,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.18.tgz",
-      "integrity": "sha512-oC97/9Hc4kJDuuHABvBm1qnNYyeC9sW/QEcHjwD4yj2bIkMonbvDTeVhTMpxv6KL0P/4dHMgHkjpR2fADyYmGw==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.19.tgz",
+      "integrity": "sha512-sfYQF6IBCCffZLlml/NTSibEC4S2kXwKVijm3YOIJ6jbs9XyHm8qTXQGfwTsrwtqGSZEYFYO9i/QbhABWFxLGQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^22.13.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.7-LP-1",
+  "version": "1.11.7-LP-1-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/omnichannel-chat-sdk",
-      "version": "1.11.7-LP-1",
+      "version": "1.11.7-LP-1-2",
       "license": "MIT",
       "dependencies": {
         "@azure/communication-chat": "1.5.4",
         "@azure/communication-common": "2.3.1",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.5",
-        "@microsoft/ocsdk": "0.5.20-main.dfb694e",
+        "@microsoft/ocsdk": "^0.5.20-main.a3b9c5e",
         "@microsoft/omnichannel-amsclient": "^0.1.11",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
       },
@@ -1533,9 +1533,9 @@
       "license": "0BSD"
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.20-main.dfb694e",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.20-main.dfb694e.tgz",
-      "integrity": "sha512-PkPLn83zX0CKW63Nv1R2gXPeoxEGoRVhOoBatCkebKpq8+Gkd9tMGB/VQ8Br6iGEPHxvNzRcevTda6u/DcV+4w==",
+      "version": "0.5.20-main.a3b9c5e",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.20-main.a3b9c5e.tgz",
+      "integrity": "sha512-HHo0z0+iJcynnDqnrwPFk1Jr5ZmJ9ZCtOKew63Smn+ftAZ4G8wJt0AYacv3iKwLxdx79nBDr7oWt+WnltqwRfg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
@@ -7757,9 +7757,9 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.5.20-main.dfb694e",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.20-main.dfb694e.tgz",
-      "integrity": "sha512-PkPLn83zX0CKW63Nv1R2gXPeoxEGoRVhOoBatCkebKpq8+Gkd9tMGB/VQ8Br6iGEPHxvNzRcevTda6u/DcV+4w==",
+      "version": "0.5.20-main.a3b9c5e",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.20-main.a3b9c5e.tgz",
+      "integrity": "sha512-HHo0z0+iJcynnDqnrwPFk1Jr5ZmJ9ZCtOKew63Smn+ftAZ4G8wJt0AYacv3iKwLxdx79nBDr7oWt+WnltqwRfg==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^22.13.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.7",
+  "version": "1.11.7-LP-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/omnichannel-chat-sdk",
-      "version": "1.11.7",
+      "version": "1.11.7-LP-1",
       "license": "MIT",
       "dependencies": {
         "@azure/communication-chat": "1.5.4",
         "@azure/communication-common": "2.3.1",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.5",
-        "@microsoft/ocsdk": "0.5.19",
+        "@microsoft/ocsdk": "0.5.20-main.dfb694e",
         "@microsoft/omnichannel-amsclient": "^0.1.11",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
       },
@@ -1533,14 +1533,14 @@
       "license": "0BSD"
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.19.tgz",
-      "integrity": "sha512-sfYQF6IBCCffZLlml/NTSibEC4S2kXwKVijm3YOIJ6jbs9XyHm8qTXQGfwTsrwtqGSZEYFYO9i/QbhABWFxLGQ==",
+      "version": "0.5.20-main.dfb694e",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.20-main.dfb694e.tgz",
+      "integrity": "sha512-PkPLn83zX0CKW63Nv1R2gXPeoxEGoRVhOoBatCkebKpq8+Gkd9tMGB/VQ8Br6iGEPHxvNzRcevTda6u/DcV+4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^22.13.10",
-        "axios": "^1.8.2",
+        "axios": "^1.12.0",
         "axios-retry": "^3.9.1",
         "crypto-js": "^4.2.0"
       }
@@ -2260,13 +2260,13 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2274,6 +2274,7 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
       "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
@@ -2537,6 +2538,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2920,6 +2934,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2995,6 +3023,51 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -3592,13 +3665,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -3630,7 +3705,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3662,6 +3736,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3670,6 +3768,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3748,6 +3859,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3771,11 +3894,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4053,6 +4202,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -5043,6 +5193,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge-stream": {
@@ -7598,13 +7757,13 @@
       }
     },
     "@microsoft/ocsdk": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.19.tgz",
-      "integrity": "sha512-sfYQF6IBCCffZLlml/NTSibEC4S2kXwKVijm3YOIJ6jbs9XyHm8qTXQGfwTsrwtqGSZEYFYO9i/QbhABWFxLGQ==",
+      "version": "0.5.20-main.dfb694e",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.20-main.dfb694e.tgz",
+      "integrity": "sha512-PkPLn83zX0CKW63Nv1R2gXPeoxEGoRVhOoBatCkebKpq8+Gkd9tMGB/VQ8Br6iGEPHxvNzRcevTda6u/DcV+4w==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/node": "^22.13.10",
-        "axios": "^1.8.2",
+        "axios": "^1.12.0",
         "axios-retry": "^3.9.1",
         "crypto-js": "^4.2.0"
       }
@@ -8114,12 +8273,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "requires": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -8300,6 +8459,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -8552,6 +8720,16 @@
         "webidl-conversions": "^7.0.0"
       }
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -8601,6 +8779,35 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       }
     },
     "escalade": {
@@ -9038,12 +9245,14 @@
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       }
     },
@@ -9063,8 +9272,7 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -9084,11 +9292,37 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -9139,6 +9373,11 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -9157,11 +9396,23 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
+    },
     "hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -10057,6 +10308,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.7-0",
+  "version": "1.11.7",
   "description": "Microsoft Omnichannel Chat SDK",
   "files": [
     "lib/**/*"
@@ -48,7 +48,7 @@
     "@azure/communication-chat": "1.5.4",
     "@azure/communication-common": "2.3.1",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.5",
-    "@microsoft/ocsdk": "^0.5.18",
+    "@microsoft/ocsdk": "0.5.19",
     "@microsoft/omnichannel-amsclient": "^0.1.11",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.7-LP-1",
+  "version": "1.11.7-0",
   "description": "Microsoft Omnichannel Chat SDK",
   "files": [
     "lib/**/*"
@@ -48,7 +48,7 @@
     "@azure/communication-chat": "1.5.4",
     "@azure/communication-common": "2.3.1",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.5",
-    "@microsoft/ocsdk": "0.5.20-main.dfb694e",
+    "@microsoft/ocsdk": "^0.5.20-main.a3b9c5e",
     "@microsoft/omnichannel-amsclient": "^0.1.11",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.7",
+  "version": "1.11.7-LP-1",
   "description": "Microsoft Omnichannel Chat SDK",
   "files": [
     "lib/**/*"
@@ -48,7 +48,7 @@
     "@azure/communication-chat": "1.5.4",
     "@azure/communication-common": "2.3.1",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.5",
-    "@microsoft/ocsdk": "^0.5.19",
+    "@microsoft/ocsdk": "0.5.20-main.dfb694e",
     "@microsoft/omnichannel-amsclient": "^0.1.11",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@azure/communication-chat": "1.5.4",
     "@azure/communication-common": "2.3.1",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.5",
-    "@microsoft/ocsdk": "0.5.19",
+    "@microsoft/ocsdk": "^0.5.19",
     "@microsoft/omnichannel-amsclient": "^0.1.11",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   }

--- a/playwright/public/index.html
+++ b/playwright/public/index.html
@@ -9,7 +9,7 @@
     <script>var exports = {};</script> <!-- Fix for "Uncaught ReferenceError: exports is not defined" -->
     <script src="./scripts/globals.js"></script>
     <script src='../dist/lib.js'></script>
-    <!--<script src="./scripts/sdk.js"></script>-->
+    <script src="./scripts/oauth-sdk.js"></script>
 </head>
 <body>
 </body>

--- a/playwright/public/scripts/oauth-sdk.js
+++ b/playwright/public/scripts/oauth-sdk.js
@@ -1,0 +1,100 @@
+/**
+ * This is a test JS file to test the SDK simulating an scenario, this is to test the SDK locally
+ *  1.- Enable the JS in the ../index.html file
+ *  2.- go to server and run `node app.js`
+ *  3.- go to localhost:8080 and open the console
+ *
+ * important : index.html wont run locally in the browser without a server behind , because there are security validations for AMS iframe.
+ */
+
+const run = async () => {
+
+    // cpsBotId if needed, add it here 
+    const omnichannelConfig = {
+        orgId: "ce4db5f6-1c20-ee11-a66d-000d3a0a02f3",
+        orgUrl: "https://m-ce4db5f6-1c20-ee11-a66d-000d3a0a02f3.ca.omnichannelengagementhub.com",
+        widgetId: "4b537f7e-4df5-481c-b2d9-d543bb7e9d4d"
+    };
+
+    const defaultChatSDKConfig = {
+        dataMasking: {
+            disable: false,
+            maskingCharacter: '#'
+        },
+        telemetry: {
+            disable: false,
+            ariaTelemetryKey: ""
+        },
+        persistentChat: {
+            disable: false,
+            tokenUpdateTime: 21600000
+        },
+        chatReconnect: {
+            disable: true,
+        },
+        useCreateConversation: {
+            disable: false,
+        },
+        getAuthToken: () => {
+            return "<OAUTH>";
+        }
+    };
+
+    const { sleep } = window;
+
+    const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
+
+    const chatSDK = new OmnichannelChatSDK.default(omnichannelConfig,  defaultChatSDKConfig);
+
+    await chatSDK.initialize();
+
+    await chatSDK.startChat();
+
+    console.table(await chatSDK.getMessages());
+
+    const messages = [];
+
+    try {
+        chatSDK.onNewMessage((message) => {
+            console.log("*************** New Message Alert ************************", JSON.stringify(message));
+
+            messages.push(message);
+        }, { rehydrate: true });
+    } catch (err) {
+        runtimeContext.errorMessage = `${err.message}`;
+        runtimeContext.errorObject = `${err}`;
+    }
+    await sleep(5000);
+
+    await chatSDK.sendMessage({ "content": "hi" });
+    await sleep(1000);
+    console.log("*************** ALL MESSAGES ***********************");
+    console.table(await chatSDK.getMessages());
+
+    console.log("*************** FIRST PULL ************************");
+    console.table(await chatSDK.getPersistentChatHistory({}));
+
+    await sleep(1000);
+
+    console.log("*************** SECOND PULL ************************");
+    console.table(await chatSDK.getPersistentChatHistory({pageSize:2, pageToken:"<PAGE_TOKEN>"}));
+
+    console.log("*************** THIRD PULL ************************");
+    console.table(await chatSDK.getPersistentChatHistory({pageSize:2}));
+
+    
+    console.log("*************** Pushed Messages ************************");
+    console.table(messages);
+    console.log("*************** ENDING CHAT MID FLY ************************");
+
+    await sleep(5000);
+    await chatSDK.endChat();
+
+
+    await sleep(60000);
+    console.log("*************** ALL MESSAGES BEFORE END CHAT ************************");
+    console.table(await chatSDK.getMessages());
+
+};
+
+run();

--- a/playwright/public/scripts/oauth-sdk.js
+++ b/playwright/public/scripts/oauth-sdk.js
@@ -11,9 +11,9 @@ const run = async () => {
 
     // cpsBotId if needed, add it here 
     const omnichannelConfig = {
-        orgId: "ce4db5f6-1c20-ee11-a66d-000d3a0a02f3",
-        orgUrl: "https://m-ce4db5f6-1c20-ee11-a66d-000d3a0a02f3.ca.omnichannelengagementhub.com",
-        widgetId: "4b537f7e-4df5-481c-b2d9-d543bb7e9d4d"
+        orgId: "",
+        orgUrl: "",
+        widgetId: ""
     };
 
     const defaultChatSDKConfig = {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -184,7 +184,6 @@ class OmnichannelChatSDK {
         this.liveChatVersion = LiveChatVersion.V2;
         this.localeId = defaultLocaleId;
 
-        console.log("OmnichannelChatSDK initialized with runtimeId:");
         this.requestId = uuidv4();
         this.chatToken = {};
         this.liveChatConfig = {};

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2780,7 +2780,7 @@ class OmnichannelChatSDK {
      * @param requestId Optional request id.
      * @param getPersistentChatHistoryOptionalParams Optional parameters for persistent chat history retrieval.
      */
-    public async getPersistentChatHistory(getPersistentChatHistoryOptionalParams: GetPersistentChatHistoryOptionalParams = {}): Promise<GetPersistentChatHistoryResponse> {
+    public async getPersistentChatHistory(getPersistentChatHistoryOptionalParams: GetPersistentChatHistoryOptionalParams = {}): Promise<GetPersistentChatHistoryResponse | undefined> {
 
         if (!this.requestId) {
             this.requestId = uuidv4();

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2795,10 +2795,6 @@ class OmnichannelChatSDK {
             exceptionThrowers.throwUninitializedChatSDK(this.scenarioMarker, TelemetryEvent.GetPersistentChatHistory);
         }
 
-        console.log("SDK :: Persistent chat history called");
-        console.log("SDK :: isPersistentChat", this.isPersistentChat);
-        console.log("SDK :: chatSDKConfig.persistentChat?.disable", this.chatSDKConfig.persistentChat?.disable);
-
         if (!this.isPersistentChat || this.chatSDKConfig.persistentChat?.disable === true) {
             exceptionThrowers.throwNotPersistentChatEnabled(this.scenarioMarker, TelemetryEvent.GetPersistentChatHistory, {
                 RequestId: this.requestId,
@@ -2816,8 +2812,6 @@ class OmnichannelChatSDK {
         }
 
         try {
-            console.log("LOPEZ :: Persistent chat history called 2");
-
             getPersistentChatHistoryOptionalParams.authenticatedUserToken = this.authenticatedUserToken as string;
 
             const result = await this.OCClient.getPersistentChatHistory(this.requestId, getPersistentChatHistoryOptionalParams);
@@ -2826,7 +2820,6 @@ class OmnichannelChatSDK {
                 RequestId: this.requestId,
                 ChatId: this.chatToken?.chatId as string
             });
-            console.log('LOPEZ :: Persistent chat history retrieved successfully:', result);
             return result;
         } catch (error) {
             const telemetryData = {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -169,7 +169,6 @@ class OmnichannelChatSDK {
     private detailedDebugEnabled = false;
 
     constructor(omnichannelConfig: OmnichannelConfig, chatSDKConfig: ChatSDKConfig = defaultChatSDKConfig) {
-        console.log("SDK :: Config ::", { omnichannelConfig, chatSDKConfig });
         this.debug = false;
         this.debugSDK = false;
         this.debugAMS = false;

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -183,6 +183,8 @@ class OmnichannelChatSDK {
         this.isInitialized = false;
         this.liveChatVersion = LiveChatVersion.V2;
         this.localeId = defaultLocaleId;
+
+        console.log("OmnichannelChatSDK initialized with runtimeId:");
         this.requestId = uuidv4();
         this.chatToken = {};
         this.liveChatConfig = {};
@@ -2783,6 +2785,7 @@ class OmnichannelChatSDK {
     public async getPersistentChatHistory(getPersistentChatHistoryOptionalParams: GetPersistentChatHistoryOptionalParams = {}): Promise<GetPersistentChatHistoryResponse | undefined> {
 
         if (!this.requestId) {
+            console.log("LOPEZ :: SDK :: Creating new request ID");
             this.requestId = uuidv4();
         }
 
@@ -2811,10 +2814,19 @@ class OmnichannelChatSDK {
 
         try {
 
+            const params: { pageSize?: number; pageToken?: string } = {};
+
+            if (getPersistentChatHistoryOptionalParams.pageSize) {
+                params.pageSize = getPersistentChatHistoryOptionalParams.pageSize;
+            }
+
+            if (getPersistentChatHistoryOptionalParams.pageToken) {
+                params.pageToken = getPersistentChatHistoryOptionalParams.pageToken;
+            }
+
             const result = await this.OCClient.getPersistentChatHistory(this.requestId, {
-                authenticatedUserToken: this.authenticatedUserToken,
-                pageSize: getPersistentChatHistoryOptionalParams?.pageSize || 5,
-                pageToken: getPersistentChatHistoryOptionalParams?.pageToken || ""
+                ...params,
+                authenticatedUserToken: this.authenticatedUserToken
             });
 
             this.scenarioMarker.completeScenario(TelemetryEvent.GetPersistentChatHistory, {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2785,7 +2785,6 @@ class OmnichannelChatSDK {
     public async getPersistentChatHistory(getPersistentChatHistoryOptionalParams: GetPersistentChatHistoryOptionalParams = {}): Promise<GetPersistentChatHistoryResponse | undefined> {
 
         if (!this.requestId) {
-            console.log("LOPEZ :: SDK :: Creating new request ID");
             this.requestId = uuidv4();
         }
 
@@ -2802,7 +2801,6 @@ class OmnichannelChatSDK {
                 RequestId: this.requestId,
                 ChatId: this.chatToken?.chatId as string
             });
-
         }
 
         if (!this.authenticatedUserToken) {
@@ -2813,16 +2811,10 @@ class OmnichannelChatSDK {
         }
 
         try {
+            const params: { pageSize?: number | undefined; pageToken?: string | undefined } = {};
 
-            const params: { pageSize?: number; pageToken?: string } = {};
-
-            if (getPersistentChatHistoryOptionalParams.pageSize) {
-                params.pageSize = getPersistentChatHistoryOptionalParams.pageSize;
-            }
-
-            if (getPersistentChatHistoryOptionalParams.pageToken) {
-                params.pageToken = getPersistentChatHistoryOptionalParams.pageToken;
-            }
+            params.pageSize = getPersistentChatHistoryOptionalParams.pageSize || undefined;
+            params.pageToken = getPersistentChatHistoryOptionalParams.pageToken || undefined;
 
             const result = await this.OCClient.getPersistentChatHistory(this.requestId, {
                 ...params,
@@ -2849,7 +2841,6 @@ class OmnichannelChatSDK {
                 telemetryData
             );
         }
-
     }
 }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2802,7 +2802,6 @@ class OmnichannelChatSDK {
 
         }
 
-        // Prefer provided authenticated user token, otherwise try SDK's stored token
         if (!this.authenticatedUserToken) {
             exceptionThrowers.throwChatSDKError(ChatSDKErrorName.AuthenticatedUserTokenNotFound, new Error('Authenticated user token not found'), this.scenarioMarker, TelemetryEvent.GetPersistentChatHistory, {
                 RequestId: this.requestId,

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -2829,7 +2829,6 @@ class OmnichannelChatSDK {
             exceptionThrowers.throwPersistentChatConversationRetrievalFailure(error, this.scenarioMarker, TelemetryEvent.GetPersistentChatHistory, telemetryData);
         }
 
-        return {} as GetPersistentChatHistoryResponse;
     }
 }
 

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1797,6 +1797,7 @@ class OmnichannelChatSDK {
                 this.scenarioMarker.failScenario(TelemetryEvent.UploadFileAttachment, {
                     RequestId: this.requestId,
                     ChatId: this.chatToken.chatId as string
+
                 });
             }
 
@@ -2777,7 +2778,6 @@ class OmnichannelChatSDK {
 
     /**
      * Get persistent chat history for authenticated users.
-     * @param requestId Optional request id.
      * @param getPersistentChatHistoryOptionalParams Optional parameters for persistent chat history retrieval.
      */
     public async getPersistentChatHistory(getPersistentChatHistoryOptionalParams: GetPersistentChatHistoryOptionalParams = {}): Promise<GetPersistentChatHistoryResponse | undefined> {
@@ -2810,22 +2810,32 @@ class OmnichannelChatSDK {
         }
 
         try {
-            getPersistentChatHistoryOptionalParams.authenticatedUserToken = this.authenticatedUserToken as string;
 
-            const result = await this.OCClient.getPersistentChatHistory(this.requestId, getPersistentChatHistoryOptionalParams);
+            const result = await this.OCClient.getPersistentChatHistory(this.requestId, {
+                authenticatedUserToken: this.authenticatedUserToken,
+                pageSize: getPersistentChatHistoryOptionalParams?.pageSize || 5,
+                pageToken: getPersistentChatHistoryOptionalParams?.pageToken || ""
+            });
 
             this.scenarioMarker.completeScenario(TelemetryEvent.GetPersistentChatHistory, {
                 RequestId: this.requestId,
                 ChatId: this.chatToken?.chatId as string
             });
+
             return result;
         } catch (error) {
             const telemetryData = {
                 RequestId: this.requestId,
-                ChatId: this.chatToken?.chatId as string
+                ChatId: this.chatToken?.chatId as string,
+                ErrorMessage: (error as Error)?.message || 'Unknown error' // Added error message for better debugging
             };
 
-            exceptionThrowers.throwPersistentChatConversationRetrievalFailure(error, this.scenarioMarker, TelemetryEvent.GetPersistentChatHistory, telemetryData);
+            exceptionThrowers.throwPersistentChatConversationRetrievalFailure(
+                error,
+                this.scenarioMarker,
+                TelemetryEvent.GetPersistentChatHistory,
+                telemetryData
+            );
         }
 
     }

--- a/src/core/ChatSDKError.ts
+++ b/src/core/ChatSDKError.ts
@@ -62,6 +62,8 @@ export enum ChatSDKErrorName {
     ChatSDKSendMessageFailed = "ChatSDKSendMessageFailed",
 
     AttachmentClientNotLoaded = "AttachmentClientNotLoaded",
+    NotPersistentChatEnabled = "NotPersistentChatEnabled",
+    AuthenticatedUserTokenNotFound = "AuthenticatedUserTokenNotFound",
 
 }
 

--- a/src/core/GetPersistentChatHistoryOptionalParams.ts
+++ b/src/core/GetPersistentChatHistoryOptionalParams.ts
@@ -1,10 +1,5 @@
 export default interface GetPersistentChatHistoryOptionalParams {
     /**
-     * Authenticated user token for the request.
-     */
-    authenticatedUserToken?: string;
-
-    /**
      * Number of messages to retrieve per page (Optional).
      */
     pageSize?: number;

--- a/src/core/GetPersistentChatHistoryOptionalParams.ts
+++ b/src/core/GetPersistentChatHistoryOptionalParams.ts
@@ -1,0 +1,16 @@
+export default interface GetPersistentChatHistoryOptionalParams {
+    /**
+     * Authenticated user token for the request.
+     */
+    authenticatedUserToken?: string;
+
+    /**
+     * Number of messages to retrieve per page (Optional).
+     */
+    pageSize?: number;
+
+    /**
+     * Token for pagination to get the next page of results (Optional).
+     */
+    pageToken?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ACSAdapter, ChatAdapter, DirectLineAdapter, GeneralResponse, GetAgentAvailabilityResponse, GetCurrentLiveChatContextResponse, GetLiveChatTranscriptResponse, GetMessagesResponse, GetPreChatSurveyResponse, GetVoiceVideoCallingResponse, IC3Adapter, MaskingRule, MaskingRules, UploadFileAttachmentResponse } from "./types/response";
+import { ACSAdapter, ChatAdapter, DirectLineAdapter, GeneralResponse, GetAgentAvailabilityResponse, GetCurrentLiveChatContextResponse, GetLiveChatTranscriptResponse, GetMessagesResponse, GetPersistentChatHistoryResponse, GetPreChatSurveyResponse, GetVoiceVideoCallingResponse, IC3Adapter, MaskingRule, MaskingRules, UploadFileAttachmentResponse } from "./types/response";
 import { AmsClient, ChatWidgetLanguage, DataMaskingInfo, LiveChatConfig, LiveWSAndLiveChatEngJoin, Setting, VoiceVideoCallingOptionalParams } from "./types/config";
 import { ChatSDKError, ChatSDKErrorName } from "./core/ChatSDKError";
 import {SDKProvider as OCSDKProvider, uuidv4} from "@microsoft/ocsdk";
@@ -47,6 +47,7 @@ export {
     GeneralResponse,
     GetPreChatSurveyResponse,
     GetLiveChatTranscriptResponse,
+    GetPersistentChatHistoryResponse,
     DirectLineAdapter,
     ACSAdapter,
     IC3Adapter,
@@ -55,7 +56,7 @@ export {
     GetVoiceVideoCallingResponse,
     UploadFileAttachmentResponse,
     GetMessagesResponse,
-    GetCurrentLiveChatContextResponse
+    GetCurrentLiveChatContextResponse,
 }
 
 export default {

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -46,6 +46,7 @@ enum TelemetryEvent {
     StartPolling = "StartPolling",
     StopPolling = "StopPolling",
     MessageReceived = "MessageReceived",
+    GetPersistentChatHistory = "GetPersistentChatHistory",
 }
 
 export default TelemetryEvent;

--- a/src/types/response.d.ts
+++ b/src/types/response.d.ts
@@ -13,6 +13,53 @@ export type MaskingRule = {
 export type MaskingRules = {
 	rules: MaskingRule[];
 }
+
+export type PersistentChatHistoryApplication = {
+	displayName: string;
+	id: string;
+	additionalData: unknown | null;
+	oDataType: string | null;
+}
+
+export type PersistentChatHistoryFrom = {
+	application: PersistentChatHistoryApplication | null;
+	device: unknown | null;
+	user: unknown | null;
+	additionalData: unknown | null;
+	oDataType: string | null;
+}
+
+export type PersistentChatHistoryMessage = {
+	created: string;
+	isControlMessage: boolean;
+	transcriptOriginalMessageId: string;
+	content: string;
+	contentType: number;
+	createdDateTime: string;
+	culture: string | null;
+	deleted: boolean;
+	from: PersistentChatHistoryFrom;
+	important: unknown | null;
+	likes: unknown | null;
+	modifiedDateTime: string | null;
+	attachments: unknown[];
+	mentions: unknown | null;
+	id: string;
+	oDataType: string | null;
+	additionalData: {
+		deliveryMode: string;
+		widgetId: string;
+		clientActivityId: string;
+		tags: string;
+		ConversationId: string;
+	};
+}
+
+export type GetPersistentChatHistoryResponse = {
+	chatMessages: PersistentChatHistoryMessage[];
+	nextPageToken: string | null;
+}
+
 export type GeneralResponse = {} | string | undefined;
 export type GetPreChatSurveyResponse = GeneralResponse;
 export type GetLiveChatTranscriptResponse = GeneralResponse;

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -100,6 +100,11 @@ export const throwUninitializedChatSDK = (scenarioMarker: ScenarioMarker, teleme
     throwChatSDKError(ChatSDKErrorName.UninitializedChatSDK, undefined, scenarioMarker, telemetryEvent)
 };
 
+export const throwNotPersistentChatEnabled = (scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string}): void => {
+    const message = `Persistent chat is not enabled for this chat widget`;
+    throwChatSDKError(ChatSDKErrorName.NotPersistentChatEnabled, undefined, scenarioMarker, telemetryEvent, telemetryData, message);
+}
+
 export const throwChatTokenRetrievalFailure = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string}): void => {
     throwChatSDKError(ChatSDKErrorName.ChatTokenRetrievalFailure, e, scenarioMarker, telemetryEvent, telemetryData);
 }
@@ -176,5 +181,6 @@ export default {
     throwMessagingClientConversationJoinFailure,
     throwChatAdapterInitializationFailure,
     throwLiveChatTranscriptRetrievalFailure,
-    throwAuthContactIdNotFoundFailure
+    throwAuthContactIdNotFoundFailure,
+    throwNotPersistentChatEnabled
 }


### PR DESCRIPTION
This pull request introduces a new method to the SDK for retrieving persistent chat history for authenticated chats, along with comprehensive tests to ensure its correct behavior across platforms and initialization modes. It also updates the SDK dependency and improves performance for survey invite link requests.

### SDK Feature Addition

* Added `ChatSDK.getPersistentChatHistory()` method to enable retrieval of persistent chat history for authenticated users. This includes robust error handling for various failure scenarios, such as uninitialized SDK, disabled persistent chat, missing authenticated token, and backend failures. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R16) [[2]](diffhunk://#diff-3f04a8141d95bb78b5936d039c2177f55e803e83f8a78d897afb274ad09a128aR3188-R3430) [[3]](diffhunk://#diff-cd3e6647c642242e6f1ee0f6f44d5255e61b24e8fe9dfb244b0957262628fc8dR198-R255) [[4]](diffhunk://#diff-6935800be6938d6c097fe7dcd5a98ca0b9ed25b22b73cfd56af1da534f63740dR158-R230)

### Testing Enhancements

* Added extensive unit tests for `getPersistentChatHistory()` in both Node.js and Web environments, covering success cases, error handling, optional parameters, and parallel initialization. [[1]](diffhunk://#diff-3f04a8141d95bb78b5936d039c2177f55e803e83f8a78d897afb274ad09a128aR3188-R3430) [[2]](diffhunk://#diff-cd3e6647c642242e6f1ee0f6f44d5255e61b24e8fe9dfb244b0957262628fc8dR198-R255) [[3]](diffhunk://#diff-6935800be6938d6c097fe7dcd5a98ca0b9ed25b22b73cfd56af1da534f63740dR158-R230)
* Introduced a utility `fail()` function in test files to simplify error expectation handling. [[1]](diffhunk://#diff-7ca62b0640d422565f499ed83c41906f7159417d5e787d301250edbf9b06fd2eR20-R23) [[2]](diffhunk://#diff-cd3e6647c642242e6f1ee0f6f44d5255e61b24e8fe9dfb244b0957262628fc8dR28-R31) [[3]](diffhunk://#diff-6935800be6938d6c097fe7dcd5a98ca0b9ed25b22b73cfd56af1da534f63740dR20-R23)

### Dependency and Performance Updates

* Updated the SDK dependency to `@microsoft/omnichannel-sdk` version `^0.5.19`.
* Improved performance by parallelizing survey invite link requests in the `getPostChatSurveyContext` method.

### Miscellaneous

* Added missing imports for `ChatSDKError`, `ChatSDKErrorName`, and `ConversationMode` in test files to support new tests and features. [[1]](diffhunk://#diff-7ca62b0640d422565f499ed83c41906f7159417d5e787d301250edbf9b06fd2eR8-R11) [[2]](diffhunk://#diff-cd3e6647c642242e6f1ee0f6f44d5255e61b24e8fe9dfb244b0957262628fc8dR17) [[3]](diffhunk://#diff-6935800be6938d6c097fe7dcd5a98ca0b9ed25b22b73cfd56af1da534f63740dR8-R11) [[4]](diffhunk://#diff-42ec16ea5b39e0958b4178a9c6b9e261fc1b1129070d342879db28729f2dbdffR5)

### Evidence using OCW

<img width="450" height="622" alt="image" src="https://github.com/user-attachments/assets/6746f1f1-3c6b-4a1e-8034-06ed59b61dde" />
<img width="425" height="613" alt="image" src="https://github.com/user-attachments/assets/5272a7b0-5149-4254-97cc-eaca50c8195a" />
<img width="1580" height="722" alt="image" src="https://github.com/user-attachments/assets/82107ccb-2144-4e9d-a001-23b8079c6c42" />
