### PR TITLE
fix: assign role to V1 messages in createOmnichannelMessage

### DIFF
--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import LiveChatVersion from '../../src/core/LiveChatVersion';
-import { MessageType } from '../../src/core/messaging/OmnichannelMessage';
+import { MessageType, Role } from '../../src/core/messaging/OmnichannelMessage';
 import PersonType from '@microsoft/omnichannel-ic3core/lib/model/PersonType';
 import createOmnichannelMessage from '../../src/utils/createOmnichannelMessage';
 
@@ -299,5 +299,48 @@ describe('createOmnichannelMessage', () => {
         if (omnichannelMessage.properties) {
             expect(omnichannelMessage.properties.originalMessageId).toEqual(sampleMessage.metadata.OriginalMessageId);
         }
+
+    it('createOmnichannelMessage with LiveChatV1 agent message should include role', () => {
+        const sampleMessage = {
+            clientmessageid: 'client-id-1',
+            messageType: MessageType.UserMessage,
+            properties: {
+                tags: ['public']
+            },
+            tags: [],
+            content: 'agent content',
+            sender: {
+                id: 'agent-sender-id',
+                displayName: 'Agent'
+            }
+        };
+
+        const omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+            liveChatVersion: LiveChatVersion.V1
+        });
+
+        expect(omnichannelMessage.role).toBe(Role.Agent);
+    });
+
+    it('createOmnichannelMessage with LiveChatV1 system message should include role', () => {
+        const sampleMessage = {
+            clientmessageid: 'client-id-2',
+            messageType: MessageType.UserMessage,
+            properties: {
+                tags: ['system']
+            },
+            tags: [],
+            content: 'system content',
+            sender: {
+                id: 'system-sender-id',
+                displayName: 'System'
+            }
+        };
+
+        const omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+            liveChatVersion: LiveChatVersion.V1
+        });
+
+        expect(omnichannelMessage.role).toBe(Role.System);
     });
 });

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -101,6 +101,7 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
         const { clientmessageid } = message as IRawMessage;
         omnichannelMessage.id = clientmessageid as string;
         omnichannelMessage = { ...message } as OmnichannelMessage;
+        omnichannelMessage.role = getMessageRole(omnichannelMessage);
     }
 
     return omnichannelMessage as OmnichannelMessage;


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

Fixes #526

### Description

- Adds `omnichannelMessage.role = getMessageRole(omnichannelMessage)` to the LiveChatVersion.V1 path in `createOmnichannelMessage.ts`
- Adds two tests to `createOmnichannelMessage.spec.ts` covering the V1 agent and system roles (V1 path had no test coverage)

## Problem

`createOmnichannelMessage` assigns `role` only in the V2 branch:

\`\`\`ts
// V2 path — role is assigned
omnichannelMessage.role = getMessageRole(omnichannelMessage);
} else {
// V1 path — bare spread, role never assigned
omnichannelMessage = { ...message } as OmnichannelMessage;
}
\`\`\`

Callers on `LiveChatVersion.V1` receive a message object where `role` is always `undefined`. `getMessageRole()` already handles V1 IRawMessage shapes correctly (it checks `messageType`, `properties.tags`, and `sender.id`), so the fix is a one-line addition.

## Solution Proposed

Add the same assignment the V2 path already uses, after the V1 spread:

\`\`\`ts
omnichannelMessage = { ...message } as OmnichannelMessage;
omnichannelMessage.role = getMessageRole(omnichannelMessage);
\`\`\`

### Acceptance criteria

- `message.role` is defined for V1 messages in `onNewMessage` callbacks
- `message.role` returns `Role.Agent`, `Role.System`, `Role.Bot`, or `Role.User` based on message properties, consistent with V2 behaviour
- V2 behaviour is unchanged

## Test cases and evidence

Added two tests to `createOmnichannelMessage.spec.ts`:
- V1 agent message (properties.tags includes `'public'`) → `Role.Agent`
- V1 system message (properties.tags includes `'system'`) → `Role.System`

The V1 code path had no prior test coverage in that file.

### Sanity Tests

- [ ] You have tested all changes in Popout mode