### PR TITLE
Enable send read receipt and get unread messages count feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added `getUnreadMessageCount` public method to fetch unread message count for authenticated users (auth-only, pre-session badge use case)
+- Added `sendReadReceipt` public method to mark messages as read (authenticated: via MRT, unauthenticated: via ACS directly)
+- Added `sendReadReceipt` to `ACSClient` for direct ACS read receipt delivery (unauthenticated path)
+- Added `GetUnreadMessageCount` and `SendReadReceipt` telemetry events
+- Added `SendReadReceiptFailure`, `SendReadReceiptInvalidParams`, `UnreadMessageCountRetrievalFailure` to `ChatSDKErrorName` enum
+- Added throw helpers in `exceptionThrowers.ts` for read receipt error handling
+- HTTP error mapping: 404 → `InvalidConversation`, 400 → `SendReadReceiptInvalidParams`, others → retrieval/send failure
+
 - Added `authenticateChat` public method to authenticate an ongoing unauthenticated chat session mid-conversation
 - Added `MidConversationAuth` telemetry event for scenario tracking
 - Added `MidConversationAuthFailure` to `ChatSDKErrorName` enum

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -6035,4 +6035,172 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             });
         });
     });
+
+    describe('Read Receipts', () => {
+        describe('getUnreadMessageCount', () => {
+            it('ChatSDK.getUnreadMessageCount() should call OCClient.getUnreadMessageCount()', async () => {
+                const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
+                chatSDK.getChatConfig = jest.fn();
+
+                await chatSDK.initialize();
+
+                chatSDK.authenticatedUserToken = 'validToken';
+                chatSDK.OCClient = {
+                    getUnreadMessageCount: jest.fn().mockResolvedValue({ unreadMessageCount: 3, mostRecentUnreadMessage: null })
+                };
+
+                const result = await chatSDK.getUnreadMessageCount();
+                expect(chatSDK.OCClient.getUnreadMessageCount).toHaveBeenCalledWith('validToken');
+                expect(result).toEqual({ unreadMessageCount: 3, mostRecentUnreadMessage: null });
+            });
+
+            it('ChatSDK.getUnreadMessageCount() should throw UndefinedAuthToken when no auth token', async () => {
+                const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
+                chatSDK.getChatConfig = jest.fn();
+
+                await chatSDK.initialize();
+
+                chatSDK.authenticatedUserToken = null;
+
+                try {
+                    await chatSDK.getUnreadMessageCount();
+                    fail('Should have thrown');
+                } catch (error) {
+                    expect(error).toBeInstanceOf(ChatSDKError);
+                    expect((error as ChatSDKError).message).toBe(ChatSDKErrorName.UndefinedAuthToken);
+                }
+            });
+
+            it('ChatSDK.getUnreadMessageCount() should throw InvalidConversation on 404', async () => {
+                const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
+                chatSDK.getChatConfig = jest.fn();
+
+                await chatSDK.initialize();
+
+                chatSDK.authenticatedUserToken = 'validToken';
+                const axiosError = new Error('Not Found');
+                (axiosError as any).isAxiosError = true;
+                (axiosError as any).response = { status: 404 };
+                chatSDK.OCClient = {
+                    getUnreadMessageCount: jest.fn().mockRejectedValue(axiosError)
+                };
+
+                try {
+                    await chatSDK.getUnreadMessageCount();
+                    fail('Should have thrown');
+                } catch (error) {
+                    expect(error).toBeInstanceOf(ChatSDKError);
+                    expect((error as ChatSDKError).message).toBe(ChatSDKErrorName.InvalidConversation);
+                }
+            });
+        });
+
+        describe('sendReadReceipt', () => {
+            it('ChatSDK.sendReadReceipt() should call OCClient.sendReadReceipt() for authenticated chat', async () => {
+                const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
+                chatSDK.getChatConfig = jest.fn();
+                chatSDK.getChatToken = jest.fn();
+
+                await chatSDK.initialize();
+
+                chatSDK.OCClient = {
+                    sessionInit: jest.fn(),
+                    createConversation: jest.fn(),
+                    sendReadReceipt: jest.fn().mockResolvedValue(undefined)
+                };
+
+                chatSDK.AMSClient = {
+                    initialize: jest.fn()
+                };
+
+                jest.spyOn(chatSDK.ACSClient, 'initialize').mockResolvedValue(Promise.resolve());
+                jest.spyOn(chatSDK.ACSClient, 'joinConversation').mockResolvedValue(Promise.resolve({
+                    sendReadReceipt: jest.fn()
+                }));
+
+                await chatSDK.startChat();
+
+                chatSDK.authenticatedUserToken = 'validToken';
+                chatSDK.requestId = 'test-request-id';
+
+                await chatSDK.sendReadReceipt('1777185788167');
+                expect(chatSDK.OCClient.sendReadReceipt).toHaveBeenCalledWith('test-request-id', '1777185788167', 'validToken');
+            });
+
+            it('ChatSDK.sendReadReceipt() should call ACS directly for unauthenticated chat', async () => {
+                const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
+                chatSDK.getChatConfig = jest.fn();
+                chatSDK.getChatToken = jest.fn();
+
+                await chatSDK.initialize();
+
+                chatSDK.OCClient = {
+                    sessionInit: jest.fn(),
+                    createConversation: jest.fn()
+                };
+
+                chatSDK.AMSClient = {
+                    initialize: jest.fn()
+                };
+
+                const mockSendReadReceipt = jest.fn().mockResolvedValue(undefined);
+                jest.spyOn(chatSDK.ACSClient, 'initialize').mockResolvedValue(Promise.resolve());
+                jest.spyOn(chatSDK.ACSClient, 'joinConversation').mockResolvedValue(Promise.resolve({
+                    sendReadReceipt: mockSendReadReceipt
+                }));
+
+                await chatSDK.startChat();
+
+                chatSDK.authenticatedUserToken = null;
+
+                await chatSDK.sendReadReceipt('1777185788167');
+                expect(mockSendReadReceipt).toHaveBeenCalledWith('1777185788167');
+            });
+
+            it('ChatSDK.sendReadReceipt() should throw SendReadReceiptInvalidParams when messageId is empty', async () => {
+                const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
+                chatSDK.getChatConfig = jest.fn();
+                chatSDK.getChatToken = jest.fn();
+
+                await chatSDK.initialize();
+
+                chatSDK.OCClient = {
+                    sessionInit: jest.fn(),
+                    createConversation: jest.fn()
+                };
+
+                chatSDK.AMSClient = {
+                    initialize: jest.fn()
+                };
+
+                jest.spyOn(chatSDK.ACSClient, 'initialize').mockResolvedValue(Promise.resolve());
+                jest.spyOn(chatSDK.ACSClient, 'joinConversation').mockResolvedValue(Promise.resolve({}));
+
+                await chatSDK.startChat();
+
+                try {
+                    await chatSDK.sendReadReceipt('');
+                    fail('Should have thrown');
+                } catch (error) {
+                    expect(error).toBeInstanceOf(ChatSDKError);
+                    expect((error as ChatSDKError).message).toBe(ChatSDKErrorName.SendReadReceiptInvalidParams);
+                }
+            });
+
+            it('ChatSDK.sendReadReceipt() should throw UninitializedChatSDK when not initialized', async () => {
+                const chatSDK = new OmnichannelChatSDK(omnichannelConfigGlobal);
+                chatSDK.getChatConfig = jest.fn();
+
+                // Do NOT call initialize() — isInitialized remains false
+
+                try {
+                    await chatSDK.sendReadReceipt('1777185788167');
+                    fail('Should have thrown');
+                } catch (error) {
+                    expect(error).toBeInstanceOf(ChatSDKError);
+                    expect((error as ChatSDKError).message).toBe(ChatSDKErrorName.UninitializedChatSDK);
+                }
+            });
+        });
+    });
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.9",
+  "version": "1.11.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/omnichannel-chat-sdk",
-      "version": "1.11.9",
+      "version": "1.11.13",
       "license": "MIT",
       "dependencies": {
         "@azure/communication-chat": "1.5.4",
         "@azure/communication-common": "2.3.1",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.6",
-        "@microsoft/ocsdk": "0.5.22-main.27b39ce",
+        "@microsoft/ocsdk": "0.5.22-main.8dbdcd5",
         "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
       },
@@ -260,7 +260,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1437,9 +1436,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.22-main.27b39ce",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.22-main.27b39ce.tgz",
-      "integrity": "sha512-MwXzPu7BPweguN/n1jKRbQr3L9b/nDGM8hBHvh6bv9izri3Lb9+F9YOWRPHP+Wv3BH5SeVs8ypNU0o2mucGSZw==",
+      "version": "0.5.22-main.8dbdcd5",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.22-main.8dbdcd5.tgz",
+      "integrity": "sha512-nVy89H6eC4Ch/PZzL48cEgcE8Gnj4N9eTpiwK+qJ6wGqd2ZqRn4r9SmRWFCzllmyJxCVuWchs4DoEc3MUDnsEg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -1703,7 +1702,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1930,7 +1928,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2294,7 +2291,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2894,7 +2890,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3921,7 +3916,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5749,7 +5743,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5933,7 +5926,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.13",
+  "version": "1.11.9",
   "description": "Microsoft Omnichannel Chat SDK",
   "files": [
     "lib/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-sdk",
-  "version": "1.11.9",
+  "version": "1.11.13",
   "description": "Microsoft Omnichannel Chat SDK",
   "files": [
     "lib/**/*"
@@ -49,7 +49,7 @@
     "@azure/communication-chat": "1.5.4",
     "@azure/communication-common": "2.3.1",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.6",
-    "@microsoft/ocsdk": "0.5.22-main.27b39ce",
+    "@microsoft/ocsdk": "0.5.22-main.8dbdcd5",
     "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   },

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1820,7 +1820,7 @@ class OmnichannelChatSDK {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const statusCode = (error as any)?.response?.status;
             if (statusCode === 404) {
-                exceptionThrowers.throwInvalidConversation(this.scenarioMarker, TelemetryEvent.GetUnreadMessageCount, telemetryData);
+                exceptionThrowers.throwChatSDKError(ChatSDKErrorName.InvalidConversation, error, this.scenarioMarker, TelemetryEvent.GetUnreadMessageCount, telemetryData, "Conversation not found");
             }
             exceptionThrowers.throwUnreadMessageCountRetrievalFailure(error, this.scenarioMarker, TelemetryEvent.GetUnreadMessageCount, telemetryData);
         }
@@ -1868,10 +1868,10 @@ class OmnichannelChatSDK {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const statusCode = (error as any)?.response?.status;
             if (statusCode === 404) {
-                exceptionThrowers.throwInvalidConversation(this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData);
+                exceptionThrowers.throwChatSDKError(ChatSDKErrorName.InvalidConversation, error, this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData, "Conversation not found");
             }
             if (statusCode === 400) {
-                exceptionThrowers.throwSendReadReceiptInvalidParams(this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData);
+                exceptionThrowers.throwChatSDKError(ChatSDKErrorName.SendReadReceiptInvalidParams, error, this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData, "Invalid parameters");
             }
             exceptionThrowers.throwSendReadReceiptFailure(error, this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData);
         }

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1789,6 +1789,94 @@ class OmnichannelChatSDK {
         }
     }
 
+    /**
+     * Fetches unread message count for the authenticated user.
+     * Auth-only — does not require an active chat session.
+     */
+    public async getUnreadMessageCount(): Promise<object> {
+        const telemetryData = {
+            RequestId: this.requestId || ""
+        };
+
+        this.scenarioMarker.startScenario(TelemetryEvent.GetUnreadMessageCount, telemetryData);
+
+        if (!this.authenticatedUserToken) {
+            exceptionThrowers.throwChatSDKError(
+                ChatSDKErrorName.UndefinedAuthToken,
+                undefined,
+                this.scenarioMarker,
+                TelemetryEvent.GetUnreadMessageCount,
+                telemetryData,
+                "getUnreadMessageCount is only supported for authenticated chats"
+            );
+        }
+
+        try {
+            const result = await this.OCClient.getUnreadMessageCount(this.authenticatedUserToken);
+
+            this.scenarioMarker.completeScenario(TelemetryEvent.GetUnreadMessageCount, telemetryData);
+            return result;
+        } catch (error) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const statusCode = (error as any)?.response?.status;
+            if (statusCode === 404) {
+                exceptionThrowers.throwInvalidConversation(this.scenarioMarker, TelemetryEvent.GetUnreadMessageCount, telemetryData);
+            }
+            exceptionThrowers.throwUnreadMessageCountRetrievalFailure(error, this.scenarioMarker, TelemetryEvent.GetUnreadMessageCount, telemetryData);
+        }
+
+        // Unreachable — throwUnreadMessageCountRetrievalFailure always throws.
+        // Required for TypeScript return type satisfaction.
+        return {};
+    }
+
+    /**
+     * Sends a read receipt for a specific message.
+     * Authenticated: calls MRT (updates NRD + forwards to ACS).
+     * Unauthenticated: calls ACS directly.
+     */
+    public async sendReadReceipt(messageId: string): Promise<void> {
+        const telemetryData = {
+            RequestId: this.requestId,
+            ChatId: this.chatToken?.chatId as string || ""
+        };
+
+        this.scenarioMarker.startScenario(TelemetryEvent.SendReadReceipt, telemetryData);
+
+        if (!this.isInitialized) {
+            exceptionThrowers.throwUninitializedChatSDK(this.scenarioMarker, TelemetryEvent.SendReadReceipt);
+        }
+
+        if (!messageId) {
+            exceptionThrowers.throwSendReadReceiptInvalidParams(this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData);
+        }
+
+        try {
+            if (this.authenticatedUserToken) {
+                // Authenticated: call MRT which updates NRD and forwards to ACS
+                await this.OCClient.sendReadReceipt(this.requestId, messageId, this.authenticatedUserToken);
+            } else {
+                // Unauthenticated: call ACS directly (no MRT, no NRD)
+                if (!this.conversation) {
+                    exceptionThrowers.throwUninitializedChatSDK(this.scenarioMarker, TelemetryEvent.SendReadReceipt);
+                }
+                await (this.conversation as ACSConversation).sendReadReceipt(messageId);
+            }
+
+            this.scenarioMarker.completeScenario(TelemetryEvent.SendReadReceipt, telemetryData);
+        } catch (error) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const statusCode = (error as any)?.response?.status;
+            if (statusCode === 404) {
+                exceptionThrowers.throwInvalidConversation(this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData);
+            }
+            if (statusCode === 400) {
+                exceptionThrowers.throwSendReadReceiptInvalidParams(this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData);
+            }
+            exceptionThrowers.throwSendReadReceiptFailure(error, this.scenarioMarker, TelemetryEvent.SendReadReceipt, telemetryData);
+        }
+    }
+
     public async onTypingEvent(onTypingEventCallback: CallableFunction): Promise<void> {
         this.scenarioMarker.startScenario(TelemetryEvent.OnTypingEvent, {
             RequestId: this.requestId,

--- a/src/core/ChatSDKError.ts
+++ b/src/core/ChatSDKError.ts
@@ -66,7 +66,12 @@ export enum ChatSDKErrorName {
     AuthenticatedUserTokenNotFound = "AuthenticatedUserTokenNotFound",
     /** Failure in mid-conversation authentication */
     MidConversationAuthFailure = "MidConversationAuthFailure",
-
+    /** Failure in sending read receipt */
+    SendReadReceiptFailure = "SendReadReceiptFailure",
+    /** Invalid parameters for send read receipt (missing messageId) */
+    SendReadReceiptInvalidParams = "SendReadReceiptInvalidParams",
+    /** Failure in retrieving unread message count */
+    UnreadMessageCountRetrievalFailure = "UnreadMessageCountRetrievalFailure",
 }
 
 export class ChatSDKError {

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -29,6 +29,7 @@ enum ACSClientEvent {
     GetMessages = 'GetMessages',
     SendMessage = 'SendMessage',
     SendTyping = 'SendTyping',
+    SendReadReceipt = 'SendReadReceipt',
     StartPolling = 'StartPolling',
     StopPolling = 'StopPolling',
     Disconnect = 'Disconnect'
@@ -385,6 +386,26 @@ export class ACSConversation {
             });
 
             throw new Error('SendTypingFailed');
+        }
+    }
+
+    public async sendReadReceipt(messageId: string): Promise<void> {
+        this.logger?.startScenario(ACSClientEvent.SendReadReceipt);
+
+        try {
+            await this.chatThreadClient?.sendReadReceipt({ chatMessageId: messageId });
+            this.logger?.completeScenario(ACSClientEvent.SendReadReceipt);
+        } catch (error) {
+            const exceptionDetails = {
+                response: 'SendReadReceiptFailed',
+                errorObject: `${error}`
+            };
+
+            this.logger?.failScenario(ACSClientEvent.SendReadReceipt, {
+                ExceptionDetails: JSON.stringify(exceptionDetails)
+            });
+
+            throw new Error('SendReadReceiptFailed');
         }
     }
 

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -49,6 +49,8 @@ enum TelemetryEvent {
     GetPersistentChatHistory = "GetPersistentChatHistory",
     WaitForConversationalSurvey = "WaitForConversationalSurvey",
     MidConversationAuth = "MidConversationAuth",
+    GetUnreadMessageCount = "GetUnreadMessageCount",
+    SendReadReceipt = "SendReadReceipt",
 }
 
 export default TelemetryEvent;

--- a/src/utils/exceptionThrowers.ts
+++ b/src/utils/exceptionThrowers.ts
@@ -159,6 +159,19 @@ export const throwAuthContactIdNotFoundFailure = (e: unknown, scenarioMarker: Sc
     throwChatSDKError(ChatSDKErrorName.AuthContactIdNotFoundFailure, e, scenarioMarker, telemetryEvent, telemetryData);
 }
 
+export const throwSendReadReceiptFailure = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string} = {}): void => {
+    throwChatSDKError(ChatSDKErrorName.SendReadReceiptFailure, e, scenarioMarker, telemetryEvent, telemetryData);
+};
+
+export const throwSendReadReceiptInvalidParams = (scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string} = {}): void => {
+    const message = "messageId is required";
+    throwChatSDKError(ChatSDKErrorName.SendReadReceiptInvalidParams, undefined, scenarioMarker, telemetryEvent, telemetryData, message);
+};
+
+export const throwUnreadMessageCountRetrievalFailure = (e: unknown, scenarioMarker: ScenarioMarker, telemetryEvent: TelemetryEvent, telemetryData: {[key: string]: string} = {}): void => {
+    throwChatSDKError(ChatSDKErrorName.UnreadMessageCountRetrievalFailure, e, scenarioMarker, telemetryEvent, telemetryData);
+};
+
 export default {
     throwChatSDKError,
     throwScriptLoadFailure,
@@ -182,5 +195,8 @@ export default {
     throwChatAdapterInitializationFailure,
     throwLiveChatTranscriptRetrievalFailure,
     throwAuthContactIdNotFoundFailure,
-    throwNotPersistentChatEnabled
+    throwNotPersistentChatEnabled,
+    throwSendReadReceiptFailure,
+    throwSendReadReceiptInvalidParams,
+    throwUnreadMessageCountRetrievalFailure
 }


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference
[User Story 6331091](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/6331091): [OCSDK] Add read receipt support

### Description

Today there is no way to convey to the agent that customer has read a message, and for customer to know how many unread messages from agent do they have.

## Solution Proposed

Add two new authenticated SDK methods for read receipt support:

getUnreadMessageCount: GET call to fetch unread count per widget (auth-only)
sendReadReceipt: POST call to mark messages as read via MRT

Added new method for unauthenticated chat which can send read receipts directly to ACS without backend intervention:

sendReadReceipt: POST call to mark messages as read to ACS

Updated ocsdk version to support these api's

### Acceptance criteria

Local validation and unit tests

## Test cases and evidence

Persistent chat:
getUnreadMesages:
<img width="860" height="592" alt="Screenshot 2026-04-28 131836" src="https://github.com/user-attachments/assets/8567dedd-9fbd-4abc-9f0f-192e7ef71037" />

sendReadReceipt: Sent to ACS
<img width="1529" height="803" alt="Screenshot 2026-04-28 132203" src="https://github.com/user-attachments/assets/18f10db0-ae51-4e83-8f2e-04772eaa991a" />

getUnreadMessages and sendReadReceipts in disconnected state:
<img width="900" height="751" alt="Screenshot 2026-04-28 132519" src="https://github.com/user-attachments/assets/d614ca35-8830-4a35-a9aa-a736c42ed474" />

Auth chat Timeout Rule:
<img width="973" height="647" alt="Screenshot 2026-04-28 133340" src="https://github.com/user-attachments/assets/10889b27-ded0-45dc-ad22-582c9af51ff4" />

Bot messages shown and and sign in card message hidden:
<img width="986" height="592" alt="Screenshot 2026-04-28 135421" src="https://github.com/user-attachments/assets/543b99a8-44da-46d4-820d-b96b8b2b799f" />

Attahcment:
<img width="1539" height="611" alt="Screenshot 2026-04-28 135739" src="https://github.com/user-attachments/assets/3d61f3d3-0dfd-4308-aab6-cbed73a7d28f" />

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y
N/A
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
