### PR TITLE
feat: add ACS message streaming support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added `OmnichannelChatSDK.onStreamingMessage(callback)` — subscribe to ACS-driven streaming message chunks for typing-style progressive UX. Available in `LiveChatVersion.V2` over the signaling websocket. See README "On Streaming Message" section for full lifecycle and constraints.
+- Backwards-compat: consumers who only use `onNewMessage` continue to receive streaming-bot responses as a single message at completion (when the streaming `"final"` chunk arrives). No code changes required for existing integrations — only consumers who want progressive UX need to call the new `onStreamingMessage`.
+- Added new public types: `OmnichannelStreamingMessage`, `StreamingMetadata`, `PolicyViolation`, `OnStreamingMessageOptionalParams`.
+- Added `UninitializedConversation` and `StreamingSubscriptionFailure` to `ChatSDKErrorName` enum.
+- Added streaming telemetry events to `TelemetryEvent` (`OnStreamingMessage`, `StreamingMessageReceived`, `StreamingDuplicateFinal`, `StreamingPolicyViolation`, and others).
+- Added `MessageSource.WebSocketStreaming` for distinguishing streaming chunks from regular WebSocket messages in telemetry.
+- Stamps `@microsoft/botframework-webchat-adapter-azure-communication-chat` package version into telemetry context (`ACSAdapter` / `ACSAdapterVersion` fields).
 - Added `authenticateChat` public method to authenticate an ongoing unauthenticated chat session mid-conversation
 - Added `MidConversationAuth` telemetry event for scenario tracking
 - Added `MidConversationAuthFailure` to `ChatSDKErrorName` enum
@@ -14,7 +21,8 @@ All notable changes to this project will be documented in this file.
 - Throws `ChatSDKError` consistently on all failure paths (token resolution, empty token, API call, token refresh)
 
 ### Changed
-- Updated botframework-webchat-adapter-azure-communication-chat to "^0.0.1-beta.6"
+
+- Bumped `@azure/communication-chat` to `1.6.0-beta.7`, `@azure/communication-common` to `2.4.0`, and `@microsoft/botframework-webchat-adapter-azure-communication-chat` to `0.0.1-beta.7` to enable ACS message streaming support.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -454,6 +454,49 @@ chatSDK.onNewMessage((message) => {
 }, optionalParams);
 ```
 
+### On Streaming Message
+
+Subscribe to ACS-driven streaming message chunks for typing-style progressive UX. Streaming requires `LiveChatVersion.V2` and the signaling websocket to be connected.
+
+```ts
+chatSDK.onStreamingMessage((message) => {
+    switch (message.streamingMetadata.streamingMessageType) {
+        case "start":
+            // Bot started a streaming response — create the bubble
+            break;
+        case "informative":
+            // Optional progress signal (e.g., "AI is thinking...")
+            break;
+        case "streaming":
+            // Replace bubble content with message.content (full assembled-so-far text)
+            break;
+        case "final":
+            // Stream complete — check streamingMetadata.streamEndReason
+            //   "completed" — normal end
+            //   "expired"   — server-side timeout
+            //   "canceled"  — operator/server canceled
+            break;
+    }
+    // Optional: check for content moderation
+    if (message.policyViolation?.result === "contentBlocked") {
+        // Strip / show moderation notice
+    }
+});
+```
+
+**Constraints:**
+
+- Available only in `LiveChatVersion.V2`. Throws `ChatSDKError` with `UnsupportedLiveChatVersion` otherwise.
+- Must be called after `startChat()`. Throws `ChatSDKError` with `UninitializedConversation` otherwise.
+- Streaming events fire over the signaling websocket. If the websocket is unavailable, no streaming events fire.
+- No client-initiated abort. To stop a streaming response, send a custom message to the bot.
+- Each chunk's `content` field carries the **full assembled-so-far** message content (replace semantics, not delta). To compute deltas, diff against the previous chunk for the same message id.
+- Multiple handlers may register; they all receive each chunk. There is no `unregisterOnStreamingMessage` — cleanup happens via `endChat()`.
+- Historical streaming messages on reconnect arrive via `onNewMessage` with their final assembled content; `onStreamingMessage` is live-only.
+- Chunks may arrive without a preceding `"start"` (e.g., on websocket reconnect mid-stream). Render defensively from any chunk.
+
+**Backwards compatibility:** Consumers who only use `onNewMessage` (not `onStreamingMessage`) will still receive streaming-bot responses — the SDK fires `onNewMessage` once with the assembled content when the stream's `"final"` chunk arrives. This means existing integrations continue to work without code changes when a bot adds streaming support; they just see the message arrive once at completion rather than progressively. To render progressive UX, consumers must opt in by calling `onStreamingMessage`.
+
 ### On Typing Event
 
 It subscribes to an agent typing event.

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -6035,4 +6035,107 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             });
         });
     });
+
+    describe('ChatSDK.onStreamingMessage', () => {
+        const omnichannelConfig = {
+            orgUrl: '[data-org-url]',
+            orgId: '[data-org-id]',
+            widgetId: '[data-app-id]'
+        };
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('throws UnsupportedLiveChatVersion when liveChatVersion is V1', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK.liveChatVersion = LiveChatVersion.V1;
+            chatSDK["isAMSClientAllowed"] = true;
+            await chatSDK.initialize();
+
+            try {
+                await chatSDK.onStreamingMessage(jest.fn());
+                fail('Expected onStreamingMessage to throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(ChatSDKError);
+                expect(e.message).toBe(ChatSDKErrorName.UnsupportedLiveChatVersion);
+            }
+        });
+
+        it('throws UninitializedConversation when called before startChat()', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+            await chatSDK.initialize();
+            // Don't call startChat — conversation field stays null
+
+            try {
+                await chatSDK.onStreamingMessage(jest.fn());
+                fail('Expected onStreamingMessage to throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(ChatSDKError);
+                expect(e.message).toBe(ChatSDKErrorName.UninitializedConversation);
+            }
+        });
+
+        it('delegates to ACSConversation.registerOnStreamingMessage and records scenario telemetry on success', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.createConversation = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+            await chatSDK.startChat();
+
+            const registerSpy = jest.fn().mockResolvedValue(undefined);
+            chatSDK.conversation = {
+                registerOnStreamingMessage: registerSpy,
+            };
+
+            const startScenarioSpy = jest.spyOn(chatSDK.scenarioMarker, 'startScenario');
+            const completeScenarioSpy = jest.spyOn(chatSDK.scenarioMarker, 'completeScenario');
+
+            const handler = jest.fn();
+            await chatSDK.onStreamingMessage(handler);
+
+            expect(registerSpy).toHaveBeenCalledWith(handler, undefined);
+            expect(startScenarioSpy).toHaveBeenCalledWith('OnStreamingMessage', expect.any(Object));
+            expect(completeScenarioSpy).toHaveBeenCalledWith('OnStreamingMessage', expect.any(Object));
+        });
+
+        it('wraps generic ACSConversation errors into ChatSDKError with StreamingSubscriptionFailure', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+            await chatSDK.initialize();
+
+            chatSDK.OCClient.sessionInit = jest.fn();
+            chatSDK.OCClient.createConversation = jest.fn();
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+            await chatSDK.startChat();
+
+            chatSDK.conversation = {
+                registerOnStreamingMessage: jest.fn().mockRejectedValue(new Error('RegisterOnStreamingMessage')),
+            };
+
+            try {
+                await chatSDK.onStreamingMessage(jest.fn());
+                fail('Expected onStreamingMessage to throw');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(ChatSDKError);
+                expect(e.message).toBe(ChatSDKErrorName.StreamingSubscriptionFailure);
+            }
+        });
+    });
 })

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -696,4 +696,226 @@ describe('ACSClient', () => {
 
         expect(response).not.toBeDefined();
     });
+
+    describe('registerOnStreamingMessage', () => {
+        async function setupConversation() {
+            const client: any = new ACSClient();
+            const config = { token: 'token', environmentUrl: 'url' };
+            await client.initialize(config);
+
+            const chatThreadClient: any = {};
+            chatThreadClient.listParticipants = jest.fn(() => ({
+                next: jest.fn(() => ({ value: 'value', done: jest.fn() })),
+            }));
+
+            const onMock = jest.fn();
+            const offMock = jest.fn();
+            client.chatClient = {};
+            client.chatClient.getChatThreadClient = jest.fn(() => chatThreadClient);
+            client.chatClient.startRealtimeNotifications = jest.fn();
+            client.chatClient.on = onMock;
+            client.chatClient.off = offMock;
+
+            const conversation = await client.joinConversation({
+                id: 'id',
+                threadId: 'threadId',
+                pollingInterval: 1000,
+            });
+            return { conversation, onMock, offMock, client };
+        }
+
+        it('attaches listeners for streamingChatMessageStarted and streamingChatMessageChunkReceived', async () => {
+            const { conversation, onMock } = await setupConversation();
+
+            await conversation.registerOnStreamingMessage(jest.fn());
+
+            const eventNames = onMock.mock.calls.map((c: any[]) => c[0]);
+            expect(eventNames).toContain('streamingChatMessageStarted');
+            expect(eventNames).toContain('streamingChatMessageChunkReceived');
+        });
+
+        it('records start/complete scenario telemetry on successful registration', async () => {
+            const { conversation } = await setupConversation();
+            // Inject a mock logger directly to verify scenario calls.
+            const mockLogger = {
+                startScenario: jest.fn(),
+                completeScenario: jest.fn(),
+                failScenario: jest.fn(),
+                recordIndividualEvent: jest.fn(),
+            };
+            (conversation as any).logger = mockLogger;
+
+            await conversation.registerOnStreamingMessage(jest.fn());
+
+            expect(mockLogger.startScenario).toHaveBeenCalledWith('RegisterOnStreamingMessage');
+            expect(mockLogger.completeScenario).toHaveBeenCalledWith('RegisterOnStreamingMessage');
+            expect(mockLogger.failScenario).not.toHaveBeenCalled();
+        });
+
+        it('throws and logs failScenario when chatClient.on throws', async () => {
+            const { conversation, client } = await setupConversation();
+            client.chatClient.on = jest.fn(() => { throw new Error('subscribe failed'); });
+
+            await expect(conversation.registerOnStreamingMessage(jest.fn())).rejects.toThrow('RegisterOnStreamingMessage');
+        });
+
+        it('fires the consumer callback with an OmnichannelStreamingMessage for start events', async () => {
+            const { conversation, onMock } = await setupConversation();
+            const callback = jest.fn();
+            await conversation.registerOnStreamingMessage(callback);
+
+            const startListener = onMock.mock.calls.find((c: any[]) => c[0] === 'streamingChatMessageStarted')[1];
+            const startEvent = {
+                id: 'm1',
+                message: '',
+                threadId: 't',
+                sender: { kind: 'communicationUser', communicationUserId: 'b' },
+                senderDisplayName: 'Bot',
+                recipient: { kind: 'communicationUser', communicationUserId: 'u' },
+                type: 'Text',
+                version: '1',
+                createdOn: new Date(),
+                metadata: {},
+                streamingMetadata: { streamingMessageType: 'start', streamingSequenceNumber: 0 },
+            };
+            startListener(startEvent);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            const delivered = callback.mock.calls[0][0];
+            expect(delivered.id).toBe('m1');
+            expect(delivered.streamingMetadata.streamingMessageType).toBe('start');
+        });
+
+        it('does not propagate errors when consumer callback throws synchronously', async () => {
+            const { conversation, onMock } = await setupConversation();
+            const callback = jest.fn(() => { throw new Error('consumer bug'); });
+            await conversation.registerOnStreamingMessage(callback);
+
+            const startListener = onMock.mock.calls.find((c: any[]) => c[0] === 'streamingChatMessageStarted')[1];
+            const event = {
+                id: 'm1',
+                message: '',
+                threadId: 't',
+                sender: { kind: 'communicationUser', communicationUserId: 'b' },
+                senderDisplayName: 'Bot',
+                recipient: { kind: 'communicationUser', communicationUserId: 'u' },
+                type: 'Text',
+                version: '1',
+                createdOn: new Date(),
+                metadata: {},
+                streamingMetadata: { streamingMessageType: 'start', streamingSequenceNumber: 0 },
+            };
+
+            expect(() => startListener(event)).not.toThrow();
+        });
+
+        it('removes streaming listeners via existing eventListeners cleanup on disconnect', async () => {
+            const { conversation, offMock } = await setupConversation();
+            await conversation.registerOnStreamingMessage(jest.fn());
+            await conversation.disconnect();
+
+            const offEventNames = offMock.mock.calls.map((c: any[]) => c[0]);
+            expect(offEventNames).toContain('streamingChatMessageStarted');
+            expect(offEventNames).toContain('streamingChatMessageChunkReceived');
+        });
+
+        // Backwards-compat fire-through: when streaming "final" arrives, the SDK
+        // also invokes the registered chatMessageReceived listeners so consumers
+        // who only use onNewMessage still see the assembled message once at the
+        // end. This protects them from silent message loss when bots upgrade to
+        // streaming responses.
+        describe('backwards-compat fire-through to onNewMessage', () => {
+            const finalChunkEvent = (id = 'm1', content = 'Hello world') => ({
+                id,
+                message: content,
+                threadId: 't',
+                sender: { kind: 'communicationUser', communicationUserId: 'b' },
+                senderDisplayName: 'Bot',
+                recipient: { kind: 'communicationUser', communicationUserId: 'u' },
+                type: 'Text',
+                version: '1',
+                createdOn: new Date(),
+                editedOn: new Date(),
+                metadata: {},
+                streamingMetadata: {
+                    streamingMessageType: 'final',
+                    streamingSequenceNumber: 5,
+                    streamEndReason: 'completed',
+                },
+            });
+
+            const nonFinalChunkEvent = (id = 'm1', content = 'partial') => ({
+                ...finalChunkEvent(id, content),
+                streamingMetadata: {
+                    streamingMessageType: 'streaming',
+                    streamingSequenceNumber: 2,
+                },
+            });
+
+            it('"final" chunk fires through to chatMessageReceived listeners', async () => {
+                const { conversation, onMock } = await setupConversation();
+
+                // Register a fake chatMessageReceived listener (simulating what
+                // registerOnNewMessage would do — pushed via trackListener).
+                const newMessageListener = jest.fn();
+                (conversation as any).eventListeners['chatMessageReceived'] = [newMessageListener];
+
+                // Register streaming
+                await conversation.registerOnStreamingMessage(jest.fn());
+
+                // Simulate ACS firing a "final" chunk
+                const chunkListener = onMock.mock.calls.find((c: any[]) => c[0] === 'streamingChatMessageChunkReceived')[1];
+                const event = finalChunkEvent();
+                chunkListener(event);
+
+                // The chatMessageReceived listener should have been invoked with the chunk event
+                expect(newMessageListener).toHaveBeenCalledTimes(1);
+                expect(newMessageListener).toHaveBeenCalledWith(event);
+            });
+
+            it('non-final chunks do NOT fire through to chatMessageReceived listeners', async () => {
+                const { conversation, onMock } = await setupConversation();
+
+                const newMessageListener = jest.fn();
+                (conversation as any).eventListeners['chatMessageReceived'] = [newMessageListener];
+
+                await conversation.registerOnStreamingMessage(jest.fn());
+
+                const chunkListener = onMock.mock.calls.find((c: any[]) => c[0] === 'streamingChatMessageChunkReceived')[1];
+                chunkListener(nonFinalChunkEvent());
+
+                expect(newMessageListener).not.toHaveBeenCalled();
+            });
+
+            it('fire-through still happens when consumer registers onlystreaming, no chatMessageReceived listeners', async () => {
+                const { conversation, onMock } = await setupConversation();
+                // No chatMessageReceived listeners registered.
+                const streamingCallback = jest.fn();
+                await conversation.registerOnStreamingMessage(streamingCallback);
+
+                const chunkListener = onMock.mock.calls.find((c: any[]) => c[0] === 'streamingChatMessageChunkReceived')[1];
+                expect(() => chunkListener(finalChunkEvent())).not.toThrow();
+
+                // Streaming callback still fires
+                expect(streamingCallback).toHaveBeenCalledTimes(1);
+            });
+
+            it('exception in chatMessageReceived listener does not break streaming delivery', async () => {
+                const { conversation, onMock } = await setupConversation();
+
+                const buggyListener = jest.fn(() => { throw new Error('newMessage handler bug'); });
+                (conversation as any).eventListeners['chatMessageReceived'] = [buggyListener];
+                const streamingCallback = jest.fn();
+                await conversation.registerOnStreamingMessage(streamingCallback);
+
+                const chunkListener = onMock.mock.calls.find((c: any[]) => c[0] === 'streamingChatMessageChunkReceived')[1];
+                expect(() => chunkListener(finalChunkEvent())).not.toThrow();
+
+                // Buggy listener was attempted
+                expect(buggyListener).toHaveBeenCalledTimes(1);
+                // Streaming callback still fired
+                expect(streamingCallback).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
 });

--- a/__tests__/utils/createOmnichannelStreamingMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelStreamingMessage.spec.ts
@@ -1,0 +1,235 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import LiveChatVersion from '../../src/core/LiveChatVersion';
+import createOmnichannelStreamingMessage from '../../src/utils/createOmnichannelStreamingMessage';
+import { makeStreamChunkEvent, makeStreamFinalEvent, makeStreamStartEvent } from './streamingFixtures';
+
+describe('createOmnichannelStreamingMessage', () => {
+    let sequenceCounters: Map<string, number>;
+    let finalizedMessageIds: Set<string>;
+    let logger: any;
+
+    beforeEach(() => {
+        sequenceCounters = new Map();
+        finalizedMessageIds = new Set();
+        logger = { recordIndividualEvent: jest.fn() };
+    });
+
+    it('converts a start event into an OmnichannelStreamingMessage with type=start', () => {
+        const event = makeStreamStartEvent({ id: 'm1', message: '' });
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageStarted',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result).toBeDefined();
+        expect(result!.id).toBe('m1');
+        expect(result!.streamingMetadata.streamingMessageType).toBe('start');
+        expect(result!.streamingMetadata.streamingSequenceNumber).toBe(0);
+    });
+
+    it('converts a chunk event into a streaming message with type=streaming', () => {
+        const event = makeStreamChunkEvent(3, 'Hello world', { id: 'm1' });
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result).toBeDefined();
+        expect(result!.streamingMetadata.streamingMessageType).toBe('streaming');
+        expect(result!.streamingMetadata.streamingSequenceNumber).toBe(3);
+        expect(result!.content).toBe('Hello world');
+    });
+
+    it('converts a final event and adds messageId to finalizedMessageIds', () => {
+        const event = makeStreamFinalEvent(7, 'Done', 'completed');
+        event.id = 'm1';
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result!.streamingMetadata.streamingMessageType).toBe('final');
+        expect(result!.streamingMetadata.streamEndReason).toBe('completed');
+        expect(finalizedMessageIds.has('m1')).toBe(true);
+    });
+
+    it('defaults missing streamingMessageType to "start" for start events with telemetry warning', () => {
+        const event = makeStreamStartEvent({ streamingMetadata: undefined });
+        event.id = 'm1';
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageStarted',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result!.streamingMetadata.streamingMessageType).toBe('start');
+        expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+            'StreamingMetadataMissingType',
+            'WSStream',
+            expect.objectContaining({ messageId: 'm1' })
+        );
+    });
+
+    it('defaults missing streamingMessageType to "streaming" for chunk events', () => {
+        const event = makeStreamChunkEvent(2, 'partial');
+        event.id = 'm1';
+        event.streamingMetadata = undefined as any;
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result!.streamingMetadata.streamingMessageType).toBe('streaming');
+    });
+
+    it('defaults missing streamEndReason on final to "completed" with warning telemetry', () => {
+        const event = makeStreamFinalEvent(5, 'Done');
+        event.id = 'm1';
+        event.streamingMetadata = { streamingMessageType: 'final', streamingSequenceNumber: 5 };
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result!.streamingMetadata.streamEndReason).toBe('completed');
+        expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+            'StreamingFinalMissingReason',
+            'WSStream',
+            expect.objectContaining({ messageId: 'm1' })
+        );
+    });
+
+    it('drops duplicate final events for the same messageId', () => {
+        const finalA = makeStreamFinalEvent(5, 'Done', 'completed');
+        finalA.id = 'm1';
+        const finalB = makeStreamFinalEvent(5, 'Done again', 'completed');
+        finalB.id = 'm1';
+
+        createOmnichannelStreamingMessage(finalA, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        const second = createOmnichannelStreamingMessage(finalB, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(second).toBeUndefined();
+        expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+            'StreamingDuplicateFinal',
+            'WSStream',
+            expect.objectContaining({ messageId: 'm1' })
+        );
+    });
+
+    it('logs StreamingChunkAfterFinal but still emits a chunk that arrives post-final', () => {
+        const finalEvent = makeStreamFinalEvent(5, 'Done', 'completed');
+        finalEvent.id = 'm1';
+        const lateChunk = makeStreamChunkEvent(6, 'Late');
+        lateChunk.id = 'm1';
+
+        createOmnichannelStreamingMessage(finalEvent, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+        const late = createOmnichannelStreamingMessage(lateChunk, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(late).toBeDefined();
+        expect(late!.streamingMetadata.streamingMessageType).toBe('streaming');
+        expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+            'StreamingChunkAfterFinal',
+            'WSStream',
+            expect.objectContaining({ messageId: 'm1' })
+        );
+    });
+
+    it('passes policyViolation through and logs StreamingPolicyViolation telemetry', () => {
+        const event = makeStreamChunkEvent(2, 'flagged');
+        event.id = 'm1';
+        (event as any).policyViolation = { result: 'contentBlocked' };
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result!.policyViolation).toEqual({ result: 'contentBlocked' });
+        expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+            'StreamingPolicyViolation',
+            'WSStream',
+            expect.objectContaining({ messageId: 'm1', result: 'contentBlocked' })
+        );
+    });
+
+    it('evicts oldest sequence counter at MAX_TRACKED_STREAMS and logs eviction', () => {
+        // Pre-fill 256 counters with arbitrary messageIds.
+        for (let i = 0; i < 256; i++) {
+            sequenceCounters.set(`pre-${i}`, 1);
+        }
+
+        // Now process a fresh chunk for a brand-new messageId without ACS sequence number.
+        const event = makeStreamChunkEvent(0, 'new stream');
+        event.id = 'fresh';
+        event.streamingMetadata = { streamingMessageType: 'streaming' };
+
+        const result = createOmnichannelStreamingMessage(event, {
+            liveChatVersion: LiveChatVersion.V2,
+            eventName: 'streamingChatMessageChunkReceived',
+            sequenceCounters,
+            finalizedMessageIds,
+            logger,
+        });
+
+        expect(result).toBeDefined();
+        expect(sequenceCounters.has('fresh')).toBe(true);
+        expect(sequenceCounters.has('pre-0')).toBe(false);
+        expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+            'StreamingCounterEvicted',
+            'WSStream',
+            expect.objectContaining({ evictedMessageId: 'pre-0' })
+        );
+    });
+});

--- a/__tests__/utils/printers/StreamingMessagePrinter.spec.ts
+++ b/__tests__/utils/printers/StreamingMessagePrinter.spec.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { StreamingMessagePrinter } from '../../../src/utils/printers/StreamingMessagePrinter';
+import { makeStreamChunkEvent, makeStreamStartEvent } from '../streamingFixtures';
+
+describe('StreamingMessagePrinter', () => {
+    it('printifies a start event with id, tags, bot flag, content size, and streaming metadata', () => {
+        const event = makeStreamStartEvent({
+            id: 'm1',
+            metadata: { tags: 'public,bot' },
+            message: 'Hi',
+        });
+
+        const result = StreamingMessagePrinter.printify(event);
+
+        expect(result.id).toBe('m1');
+        expect(result.tags).toEqual(['public', 'bot']);
+        expect(result.bot).toBe(false);
+        expect((result as any).streamingMessageType).toBe('start');
+        expect((result as any).streamingSequenceNumber).toBe(0);
+    });
+
+    it('printifies a chunk event without leaking raw content (length only)', () => {
+        const event = makeStreamChunkEvent(3, 'sensitive content here');
+        event.id = 'm1';
+
+        const result = StreamingMessagePrinter.printify(event);
+
+        expect(result.id).toBe('m1');
+        expect(result.content).not.toContain('sensitive content here');
+        expect(result.content).toBe('22 chars');
+    });
+
+    it('returns an empty PrintableMessage when event is falsy', () => {
+        const result = StreamingMessagePrinter.printify(undefined as any);
+        expect(result).toEqual({});
+    });
+});

--- a/__tests__/utils/streamingFixtures.ts
+++ b/__tests__/utils/streamingFixtures.ts
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {
+    StreamingChatMessageStartEvent,
+    StreamingChatMessageChunkReceivedEvent,
+    StreamEndReason,
+} from '@azure/communication-signaling';
+
+export function makeStreamStartEvent(
+    overrides: Partial<StreamingChatMessageStartEvent> = {}
+): StreamingChatMessageStartEvent {
+    return {
+        id: "msg-1",
+        message: "",
+        threadId: "thread-1",
+        sender: { kind: "communicationUser", communicationUserId: "bot-1" } as any,
+        senderDisplayName: "Bot",
+        recipient: { kind: "communicationUser", communicationUserId: "user-1" } as any,
+        type: "Text",
+        version: "1",
+        createdOn: new Date("2026-04-29T12:00:00Z"),
+        metadata: {},
+        streamingMetadata: { streamingMessageType: "start", streamingSequenceNumber: 0 },
+        ...overrides,
+    };
+}
+
+export function makeStreamChunkEvent(
+    seq: number,
+    content: string,
+    overrides: Partial<StreamingChatMessageChunkReceivedEvent> = {}
+): StreamingChatMessageChunkReceivedEvent {
+    return {
+        ...makeStreamStartEvent({ message: content }),
+        editedOn: new Date("2026-04-29T12:00:01Z"),
+        streamingMetadata: { streamingMessageType: "streaming", streamingSequenceNumber: seq },
+        ...overrides,
+    };
+}
+
+export function makeStreamFinalEvent(
+    seq: number,
+    content: string,
+    reason: StreamEndReason = "completed"
+): StreamingChatMessageChunkReceivedEvent {
+    return makeStreamChunkEvent(seq, content, {
+        streamingMetadata: {
+            streamingMessageType: "final",
+            streamingSequenceNumber: seq,
+            streamEndReason: reason,
+        },
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.11.9",
       "license": "MIT",
       "dependencies": {
-        "@azure/communication-chat": "1.5.4",
-        "@azure/communication-common": "2.3.1",
-        "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.6",
+        "@azure/communication-chat": "1.6.0-beta.7",
+        "@azure/communication-common": "2.4.0",
+        "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.7",
         "@microsoft/ocsdk": "0.5.22-main.27b39ce",
         "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
@@ -29,6 +29,23 @@
         "typescript": "^5.4.2"
       }
     },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
+      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
@@ -42,63 +59,51 @@
       }
     },
     "node_modules/@azure/communication-chat": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@azure/communication-chat/-/communication-chat-1.5.4.tgz",
-      "integrity": "sha512-sC5IACFEGgvGbt6qzL3kocdMbhuWkldkE0HHsUfRPokPKiK4IfVCpn2syJcc9R8ts6hk0N5XvEY04KM2yayhJg==",
+      "version": "1.6.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@azure/communication-chat/-/communication-chat-1.6.0-beta.7.tgz",
+      "integrity": "sha512-L/v6JbQLKkt2pdkgFBM0BLXl7b0MfaWsg2sfNWLb9kUucu0UUcIz9DuMtCtBx/dc54OXRpYQLhTgcU4rwVQjcg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/communication-common": "^2.3.1",
-        "@azure/communication-signaling": "1.0.0-beta.29",
-        "@azure/core-auth": "^1.3.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/communication-common": "^2.3.2-beta.1",
+        "@azure/communication-signaling": "1.0.0-beta.33",
+        "@azure/core-auth": "^1.9.0",
         "@azure/core-client": "^1.9.2",
         "@azure/core-paging": "^1.1.1",
-        "@azure/core-rest-pipeline": "^1.16.3",
+        "@azure/core-rest-pipeline": "^1.18.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "events": "^3.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/communication-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.3.1.tgz",
-      "integrity": "sha512-6ZQt20iMZbyckQn4m1TDwiDv3Fzyt1h4lnQ1szBBns2x3VQY9XHbnskPtvUdwK/HT+c/1PoUwof3toy1AIznbQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.4.0.tgz",
+      "integrity": "sha512-wwn4AoOgTgoA9OZkO34SKBpQg7/kfcABnzbaYEbc+9bCkBtwwjgMEk6xM+XLEE/uuODZ8q8jidUoNcZHQyP5AQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.3.2",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
-        "events": "^3.0.0",
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "events": "^3.3.0",
         "jwt-decode": "^4.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/communication-common/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@azure/communication-signaling": {
-      "version": "1.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.29.tgz",
-      "integrity": "sha512-bTNxJaS000wjtbLlH/nju3Off9uSybYeRVLvx1Y5k3ajb1rqVGUcsIduSEz1JBf+dRQx9pHRDCAEAXs/hOvzpg==",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.33.tgz",
+      "integrity": "sha512-WdCmwcK3Y2BHV8MVksXg7o6damflHLT1bOKNL14SftFbnuBLgmUM9Uw/HnkPWkpwrhptYC8jeCMv2XKhWmA4YQ==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -260,7 +265,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1423,17 +1427,74 @@
       }
     },
     "node_modules/@microsoft/botframework-webchat-adapter-azure-communication-chat": {
-      "version": "0.0.1-beta-1",
-      "resolved": "https://registry.npmjs.org/@microsoft/botframework-webchat-adapter-azure-communication-chat/-/botframework-webchat-adapter-azure-communication-chat-0.0.1-beta-1.tgz",
-      "integrity": "sha512-vcpoztqbko6R2qlzlw8zCbtrNasSEKtu1JtrJguW5dG6Sddvxs+/3oC8oZMIOa5FrmZ+knVPfVJ+guUPu7NM/A==",
+      "version": "0.0.1-beta.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/botframework-webchat-adapter-azure-communication-chat/-/botframework-webchat-adapter-azure-communication-chat-0.0.1-beta.7.tgz",
+      "integrity": "sha512-Ew1EUgHagBGyCYVeFNOh36nBzP49eCMfglFQIjeuoG8w3BP6I9bRywQrnRCUlb3hfKhb8rxu65VU71Hu12ZSQQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/communication-chat": "^1.5.4",
-        "@azure/communication-common": "^2.3.1",
-        "core-js": "^3.6.5",
-        "http-status-codes": "^2.1.4",
+        "@azure/communication-chat": "1.6.0-beta.5",
+        "@azure/communication-common": "^2.4.0",
+        "core-js": "^3.43.0",
+        "event-target-shim": "^6.0.2",
+        "http-status-codes": "^2.3.0",
+        "p-defer": "^4.0.1",
         "redux": "^4.0.5",
-        "regenerator-runtime": "^0.13.7"
+        "regenerator-runtime": "^0.14.1"
+      }
+    },
+    "node_modules/@microsoft/botframework-webchat-adapter-azure-communication-chat/node_modules/@azure/communication-chat": {
+      "version": "1.6.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@azure/communication-chat/-/communication-chat-1.6.0-beta.5.tgz",
+      "integrity": "sha512-8R+s998qshBKnbSomlhnofljuwd/DNg8hhQvKQWOHqtCUvoWsyDGjCem5bcqq6wBXnVSBsg+GjOU4m05B/6PuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/communication-common": "^2.3.1",
+        "@azure/communication-signaling": "1.0.0-beta.32",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-rest-pipeline": "^1.18.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/logger": "^1.0.0",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@microsoft/botframework-webchat-adapter-azure-communication-chat/node_modules/@azure/communication-signaling": {
+      "version": "1.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.32.tgz",
+      "integrity": "sha512-ChhJXblgILpnuZd6cQlf1EDBNSTJ5cGUtvMQkxNjdlMa0qYKOXUN0Ugz6clw6jcrcMorXJlbda6tI7iGmgDPuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.16.3",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.0.0",
+        "@azure/logger": "^1.0.0",
+        "events": "^3.0.0",
+        "tslib": "^2.2.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@microsoft/botframework-webchat-adapter-azure-communication-chat/node_modules/@azure/communication-signaling/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@microsoft/ocsdk": {
@@ -1703,7 +1764,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1930,7 +1990,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2294,7 +2353,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2894,7 +2952,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3104,6 +3161,18 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/events": {
@@ -3921,7 +3990,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5017,6 +5085,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5362,9 +5442,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -5749,7 +5829,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5933,7 +6012,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6028,6 +6106,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.5.4",
-    "@azure/communication-common": "2.3.1",
-    "@microsoft/botframework-webchat-adapter-azure-communication-chat": "^0.0.1-beta.6",
+    "@azure/communication-chat": "1.6.0-beta.7",
+    "@azure/communication-common": "2.4.0",
+    "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.7",
     "@microsoft/ocsdk": "0.5.22-main.27b39ce",
     "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
     "@microsoft/omnichannel-ic3core": "^0.1.5"

--- a/playwright/integrations/streaming-disconnect-recovery.spec.ts
+++ b/playwright/integrations/streaming-disconnect-recovery.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E: ACS streaming — disconnect recovery
+ *
+ * BLOCKED: requires a streaming-capable test bot. See streaming-happy-path.spec.ts.
+ *
+ * Verifies the design spec §6.1 behavior: chunks resume after transient
+ * websocket disconnect with no synthetic stream-end fired.
+ */
+test.describe.skip('ACS streaming — disconnect recovery', () => {
+    test('chunks resume after transient websocket disconnect with no synthetic end', async ({ page, context }) => {
+        // 1. Initialize ChatSDK with V2 config and streaming bot.
+        // 2. Register onStreamingMessage handler that records every fire
+        //    plus its timestamp.
+        // 3. await chatSDK.startChat()
+        // 4. Trigger a streaming bot response.
+        // 5. After ~1 second of streaming, force websocket disconnect:
+        //      await context.setOffline(true);
+        //      await sleep(2000);
+        //      await context.setOffline(false);
+        // 6. Wait for the rest of the stream to complete.
+        // 7. Assert: handler fired chunks both before and after the disconnect window.
+        // 8. Assert: NO chunk with streamEndReason that's not one of
+        //    "completed" | "expired" | "canceled" — verifying the SDK does NOT
+        //    synthesize a "connectionLost" reason.
+        // 9. Assert: stream eventually receives a real "final" if the bot
+        //    completed during reconnect.
+        expect(true).toBe(true);
+    });
+});

--- a/playwright/integrations/streaming-happy-path.spec.ts
+++ b/playwright/integrations/streaming-happy-path.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E: ACS streaming — happy path
+ *
+ * BLOCKED: requires a streaming-capable test bot in the test environment.
+ * Provision a bot that uses ACS chat's send-streaming-message API
+ * (see @azure/communication-chat 1.6.0+) before un-skipping.
+ *
+ * When un-skipping:
+ * 1. Replace test.skip with test.
+ * 2. Wire fetchOmnichannelConfig with a streaming-capable widget id.
+ * 3. Implement the steps inside page.evaluate following the existing
+ *    pattern at playwright/integrations/authenticated-chat-with-typing.spec.ts.
+ */
+test.describe.skip('ACS streaming — happy path', () => {
+    test('receives full lifecycle (start + chunks + final) for a streaming bot response', async ({ page }) => {
+        // 1. Initialize ChatSDK with V2 config and streaming-capable bot endpoint.
+        // 2. await chatSDK.startChat()
+        // 3. Register chatSDK.onStreamingMessage handler that records every fire
+        //    (push to a window-scoped array so the assertion can read it).
+        // 4. Send a message that triggers the bot's streaming response.
+        // 5. await sleep(streamDuration) until "final" is observed.
+        // 6. Assert: handler fired with streamingMessageType "start",
+        //    N "streaming"/"informative", and exactly one "final" with
+        //    streamEndReason "completed".
+        // 7. Assert: assembled content from final chunk equals what
+        //    getMessages() returns after the stream completes.
+        expect(true).toBe(true);
+    });
+});

--- a/playwright/integrations/streaming-no-handler.spec.ts
+++ b/playwright/integrations/streaming-no-handler.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E: ACS streaming — lazy opt-in verification
+ *
+ * BLOCKED: requires a streaming-capable test bot. See streaming-happy-path.spec.ts.
+ *
+ * Verifies that the SDK does NOT subscribe to ACS streaming events when no
+ * onStreamingMessage handler is registered. This is the runtime confirmation
+ * of decision #6 from the design spec.
+ */
+test.describe.skip('ACS streaming — lazy opt-in', () => {
+    test('does NOT subscribe to ACS streaming events when no handler is registered', async ({ page }) => {
+        // 1. Initialize ChatSDK with V2 config and streaming-capable bot.
+        // 2. Spy on chatClient.on to record subscribed event names BEFORE
+        //    calling startChat (intercept via prototype patching or wrap
+        //    the SDK's ACSClient via test seam).
+        // 3. await chatSDK.startChat()
+        // 4. Do NOT call onStreamingMessage.
+        // 5. Trigger the bot's streaming response.
+        // 6. Wait for the bot to complete (it will via getMessages backfill).
+        // 7. Assert: chatClient.on was NEVER called with "streamingChatMessageStarted"
+        //    or "streamingChatMessageChunkReceived".
+        // 8. Assert: onNewMessage fires once with the final assembled content
+        //    (after the stream completes server-side).
+        expect(true).toBe(true);
+    });
+});

--- a/playwright/integrations/streaming-with-adapter.spec.ts
+++ b/playwright/integrations/streaming-with-adapter.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E: ACS streaming — dual-subscription with adapter
+ *
+ * BLOCKED: requires a streaming-capable test bot. See streaming-happy-path.spec.ts.
+ *
+ * Verifies the design spec decision #4: SDK onStreamingMessage and the
+ * adapter's WebChat activities both fire independently for the same chunks
+ * (pragmatic dual-subscription on shared ChatClient).
+ */
+test.describe.skip('ACS streaming — dual subscription with adapter', () => {
+    test('SDK onStreamingMessage and adapter activities both fire for same chunks', async ({ page }) => {
+        // 1. Initialize ChatSDK with V2 config and adapter (createChatAdapter).
+        // 2. Register both:
+        //    a. chatSDK.onStreamingMessage SDK-side handler that records each fire.
+        //    b. WebChat activity listener on the adapter that records each activity.
+        // 3. await chatSDK.startChat()
+        // 4. Trigger streaming bot response.
+        // 5. Wait for the stream to complete.
+        // 6. Assert: SDK handler received chunks for the bot's message id.
+        // 7. Assert: WebChat adapter produced activities for the same message id
+        //    with channelData.streamType set to lifecycle phase
+        //    (matches SDK's streamingMessageType for each chunk).
+        // 8. Assert: total chunk counts on both paths match.
+        expect(true).toBe(true);
+    });
+});

--- a/samples/streaming-react/.gitignore
+++ b/samples/streaming-react/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.log

--- a/samples/streaming-react/README.md
+++ b/samples/streaming-react/README.md
@@ -1,0 +1,163 @@
+# Streaming React Sample
+
+A React + Webpack 5 sample app exercising `onStreamingMessage` and `onNewMessage` against a real Microsoft Contact Center tenant.
+
+**Multi-customer demo mode:** customers paste their widget snippet from the OC admin app, the app extracts the org URL / org ID / widget ID automatically, and connects to their tenant. Anonymous chat only.
+
+## What you see when you run it
+
+### Setup screen (initial)
+
+- **Step 1 · Paste your widget snippet:** textarea where customers paste the `<script>` tag from their OC admin app.
+- **Step 2 · Verify extracted values:** live preview of the parsed `widgetId` / `orgId` / `orgUrl` with checkmarks. Inline error if the snippet is malformed or missing fields.
+- **Step 3 · Allow this origin in your widget config:** prominent guidance + copy-to-clipboard button for the current page's origin. Customers must add this to their widget's allowed-domains list before the chat can connect.
+- **Remember in this browser** checkbox for localStorage persistence.
+- **Clear Saved Customer** button (visible if a saved config exists).
+
+### Chat screen (after Start Chat)
+
+Two-pane layout:
+
+- **Top:** Chat bubble UI. User messages right-aligned blue, bot/agent left-aligned gray. Streaming messages render progressively — bubble appears on `start`, content updates with each `streaming` chunk, locks on `final`.
+- **Bottom:** Live event log. Color-coded chips: green = `onNewMessage`, blue = `onStreamingMessage`, gray = `sendMessage`, purple = `lifecycle`.
+
+Header controls: **Switch Customer** (back to setup), **Clear Saved Customer** (wipe localStorage), **Start/End Chat**.
+
+### CORS error handling
+
+If the tenant rejects requests because our origin isn't allowlisted, the error banner shows a CORS-specific message with the origin to add — instead of a cryptic "Failed to fetch" error.
+
+## Why this layout for testing streaming
+
+Against a streaming bot, a successful test produces this event sequence:
+
+```
+onStreamingMessage:start    msg-abc123
+onStreamingMessage:streaming #1 msg-abc123  "Let m"
+onStreamingMessage:streaming #2 msg-abc123  "Let me che"
+onStreamingMessage:streaming #3 msg-abc123  "Let me check that for"
+... (more chunks)
+onStreamingMessage:final    msg-abc123  (completed)
+onNewMessage                msg-abc123  "Let me check that for you. Currently..."
+```
+
+Two empirical confirmations:
+
+1. **Risk 1 mitigation works** — `onNewMessage` fires exactly once at the end with the assembled content, so consumers using only `onNewMessage` continue to receive the message.
+2. **No dual-fire** — `onNewMessage` should NOT appear during the streaming chunks (only at the end). If it does, ACS is firing both event types and the SDK needs dedup.
+
+For non-streaming bots, the event log shows `onNewMessage` only — confirms backwards compatibility.
+
+## Local development
+
+### 1. Build the SDK
+
+The sample uses `"file:../.."` to install the local SDK build, so build it first:
+
+```bash
+cd ../..   # back to omnichannel-chat-sdk root
+npm install
+npm run build:tsc
+```
+
+### 2. Install sample dependencies
+
+```bash
+cd samples/streaming-react
+npm install
+```
+
+### 3. Run the dev server
+
+```bash
+npm start
+```
+
+Opens on **http://localhost:3000**. The setup screen prompts for a widget snippet — paste yours and follow the on-screen steps.
+
+### 4. Build for production
+
+```bash
+npm run build
+```
+
+Output goes to `samples/streaming-react/dist/`. This is what you'd deploy to Azure Static Web Apps.
+
+## Deploying to Azure Static Web Apps
+
+The sample is configured to deploy as a static SPA. Follow these steps to get a public URL.
+
+### 1. Create the Static Web App resource
+
+In the Azure portal:
+
+1. **Create a resource → Static Web App.**
+2. Pick a subscription, resource group, and a name (e.g., `oc-streaming-demo`).
+3. Plan: **Free** (sufficient for demo traffic).
+4. Region: any.
+5. **Deployment source:** GitHub.
+6. Sign in to GitHub and pick the `microsoft/omnichannel-chat-sdk` repo (or your fork).
+7. Branch: `poc/acs-streaming-update` (or whichever branch contains this sample).
+8. **Build presets:** Custom.
+9. **App location:** `samples/streaming-react`
+10. **Output location:** `dist`
+11. Skip the API location.
+12. Click **Review + create**.
+
+Azure will:
+- Provision the SWA resource.
+- Auto-create a GitHub Actions workflow at `.github/workflows/azure-static-web-apps-<random-suffix>.yml`.
+- Inject a deployment token as a GitHub secret.
+- Run the first deploy.
+
+### 2. Verify the workflow runs
+
+Once Azure auto-creates the workflow file, push to the branch (or merge a PR) and watch the GitHub Actions run. After it succeeds, your SWA URL (`https://<random-name>.azurestaticapps.net`) serves the app.
+
+### 3. (Optional) Configure a custom domain
+
+In the SWA resource → Custom domains, add your domain. Update the DNS records as instructed by the portal.
+
+### 4. Verify `staticwebapp.config.json` is being picked up
+
+The repo includes `samples/streaming-react/staticwebapp.config.json` which configures SPA fallback routing (any path falls back to `index.html`) and disables aggressive caching. This file is automatically detected at deploy time when it's at the SWA's app root.
+
+## Customer demo flow
+
+When you run the demo for a customer:
+
+1. Send them the SWA URL (e.g., `https://oc-streaming-demo.azurestaticapps.net`).
+2. They paste their widget snippet into Step 1.
+3. They verify extracted values in Step 2.
+4. They add our origin to their widget's allowed domains in their OC admin app (the URL Step 3 displays). **Recommend doing this on a *test* widget config, not production.** The exact navigation is:
+   - Customer Service admin center
+   - Workstreams → [their workstream] → Chat widget
+   - Behaviors → "Allow this widget on the following domains"
+5. They come back to the demo and click **Start Chat**.
+6. They send messages, watch the event log + bubble UI on the right.
+
+If they're testing a streaming bot, the event log empirically shows the streaming chunks + the post-`final` `onNewMessage` fire-through (Risk 1 mitigation working).
+
+## Architecture notes
+
+- **Runtime config, not build-time:** the original sample read tenant credentials from `process.env` at build time. This version reads them from a textarea at runtime — required for multi-customer hosting where you can't bake credentials into the bundle.
+- **Single bubble per message id:** `bubbles` is a `Map<string, BubbleState>`. Both `onNewMessage` and `onStreamingMessage` upsert the same map keyed by message id. This dedups the visible UI even if both events fire for the same message (they can, per the Risk 1 mitigation: streaming chunks fire onStreamingMessage, then the final fires onNewMessage too).
+- **Append-only event log:** every SDK event becomes a log entry, never deleted. Reflects the raw protocol behavior.
+- **No external state library:** plain React `useState` with `Map`. For a sample, simplicity beats Redux/Zustand.
+- **Webpack 5 + Node polyfills:** `node-polyfill-webpack-plugin` provides browser shims for `crypto`/`stream`/`buffer` that `@azure/communication-chat` needs at runtime. Without it, the SDK fails to initialize in the browser.
+- **localStorage only:** no server-side state. One config persisted per browser. Use the **Clear Saved Customer** button to wipe.
+- **Anonymous chat only:** for demos. Authenticated-chat tenants need a separate auth flow (token endpoint, etc.) which is out of scope for this sample. If you need auth, fork the sample and add a `chatSDKConfig.getAuthToken` callback.
+
+## Common issues
+
+**"Could not parse snippet" on Step 2:** Make sure you copied the entire `<script>` tag including the `data-app-id`, `data-org-id`, and `data-org-url` attributes. The OC admin app sometimes wraps with extra HTML — paste the raw `<script>` tag.
+
+**CORS error on Start Chat:** Your tenant's widget config doesn't allowlist this app's origin. The error banner shows the exact origin to add. Add it in the OC admin app under your widget's "Allow this widget on the following domains" setting.
+
+**`global is not defined` runtime error:** Polyfill plugin not loading. Verify `node-polyfill-webpack-plugin` is in `node_modules` and listed in `webpack.config.js` plugins.
+
+**Two `onNewMessage` events per streaming response:** The SDK currently assumes ACS does not fire `chatMessageReceived` alongside streaming events. If you observe this dual-fire happening for the same message id, document the timing and message ids, then update `ACSConversation.registerOnStreamingMessage` to track fire-through-ed message ids and skip duplicate `onNewMessage` invocations.
+
+**`onNewMessage` doesn't fire at all on a streaming response:** The backwards-compat fire-through isn't working. Verify the SDK build is up to date (`npm run build:tsc` in the SDK root, then re-run `npm install` in `samples/streaming-react/` to refresh the local link).
+
+**Bubble shows but never updates:** SDK initialized but events aren't firing. Check browser DevTools console for ACS connection errors. Most likely a credentials, network, or CORS issue rather than an SDK bug.

--- a/samples/streaming-react/package-lock.json
+++ b/samples/streaming-react/package-lock.json
@@ -1,0 +1,6512 @@
+{
+    "name": "streaming-react-sample",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "streaming-react-sample",
+            "version": "0.0.0",
+            "dependencies": {
+                "@microsoft/omnichannel-chat-sdk": "file:../..",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            },
+            "devDependencies": {
+                "@types/react": "^18.2.0",
+                "@types/react-dom": "^18.2.0",
+                "html-webpack-plugin": "^5.6.0",
+                "node-polyfill-webpack-plugin": "^4.0.0",
+                "ts-loader": "^9.5.1",
+                "typescript": "^5.4.2",
+                "webpack": "^5.95.0",
+                "webpack-cli": "^5.1.4",
+                "webpack-dev-server": "^5.1.0"
+            }
+        },
+        "../..": {
+            "name": "@microsoft/omnichannel-chat-sdk",
+            "version": "1.11.9",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/communication-chat": "1.6.0-beta.7",
+                "@azure/communication-common": "2.4.0",
+                "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.7",
+                "@microsoft/ocsdk": "0.5.22-main.27b39ce",
+                "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
+                "@microsoft/omnichannel-ic3core": "^0.1.5"
+            },
+            "devDependencies": {
+                "@types/core-js": "^2.5.5",
+                "@types/jest": "^29.1.2",
+                "@typescript-eslint/eslint-plugin": "^8.18.2",
+                "@typescript-eslint/parser": "^8.18.2",
+                "eslint": "^9.26.0",
+                "globals": "^15.14.0",
+                "jest": "^29.7.0",
+                "jest-environment-jsdom": "^29.7.0",
+                "ts-jest": "^29.2.5",
+                "typescript": "^5.4.2"
+            }
+        },
+        "node_modules/@discoveryjs/json-ext": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+            "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/buffers": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/codegen": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-core": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
+            "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.57.2",
+                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-fsa": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
+            "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.57.2",
+                "@jsonjoy.com/fs-node-builtins": "4.57.2",
+                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
+            "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.57.2",
+                "@jsonjoy.com/fs-node-builtins": "4.57.2",
+                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "@jsonjoy.com/fs-print": "4.57.2",
+                "@jsonjoy.com/fs-snapshot": "4.57.2",
+                "glob-to-regex.js": "^1.0.0",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-builtins": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
+            "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
+            "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-fsa": "4.57.2",
+                "@jsonjoy.com/fs-node-builtins": "4.57.2",
+                "@jsonjoy.com/fs-node-utils": "4.57.2"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-utils": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
+            "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.57.2"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-print": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
+            "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
+            "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^17.65.0",
+                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "@jsonjoy.com/json-pack": "^17.65.0",
+                "@jsonjoy.com/util": "^17.65.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "17.67.0",
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0",
+                "@jsonjoy.com/json-pointer": "17.67.0",
+                "@jsonjoy.com/util": "17.67.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/util": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.2.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
+                "@jsonjoy.com/util": "^1.9.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pointer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/util": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/util": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@leichtgewicht/ip-codec": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+            "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@microsoft/omnichannel-chat-sdk": {
+            "resolved": "../..",
+            "link": true
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@peculiar/asn1-cms": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+            "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.1",
+                "@peculiar/asn1-x509-attr": "^2.6.1",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-csr": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+            "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.1",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-ecc": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+            "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.1",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pfx": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+            "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.1",
+                "@peculiar/asn1-pkcs8": "^2.6.1",
+                "@peculiar/asn1-rsa": "^2.6.1",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs8": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+            "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.1",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs9": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+            "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.1",
+                "@peculiar/asn1-pfx": "^2.6.1",
+                "@peculiar/asn1-pkcs8": "^2.6.1",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.1",
+                "@peculiar/asn1-x509-attr": "^2.6.1",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-rsa": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+            "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.1",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+            "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asn1js": "^3.0.6",
+                "pvtsutils": "^1.3.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+            "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.6.0",
+                "asn1js": "^3.0.6",
+                "pvtsutils": "^1.3.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+            "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.1",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/x509": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+            "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.0",
+                "@peculiar/asn1-csr": "^2.6.0",
+                "@peculiar/asn1-ecc": "^2.6.0",
+                "@peculiar/asn1-pkcs9": "^2.6.0",
+                "@peculiar/asn1-rsa": "^2.6.0",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.0",
+                "pvtsutils": "^1.3.6",
+                "reflect-metadata": "^0.2.2",
+                "tslib": "^2.8.1",
+                "tsyringe": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.6",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/bonjour": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
+            "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect": {
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect-history-api-fallback": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+            "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express-serve-static-core": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/eslint": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/express": {
+            "version": "4.17.25",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+            "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
+                "@types/serve-static": "^1"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "4.19.8",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+            "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/@types/html-minifier-terser": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+            "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/http-proxy": {
+            "version": "1.17.17",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+            "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/mime": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.19.0"
+            }
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/qs": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.3.28",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+            "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
+            }
+        },
+        "node_modules/@types/retry": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/serve-index": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
+            "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+            "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "<1"
+            }
+        },
+        "node_modules/@types/serve-static/node_modules/@types/send": {
+            "version": "0.17.6",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/sockjs": {
+            "version": "0.3.36",
+            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
+            "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@webassemblyjs/ast": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+            "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/helper-numbers": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+            "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-api-error": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+            "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-buffer": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+            "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+            "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+            "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/helper-wasm-section": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+            "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/wasm-gen": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/ieee754": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+            "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "node_modules/@webassemblyjs/leb128": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+            "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/utf8": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+            "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@webassemblyjs/wasm-edit": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+            "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/helper-wasm-section": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-opt": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1",
+                "@webassemblyjs/wast-printer": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-gen": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+            "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-opt": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+            "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-parser": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+            "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/wast-printer": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+            "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webpack-cli/configtest": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+            "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.15.0"
+            },
+            "peerDependencies": {
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
+            }
+        },
+        "node_modules/@webpack-cli/info": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+            "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.15.0"
+            },
+            "peerDependencies": {
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
+            }
+        },
+        "node_modules/@webpack-cli/serve": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+            "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.15.0"
+            },
+            "peerDependencies": {
+                "webpack": "5.x.x",
+                "webpack-cli": "5.x.x"
+            },
+            "peerDependenciesMeta": {
+                "webpack-dev-server": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/accepts": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/ansi-html-community": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+            "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
+            "dev": true,
+            "engines": [
+                "node >= 0.8.0"
+            ],
+            "license": "Apache-2.0",
+            "bin": {
+                "ansi-html": "bin/ansi-html"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/asn1.js/node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/assert": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+            "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "is-nan": "^1.3.2",
+                "object-is": "^1.1.5",
+                "object.assign": "^4.1.4",
+                "util": "^0.12.5"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.24",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+            "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bn.js": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+            "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/body-parser": {
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "~1.2.0",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.4.24",
+                "on-finished": "~2.4.1",
+                "qs": "~6.15.1",
+                "raw-body": "~2.5.3",
+                "type-is": "~1.6.18",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/bonjour-service": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+            "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "multicast-dns": "^7.2.5"
+            }
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browser-resolve": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+            "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve": "^1.17.0"
+            }
+        },
+        "node_modules/browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+            }
+        },
+        "node_modules/browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/browserify-rsa": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+            "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^5.2.1",
+                "randombytes": "^2.1.0",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/browserify-sign": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
+            "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "bn.js": "^5.2.2",
+                "browserify-rsa": "^4.1.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.6.1",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.9",
+                "readable-stream": "^2.3.8",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pako": "~1.0.5"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/camel-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+            "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pascal-case": "^3.1.2",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001791",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+            "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chrome-trace-event": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+            "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "node_modules/cipher-base": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+            "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/clean-css": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "source-map": "~0.6.0"
+            },
+            "engines": {
+                "node": ">= 10.0"
+            }
+        },
+        "node_modules/clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
+                "debug": "2.6.9",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/connect-history-api-fallback": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+            "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/console-browserify": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+            "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+            "dev": true
+        },
+        "node_modules/constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/content-disposition": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+            "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/create-ecdh": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.5.3"
+            }
+        },
+        "node_modules/create-ecdh/node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "node_modules/create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/crypto-browserify": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+            "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserify-cipher": "^1.0.1",
+                "browserify-sign": "^4.2.3",
+                "create-ecdh": "^4.0.4",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "diffie-hellman": "^5.0.3",
+                "hash-base": "~3.0.4",
+                "inherits": "^2.0.4",
+                "pbkdf2": "^3.1.2",
+                "public-encrypt": "^4.0.3",
+                "randombytes": "^2.1.0",
+                "randomfill": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/des.js": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+            "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/destroy": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/detect-node": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+            }
+        },
+        "node_modules/diffie-hellman/node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/dns-packet": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+            "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@leichtgewicht/ip-codec": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/dom-converter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+            "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "utila": "~0.4"
+            }
+        },
+        "node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domain-browser": {
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
+            "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://bevry.me/fund"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.345",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
+            "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/elliptic": {
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/elliptic/node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+            "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/envinfo": {
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+            "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "envinfo": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esrecurse/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "node_modules/express": {
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.8",
+                "array-flatten": "1.1.1",
+                "body-parser": "~1.20.3",
+                "content-disposition": "~0.5.4",
+                "content-type": "~1.0.4",
+                "cookie": "~0.7.1",
+                "cookie-signature": "~1.0.6",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "~1.3.1",
+                "fresh": "~0.5.2",
+                "http-errors": "~2.0.0",
+                "merge-descriptors": "1.0.3",
+                "methods": "~1.1.2",
+                "on-finished": "~2.4.1",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "~0.1.12",
+                "proxy-addr": "~2.0.7",
+                "qs": "~6.14.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.2.1",
+                "send": "~0.19.0",
+                "serve-static": "~1.16.2",
+                "setprototypeof": "1.2.0",
+                "statuses": "~2.0.1",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/qs": {
+            "version": "6.14.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
+        },
+        "node_modules/faye-websocket": {
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+            "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "websocket-driver": ">=0.5.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/finalhandler": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+            "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.4.1",
+                "parseurl": "~1.3.3",
+                "statuses": "~2.0.2",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/generator-function": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/glob-to-regex.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/handle-thing": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+            "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hash-base": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+            "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "node_modules/hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "node_modules/hpack.js/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hpack.js/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/hpack.js/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hpack.js/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/html-minifier-terser": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+            "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camel-case": "^4.1.2",
+                "clean-css": "^5.2.2",
+                "commander": "^8.3.0",
+                "he": "^1.2.0",
+                "param-case": "^3.0.4",
+                "relateurl": "^0.2.7",
+                "terser": "^5.10.0"
+            },
+            "bin": {
+                "html-minifier-terser": "cli.js"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/html-webpack-plugin": {
+            "version": "5.6.7",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+            "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/html-minifier-terser": "^6.0.0",
+                "html-minifier-terser": "^6.0.2",
+                "lodash": "^4.17.21",
+                "pretty-error": "^4.0.0",
+                "tapable": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/html-webpack-plugin"
+            },
+            "peerDependencies": {
+                "@rspack/core": "0.x || 1.x",
+                "webpack": "^5.20.0"
+            },
+            "peerDependenciesMeta": {
+                "@rspack/core": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/htmlparser2": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+            "dev": true,
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "domutils": "^2.5.2",
+                "entities": "^2.0.0"
+            }
+        },
+        "node_modules/http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/http-parser-js": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+            "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/http-proxy": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/http-proxy-middleware": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-proxy": "^1.17.8",
+                "http-proxy": "^1.18.1",
+                "is-glob": "^4.0.1",
+                "is-plain-obj": "^3.0.0",
+                "micromatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "@types/express": "^4.17.13"
+            },
+            "peerDependenciesMeta": {
+                "@types/express": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/import-local": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+            "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
+            },
+            "bin": {
+                "import-local-fixture": "fixtures/cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-local/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/import-local/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/import-local/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-local/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/import-local/node_modules/pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/interpret": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+            "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/is-arguments": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4",
+                "generator-function": "^2.0.0",
+                "get-proto": "^1.0.1",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-nan": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-network-error": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+            "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+            "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "isobject": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isomorphic-timers-promises": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
+            "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/launch-editor": {
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
+            "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.1.1",
+                "shell-quote": "^1.8.3"
+            }
+        },
+        "node_modules/loader-runner": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/memfs": {
+            "version": "4.57.2",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+            "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.57.2",
+                "@jsonjoy.com/fs-fsa": "4.57.2",
+                "@jsonjoy.com/fs-node": "4.57.2",
+                "@jsonjoy.com/fs-node-builtins": "4.57.2",
+                "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+                "@jsonjoy.com/fs-node-utils": "4.57.2",
+                "@jsonjoy.com/fs-print": "4.57.2",
+                "@jsonjoy.com/fs-snapshot": "4.57.2",
+                "@jsonjoy.com/json-pack": "^1.11.0",
+                "@jsonjoy.com/util": "^1.9.0",
+                "glob-to-regex.js": "^1.0.1",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.0.3",
+                "tslib": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+            },
+            "bin": {
+                "miller-rabin": "bin/miller-rabin"
+            }
+        },
+        "node_modules/miller-rabin/node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/multicast-dns": {
+            "version": "7.2.5",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+            "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dns-packet": "^5.2.2",
+                "thunky": "^1.0.2"
+            },
+            "bin": {
+                "multicast-dns": "cli.js"
+            }
+        },
+        "node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/node-polyfill-webpack-plugin": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-4.1.0.tgz",
+            "integrity": "sha512-b4ei444EKkOagG/yFqojrD3QTYM5IOU1f8tn9o6uwrG4qL+brI7oVhjPVd0ZL2xy+Z6CP5bu9w8XTvlWgiXHcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-stdlib-browser": "^1.3.0",
+                "type-fest": "^4.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "webpack": ">=5"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.38",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+            "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-stdlib-browser": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
+            "integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert": "^2.0.0",
+                "browser-resolve": "^2.0.0",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^5.7.1",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "create-require": "^1.1.1",
+                "crypto-browserify": "^3.12.1",
+                "domain-browser": "4.22.0",
+                "events": "^3.0.0",
+                "https-browserify": "^1.0.0",
+                "isomorphic-timers-promises": "^1.0.1",
+                "os-browserify": "^0.3.0",
+                "path-browserify": "^1.0.1",
+                "pkg-dir": "^5.0.0",
+                "process": "^0.11.10",
+                "punycode": "^1.4.1",
+                "querystring-es3": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "stream-browserify": "^3.0.0",
+                "stream-http": "^3.2.0",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
+                "tty-browserify": "0.0.1",
+                "url": "^0.11.4",
+                "util": "^0.12.4",
+                "vm-browserify": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-is": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0",
+                "has-symbols": "^1.1.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/obuf": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/open": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-retry": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+            "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
+                "retry": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true,
+            "license": "(MIT AND Zlib)"
+        },
+        "node_modules/param-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+            "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/parse-asn1": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+            "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "asn1.js": "^4.10.1",
+                "browserify-aes": "^1.2.0",
+                "evp_bytestokey": "^1.0.3",
+                "pbkdf2": "^3.1.5",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/pascal-case": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/path-to-regexp": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pbkdf2": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+            "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "ripemd160": "^2.0.3",
+                "safe-buffer": "^5.2.1",
+                "sha.js": "^2.4.12",
+                "to-buffer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pkg-dir": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+            "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/pretty-error": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+            "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash": "^4.17.20",
+                "renderkid": "^3.0.0"
+            }
+        },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/public-encrypt/node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvutils": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+            "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+            "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.4.24",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/rechoir": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve": "^1.20.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/relateurl": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+            "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/renderkid": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+            "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-select": "^4.1.3",
+                "dom-converter": "^0.2.0",
+                "htmlparser2": "^6.1.0",
+                "lodash": "^4.17.21",
+                "strip-ansi": "^6.0.1"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-cwd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/ripemd160": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+            "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^3.1.2",
+                "inherits": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/ripemd160/node_modules/hash-base": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+            "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^2.3.8",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/ripemd160/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ripemd160/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ripemd160/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-regex": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/selfsigned": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+            "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/x509": "^1.14.2",
+                "pkijs": "^3.3.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/send": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+            "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "~0.5.2",
+                "http-errors": "~2.0.1",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "~2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "~2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/send/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/serve-index": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
+            "integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.8",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.8.0",
+                "mime-types": "~2.1.35",
+                "parseurl": "~1.3.3"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-index/node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-index/node_modules/http-errors": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+            "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-index/node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+            "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "~0.19.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/sha.js": {
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+            "dev": true,
+            "license": "(MIT AND BSD-3-Clause)",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
+            },
+            "bin": {
+                "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "kind-of": "^6.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/sockjs": {
+            "version": "0.3.24",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
+            "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "faye-websocket": "^0.11.3",
+                "uuid": "^8.3.2",
+                "websocket-driver": "^0.7.4"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/spdy": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+            "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
+                "http-deceiver": "^1.2.7",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/spdy-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            }
+        },
+        "node_modules/spdy-transport/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/spdy-transport/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/spdy/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/spdy/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/stream-browserify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+            "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "~2.0.4",
+                "readable-stream": "^3.5.0"
+            }
+        },
+        "node_modules/stream-http": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+            "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "xtend": "^4.0.2"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/terser": {
+            "version": "5.46.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+            "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.15.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/terser-webpack-plugin": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+            "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^4.3.0",
+                "terser": "^5.31.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/thingies": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+            "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
+            }
+        },
+        "node_modules/thunky": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/timers-browserify": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+            "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "setimmediate": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/tree-dump": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/ts-loader": {
+            "version": "9.5.7",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
+            "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "enhanced-resolve": "^5.0.0",
+                "micromatch": "^4.0.0",
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "typescript": "*",
+                "webpack": "^5.0.0"
+            }
+        },
+        "node_modules/ts-loader/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/tsyringe": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+            "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/tsyringe/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/tty-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/url": {
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+            "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^1.4.1",
+                "qs": "^6.12.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/util": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/utila": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+            "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/vm-browserify": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+            "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/watchpack": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/webpack": {
+            "version": "5.106.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+            "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint-scope": "^3.7.7",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
+                "@webassemblyjs/ast": "^1.14.1",
+                "@webassemblyjs/wasm-edit": "^1.14.1",
+                "@webassemblyjs/wasm-parser": "^1.14.1",
+                "acorn": "^8.16.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.28.1",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.20.0",
+                "es-module-lexer": "^2.0.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.11",
+                "loader-runner": "^4.3.1",
+                "mime-db": "^1.54.0",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "terser-webpack-plugin": "^5.3.17",
+                "watchpack": "^2.5.1",
+                "webpack-sources": "^3.3.4"
+            },
+            "bin": {
+                "webpack": "bin/webpack.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-cli": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+            "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@discoveryjs/json-ext": "^0.5.0",
+                "@webpack-cli/configtest": "^2.1.1",
+                "@webpack-cli/info": "^2.0.2",
+                "@webpack-cli/serve": "^2.0.5",
+                "colorette": "^2.0.14",
+                "commander": "^10.0.1",
+                "cross-spawn": "^7.0.3",
+                "envinfo": "^7.7.3",
+                "fastest-levenshtein": "^1.0.12",
+                "import-local": "^3.0.2",
+                "interpret": "^3.1.1",
+                "rechoir": "^0.8.0",
+                "webpack-merge": "^5.7.3"
+            },
+            "bin": {
+                "webpack-cli": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=14.15.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "5.x.x"
+            },
+            "peerDependenciesMeta": {
+                "@webpack-cli/generators": {
+                    "optional": true
+                },
+                "webpack-bundle-analyzer": {
+                    "optional": true
+                },
+                "webpack-dev-server": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-cli/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/webpack-dev-middleware": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.10",
+                "memfs": "^4.43.1",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "schema-utils": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/webpack-dev-server": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
+            "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.25",
+                "@types/express-serve-static-core": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
+                "ansi-html-community": "^0.0.8",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
+                "colorette": "^2.0.10",
+                "compression": "^1.8.1",
+                "connect-history-api-fallback": "^2.0.0",
+                "express": "^4.22.1",
+                "graceful-fs": "^4.2.6",
+                "http-proxy-middleware": "^2.0.9",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.6.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^5.5.0",
+                "serve-index": "^1.9.1",
+                "sockjs": "^0.3.24",
+                "spdy": "^4.0.2",
+                "webpack-dev-middleware": "^7.4.2",
+                "ws": "^8.18.0"
+            },
+            "bin": {
+                "webpack-dev-server": "bin/webpack-dev-server.js"
+            },
+            "engines": {
+                "node": ">= 18.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                },
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/webpack-sources": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
+            "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/websocket-driver": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "http-parser-js": ">=0.5.1",
+                "safe-buffer": ">=5.1.0",
+                "websocket-extensions": ">=0.1.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/websocket-extensions": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/wildcard": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+            "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        }
+    }
+}

--- a/samples/streaming-react/package.json
+++ b/samples/streaming-react/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "streaming-react-sample",
+    "version": "0.0.0",
+    "private": true,
+    "description": "React sample app exercising onStreamingMessage and onNewMessage against a real Microsoft Contact Center tenant",
+    "scripts": {
+        "start": "webpack serve --mode development",
+        "build": "webpack --mode production",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@microsoft/omnichannel-chat-sdk": "file:../..",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "devDependencies": {
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "html-webpack-plugin": "^5.6.0",
+        "node-polyfill-webpack-plugin": "^4.0.0",
+        "ts-loader": "^9.5.1",
+        "typescript": "^5.4.2",
+        "webpack": "^5.95.0",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.1.0"
+    }
+}

--- a/samples/streaming-react/public/index.html
+++ b/samples/streaming-react/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OC Chat SDK — Streaming Sample</title>
+    <style>
+        body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+        * { box-sizing: border-box; }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>

--- a/samples/streaming-react/src/App.tsx
+++ b/samples/streaming-react/src/App.tsx
@@ -1,0 +1,849 @@
+import React, { useState, useRef, useCallback, useMemo } from 'react';
+import {
+    OmnichannelChatSDK,
+    OmnichannelStreamingMessage,
+} from '@microsoft/omnichannel-chat-sdk';
+
+import { parseWidgetSnippet, WidgetConfig } from './parseWidgetSnippet';
+import { loadSavedConfig, saveConfig, clearSavedConfig, StoredConfig } from './storage';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface BubbleState {
+    id: string;
+    sender: 'user' | 'agent' | 'bot' | 'system';
+    senderDisplayName?: string;
+    content: string;
+    isStreaming: boolean;
+    streamPhase?: string;
+    streamEndReason?: string;
+    timestamp: Date;
+}
+
+interface EventLogEntry {
+    id: string;
+    source: 'onNewMessage' | 'onStreamingMessage' | 'sendMessage' | 'lifecycle';
+    phase?: string;
+    sequenceNumber?: number;
+    messageId?: string;
+    contentPreview?: string;
+    timestamp: Date;
+}
+
+type ChatError =
+    | { kind: 'cors'; message: string; originToAdd: string }
+    | { kind: 'other'; message: string };
+
+// ============================================================================
+// Top-level App — orchestrates setup vs chat mode
+// ============================================================================
+
+const App: React.FC = () => {
+    const [savedConfig, setSavedConfig] = useState<StoredConfig | null>(() => loadSavedConfig());
+    const [activeConfig, setActiveConfig] = useState<WidgetConfig | null>(null);
+
+    if (!activeConfig) {
+        return (
+            <SetupScreen
+                savedConfig={savedConfig}
+                onStart={(config, remember) => {
+                    if (remember) {
+                        saveConfig(config);
+                        setSavedConfig({ ...config, savedAt: new Date().toISOString() });
+                    }
+                    setActiveConfig(config);
+                }}
+                onClearStorage={() => {
+                    clearSavedConfig();
+                    setSavedConfig(null);
+                }}
+            />
+        );
+    }
+
+    return (
+        <ChatScreen
+            config={activeConfig}
+            onSwitchCustomer={() => setActiveConfig(null)}
+            onClearStorage={() => {
+                clearSavedConfig();
+                setSavedConfig(null);
+            }}
+        />
+    );
+};
+
+// ============================================================================
+// SetupScreen — paste, parse, extract preview, CORS guidance, start
+// ============================================================================
+
+const SetupScreen: React.FC<{
+    savedConfig: StoredConfig | null;
+    onStart: (config: WidgetConfig, remember: boolean) => void;
+    onClearStorage: () => void;
+}> = ({ savedConfig, onStart, onClearStorage }) => {
+    const [snippet, setSnippet] = useState('');
+    const [remember, setRemember] = useState(true);
+    const [originCopied, setOriginCopied] = useState(false);
+
+    const parseResult = useMemo(() => parseWidgetSnippet(snippet), [snippet]);
+    const isValid = parseResult.ok;
+
+    const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+
+    const useSavedConfig = () => {
+        if (!savedConfig) return;
+        // Reconstruct a minimal snippet so the textarea reflects the loaded values
+        const reconstructed = `<script id="Microsoft_Omnichannel_LCWidget" data-app-id="${savedConfig.widgetId}" data-org-id="${savedConfig.orgId}" data-org-url="${savedConfig.orgUrl}"></script>`;
+        setSnippet(reconstructed);
+    };
+
+    const handleStart = () => {
+        if (!parseResult.ok) return;
+        onStart(parseResult.config, remember);
+    };
+
+    const copyOrigin = async () => {
+        try {
+            await navigator.clipboard.writeText(currentOrigin);
+            setOriginCopied(true);
+            setTimeout(() => setOriginCopied(false), 2000);
+        } catch {
+            // Clipboard unavailable — user copies manually
+        }
+    };
+
+    return (
+        <div style={layoutStyles.setupRoot}>
+            <header style={layoutStyles.header}>
+                <h1 style={layoutStyles.title}>OC Chat SDK — Streaming Demo</h1>
+                <div style={layoutStyles.headerControls}>
+                    {savedConfig && (
+                        <button onClick={onClearStorage} style={btnStyles.tertiary} title="Remove saved customer from this browser">
+                            Clear Saved Customer
+                        </button>
+                    )}
+                </div>
+            </header>
+
+            <main style={layoutStyles.setupMain}>
+                <h2 style={layoutStyles.stepHeading}>Step 1 · Paste your widget snippet</h2>
+                <p style={layoutStyles.stepDescription}>
+                    Copy the chat widget code from your Microsoft Contact Center admin app and paste it below.
+                    We&apos;ll extract the widget ID, org ID, and org URL automatically.
+                </p>
+
+                {savedConfig && (
+                    <div style={layoutStyles.savedConfigBanner}>
+                        <span>Saved customer: <code>{savedConfig.orgUrl}</code></span>
+                        <button onClick={useSavedConfig} style={btnStyles.tertiary}>Use saved</button>
+                    </div>
+                )}
+
+                <textarea
+                    value={snippet}
+                    onChange={(e) => setSnippet(e.target.value)}
+                    placeholder='<script id="Microsoft_Omnichannel_LCWidget" src="..." data-app-id="..." data-org-id="..." data-org-url="..." async></script>'
+                    style={layoutStyles.snippetTextarea}
+                    spellCheck={false}
+                />
+
+                <h2 style={layoutStyles.stepHeading}>Step 2 · Verify extracted values</h2>
+                {snippet.trim() === '' ? (
+                    <p style={layoutStyles.placeholderText}>Paste a snippet above to see the extracted values.</p>
+                ) : parseResult.ok ? (
+                    <ExtractionPreview config={parseResult.config} />
+                ) : (
+                    <div style={layoutStyles.parseError}>
+                        <strong>Could not parse snippet:</strong>
+                        <div>{parseResult.error}</div>
+                    </div>
+                )}
+
+                <h2 style={layoutStyles.stepHeading}>Step 3 · Allow this origin in your widget config</h2>
+                <p style={layoutStyles.stepDescription}>
+                    You can do this step in parallel while figuring out the snippet — the origin is the same regardless of which customer you&apos;re demoing to.
+                </p>
+                <div style={layoutStyles.corsGuidance}>
+                    <p>
+                        The Microsoft Contact Center will block this app from connecting to your tenant
+                        unless our origin is allowlisted in your widget&apos;s configuration.
+                    </p>
+                    <div style={layoutStyles.originRow}>
+                        <code style={layoutStyles.originBadge}>{currentOrigin}</code>
+                        <button onClick={copyOrigin} style={btnStyles.tertiary}>
+                            {originCopied ? 'Copied!' : 'Copy'}
+                        </button>
+                    </div>
+                    <details style={layoutStyles.corsDetails}>
+                        <summary>Where do I add this in the OC admin app?</summary>
+                        <ol style={layoutStyles.corsSteps}>
+                            <li>Open the Customer Service admin center.</li>
+                            <li>Navigate to <strong>Workstreams</strong> → select the workstream backing this widget.</li>
+                            <li>Open the <strong>Chat widget</strong> configuration.</li>
+                            <li>Find <strong>Behaviors</strong> → <strong>Allow this widget on the following domains</strong>.</li>
+                            <li>Add the origin shown above to the allowlist and save.</li>
+                        </ol>
+                        <p style={{ fontSize: 13, color: '#666', marginTop: 8 }}>
+                            For demos, we recommend doing this on a <em>test</em> widget config rather than
+                            your production widget.
+                        </p>
+                    </details>
+                </div>
+
+                <div style={layoutStyles.startRow}>
+                    <label style={layoutStyles.checkboxLabel}>
+                        <input
+                            type="checkbox"
+                            checked={remember}
+                            onChange={(e) => setRemember(e.target.checked)}
+                            disabled={!isValid}
+                        />
+                        Remember this customer in this browser
+                    </label>
+                    <button
+                        onClick={handleStart}
+                        style={isValid ? btnStyles.primary : btnStyles.primaryDisabled}
+                        disabled={!isValid}
+                        title={isValid ? 'Begin the chat session' : 'Paste a valid snippet first'}
+                    >
+                        Start Chat →
+                    </button>
+                </div>
+            </main>
+        </div>
+    );
+};
+
+// ============================================================================
+// ExtractionPreview — show the three extracted values with checkmarks
+// ============================================================================
+
+const ExtractionPreview: React.FC<{ config: WidgetConfig }> = ({ config }) => (
+    <div style={layoutStyles.extractionTable}>
+        <PreviewRow label="Widget ID" value={config.widgetId} />
+        <PreviewRow label="Org ID" value={config.orgId} />
+        <PreviewRow label="Org URL" value={config.orgUrl} />
+    </div>
+);
+
+const PreviewRow: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+    <div style={layoutStyles.previewRow}>
+        <span style={layoutStyles.previewCheck}>✓</span>
+        <span style={layoutStyles.previewLabel}>{label}</span>
+        <code style={layoutStyles.previewValue}>{value}</code>
+    </div>
+);
+
+// ============================================================================
+// ChatScreen — the original two-pane layout (bubbles + event log)
+// ============================================================================
+
+const ChatScreen: React.FC<{
+    config: WidgetConfig;
+    onSwitchCustomer: () => void;
+    onClearStorage: () => void;
+}> = ({ config, onSwitchCustomer, onClearStorage }) => {
+    const [chatSDK, setChatSDK] = useState<OmnichannelChatSDK | null>(null);
+    const [chatActive, setChatActive] = useState(false);
+    const [input, setInput] = useState('');
+    const [bubbles, setBubbles] = useState<Map<string, BubbleState>>(new Map());
+    const [events, setEvents] = useState<EventLogEntry[]>([]);
+    const [error, setError] = useState<ChatError | null>(null);
+    const [starting, setStarting] = useState(false);
+
+    const eventCounter = useRef(0);
+    const nextEventId = () => `evt-${++eventCounter.current}`;
+
+    const logEvent = useCallback((entry: Omit<EventLogEntry, 'id' | 'timestamp'>) => {
+        setEvents((prev) => [
+            ...prev,
+            { id: nextEventId(), timestamp: new Date(), ...entry },
+        ]);
+    }, []);
+
+    const upsertBubble = useCallback((updater: (prev: Map<string, BubbleState>) => Map<string, BubbleState>) => {
+        setBubbles((prev) => {
+            const next = new Map(prev);
+            return updater(next);
+        });
+    }, []);
+
+    // ---------------------------------------------------------------------
+    // SDK lifecycle
+    // ---------------------------------------------------------------------
+
+    const startChat = async () => {
+        setError(null);
+        setStarting(true);
+        try {
+            logEvent({ source: 'lifecycle', phase: 'initialize' });
+            const sdk = new OmnichannelChatSDK(config);
+            await sdk.initialize();
+
+            logEvent({ source: 'lifecycle', phase: 'startChat' });
+            await sdk.startChat();
+
+            await sdk.onNewMessage((message: any) => {
+                logEvent({
+                    source: 'onNewMessage',
+                    messageId: message.id,
+                    contentPreview: (message.content ?? '').slice(0, 80),
+                });
+                upsertBubble((next) => {
+                    const existing = next.get(message.id);
+                    next.set(message.id, {
+                        id: message.id,
+                        sender: existing?.sender ?? 'bot',
+                        senderDisplayName: existing?.senderDisplayName ?? message.sender?.displayName,
+                        content: message.content ?? '',
+                        isStreaming: false,
+                        streamPhase: existing?.streamPhase,
+                        streamEndReason: existing?.streamEndReason,
+                        timestamp: new Date(message.timestamp ?? Date.now()),
+                    });
+                    return next;
+                });
+            });
+
+            await sdk.onStreamingMessage((chunk: OmnichannelStreamingMessage) => {
+                const phase = chunk.streamingMetadata.streamingMessageType;
+                logEvent({
+                    source: 'onStreamingMessage',
+                    phase,
+                    sequenceNumber: chunk.streamingMetadata.streamingSequenceNumber,
+                    messageId: chunk.id,
+                    contentPreview: (chunk.content ?? '').slice(0, 80),
+                });
+                upsertBubble((next) => {
+                    next.set(chunk.id, {
+                        id: chunk.id,
+                        sender: 'bot',
+                        senderDisplayName: chunk.sender?.displayName,
+                        content: chunk.content ?? '',
+                        isStreaming: phase !== 'final',
+                        streamPhase: phase,
+                        streamEndReason: chunk.streamingMetadata.streamEndReason,
+                        timestamp: new Date(),
+                    });
+                    return next;
+                });
+            });
+
+            setChatSDK(sdk);
+            setChatActive(true);
+            logEvent({ source: 'lifecycle', phase: 'ready' });
+        } catch (e: unknown) {
+            const errObj = classifyError(e);
+            setError(errObj);
+            logEvent({ source: 'lifecycle', phase: `error: ${errObj.message}` });
+        } finally {
+            setStarting(false);
+        }
+    };
+
+    const sendMessage = async () => {
+        if (!chatSDK || !input.trim()) return;
+        const text = input.trim();
+        setInput('');
+
+        const localId = `user-${Date.now()}`;
+        upsertBubble((next) => {
+            next.set(localId, {
+                id: localId,
+                sender: 'user',
+                content: text,
+                isStreaming: false,
+                timestamp: new Date(),
+            });
+            return next;
+        });
+        logEvent({ source: 'sendMessage', contentPreview: text.slice(0, 80) });
+
+        try {
+            await chatSDK.sendMessage({ content: text });
+        } catch (e: unknown) {
+            setError(classifyError(e));
+        }
+    };
+
+    const endChat = async () => {
+        if (!chatSDK) return;
+        try {
+            logEvent({ source: 'lifecycle', phase: 'endChat' });
+            await chatSDK.endChat();
+        } catch (e: unknown) {
+            setError(classifyError(e));
+        } finally {
+            setChatSDK(null);
+            setChatActive(false);
+        }
+    };
+
+    // ---------------------------------------------------------------------
+    // Render
+    // ---------------------------------------------------------------------
+
+    const bubbleList = Array.from(bubbles.values()).sort(
+        (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+    );
+
+    return (
+        <div style={layoutStyles.chatRoot}>
+            <header style={layoutStyles.header}>
+                <div>
+                    <h1 style={layoutStyles.title}>OC Chat SDK — Streaming Demo</h1>
+                    <div style={layoutStyles.tenantSubtitle}>Connected to: <code>{config.orgUrl}</code></div>
+                </div>
+                <div style={layoutStyles.headerControls}>
+                    <button onClick={onSwitchCustomer} style={btnStyles.tertiary}>Switch Customer</button>
+                    <button onClick={onClearStorage} style={btnStyles.tertiary}>Clear Saved Customer</button>
+                    {!chatActive ? (
+                        <button onClick={startChat} disabled={starting} style={btnStyles.primary}>
+                            {starting ? 'Starting…' : 'Start Chat'}
+                        </button>
+                    ) : (
+                        <button onClick={endChat} style={btnStyles.secondary}>End Chat</button>
+                    )}
+                </div>
+            </header>
+
+            {error && <ErrorBanner error={error} onDismiss={() => setError(null)} />}
+
+            <div style={layoutStyles.split}>
+                <section style={layoutStyles.bubblePanel}>
+                    <div style={layoutStyles.bubbleList}>
+                        {bubbleList.length === 0 && (
+                            <p style={layoutStyles.placeholderText}>
+                                {chatActive
+                                    ? 'No messages yet. Send a message below.'
+                                    : 'Click "Start Chat" to begin.'}
+                            </p>
+                        )}
+                        {bubbleList.map((b) => (
+                            <ChatBubble key={b.id} bubble={b} />
+                        ))}
+                    </div>
+                    {chatActive && (
+                        <div style={layoutStyles.inputRow}>
+                            <input
+                                type="text"
+                                value={input}
+                                onChange={(e) => setInput(e.target.value)}
+                                onKeyDown={(e) => { if (e.key === 'Enter') sendMessage(); }}
+                                placeholder="Type a message and press Enter"
+                                style={layoutStyles.input}
+                            />
+                            <button onClick={sendMessage} style={btnStyles.primary}>Send</button>
+                        </div>
+                    )}
+                </section>
+
+                <section style={layoutStyles.eventPanel}>
+                    <div style={layoutStyles.eventHeader}>
+                        <strong>Event Log ({events.length})</strong>
+                        <button onClick={() => setEvents([])} style={btnStyles.tertiary}>Clear</button>
+                    </div>
+                    <div style={layoutStyles.eventList}>
+                        {events.map((e) => (
+                            <EventRow key={e.id} entry={e} />
+                        ))}
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+};
+
+// ============================================================================
+// ErrorBanner — CORS-friendly when applicable
+// ============================================================================
+
+const ErrorBanner: React.FC<{ error: ChatError; onDismiss: () => void }> = ({ error, onDismiss }) => {
+    if (error.kind === 'cors') {
+        return (
+            <div style={layoutStyles.corsErrorBanner}>
+                <div style={{ flex: 1 }}>
+                    <strong>Connection blocked (likely CORS).</strong>
+                    <div style={{ marginTop: 4 }}>
+                        Add this origin to your widget&apos;s allowed domains in the OC admin app, then click Start Chat again:
+                    </div>
+                    <code style={layoutStyles.originBadge}>{error.originToAdd}</code>
+                </div>
+                <button onClick={onDismiss} style={btnStyles.tertiary}>Dismiss</button>
+            </div>
+        );
+    }
+    return (
+        <div style={layoutStyles.errorBanner}>
+            <span style={{ flex: 1 }}>{error.message}</span>
+            <button onClick={onDismiss} style={btnStyles.tertiary}>Dismiss</button>
+        </div>
+    );
+};
+
+// ============================================================================
+// ChatBubble & EventRow — display components
+// ============================================================================
+
+const ChatBubble: React.FC<{ bubble: BubbleState }> = ({ bubble }) => {
+    const isUser = bubble.sender === 'user';
+    const align = isUser ? 'flex-end' : 'flex-start';
+    const bg = isUser ? '#0078d4' : '#f3f3f3';
+    const fg = isUser ? '#fff' : '#222';
+    const phaseLabel = bubble.streamPhase
+        ? ` · streaming:${bubble.streamPhase}${bubble.streamEndReason ? `(${bubble.streamEndReason})` : ''}`
+        : '';
+
+    return (
+        <div style={{ display: 'flex', justifyContent: align, marginBottom: 8 }}>
+            <div style={{
+                maxWidth: '70%', background: bg, color: fg,
+                padding: '8px 12px', borderRadius: 12,
+                fontSize: 14, lineHeight: 1.4,
+            }}>
+                <div style={{ whiteSpace: 'pre-wrap' }}>
+                    {bubble.content || (bubble.isStreaming ? ' ' : '')}
+                    {bubble.isStreaming && <span style={{ marginLeft: 6, opacity: 0.6 }}>▌</span>}
+                </div>
+                <div style={{ fontSize: 10, marginTop: 4, opacity: 0.7 }}>
+                    {bubble.senderDisplayName ?? bubble.sender}
+                    {phaseLabel}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const EventRow: React.FC<{ entry: EventLogEntry }> = ({ entry }) => {
+    const tagColor = ({
+        onNewMessage: '#28a745',
+        onStreamingMessage: '#0078d4',
+        sendMessage: '#6c757d',
+        lifecycle: '#6f42c1',
+    } as const)[entry.source];
+
+    return (
+        <div style={{
+            padding: '6px 8px', borderBottom: '1px solid #eee',
+            fontSize: 12, fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+        }}>
+            <span style={{
+                background: tagColor, color: '#fff',
+                padding: '1px 6px', borderRadius: 3,
+                marginRight: 6, fontSize: 11,
+            }}>
+                {entry.source}{entry.phase ? `:${entry.phase}` : ''}
+                {entry.sequenceNumber !== undefined ? ` #${entry.sequenceNumber}` : ''}
+            </span>
+            {entry.contentPreview && <span>{entry.contentPreview}</span>}
+            <div style={{ fontSize: 10, color: '#888', marginTop: 2 }}>
+                {entry.timestamp.toLocaleTimeString()}.{entry.timestamp.getMilliseconds().toString().padStart(3, '0')}
+                {entry.messageId && ` · msg ${entry.messageId.slice(0, 12)}…`}
+            </div>
+        </div>
+    );
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function classifyError(e: unknown): ChatError {
+    // ChatSDKError uses .message for the enum name (e.g., "MessagingClientInitializationFailure")
+    // and stashes the underlying error in .exceptionDetails.errorObject. We inspect both because
+    // CORS / network details only appear in the inner errorObject — the outer message is just the
+    // SDK's classification. Without this, "Failed to fetch" CORS errors look generic.
+    const err = e as {
+        message?: string;
+        exceptionDetails?: { response?: string; message?: string; errorObject?: string };
+    };
+    const outerMessage = String(err?.message ?? '');
+    const innerObject = String(err?.exceptionDetails?.errorObject ?? '');
+    const innerMessage = String(err?.exceptionDetails?.message ?? '');
+    const innerResponse = String(err?.exceptionDetails?.response ?? '');
+
+    const haystack = `${outerMessage} ${innerObject} ${innerMessage} ${innerResponse}`.toLowerCase();
+    const looksLikeCors =
+        haystack.includes('cors') ||
+        haystack.includes('failed to fetch') ||
+        haystack.includes('cross-origin') ||
+        haystack.includes('access-control') ||
+        haystack.includes('blocked by') ||
+        (haystack.includes('network') && haystack.includes('error'));
+
+    // Build a friendly display string: outer enum name + inner detail when available.
+    const friendlyMessage = innerObject
+        ? `${outerMessage}: ${innerObject}`
+        : outerMessage || String(e ?? 'Unknown error');
+
+    if (looksLikeCors) {
+        return {
+            kind: 'cors',
+            message: friendlyMessage,
+            originToAdd: typeof window !== 'undefined' ? window.location.origin : '',
+        };
+    }
+    return { kind: 'other', message: friendlyMessage };
+}
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+const layoutStyles = {
+    setupRoot: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        minHeight: '100vh',
+        background: '#fafafa',
+    },
+    chatRoot: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        height: '100vh',
+    },
+    header: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '12px 24px',
+        borderBottom: '1px solid #ddd',
+        background: '#fff',
+    },
+    title: { fontSize: 18, margin: 0 },
+    tenantSubtitle: { fontSize: 12, color: '#666', marginTop: 4 },
+    headerControls: { display: 'flex', gap: 8 },
+    setupMain: {
+        flex: 1,
+        padding: '24px 32px',
+        maxWidth: 800,
+        width: '100%',
+        margin: '0 auto',
+    },
+    stepHeading: {
+        fontSize: 16,
+        marginTop: 24,
+        marginBottom: 4,
+    },
+    stepDescription: {
+        fontSize: 13,
+        color: '#555',
+        marginTop: 0,
+    },
+    snippetTextarea: {
+        width: '100%',
+        minHeight: 140,
+        padding: 12,
+        fontFamily: 'ui-monospace, SFMono-Regular, Consolas, monospace',
+        fontSize: 12,
+        border: '1px solid #ccc',
+        borderRadius: 6,
+        background: '#fff',
+        resize: 'vertical' as const,
+    },
+    placeholderText: {
+        color: '#888',
+        fontSize: 13,
+    },
+    parseError: {
+        padding: 12,
+        background: '#f8d7da',
+        color: '#721c24',
+        border: '1px solid #f5c6cb',
+        borderRadius: 6,
+        fontSize: 13,
+    },
+    extractionTable: {
+        background: '#fff',
+        border: '1px solid #ddd',
+        borderRadius: 6,
+        padding: 12,
+    },
+    previewRow: {
+        display: 'grid',
+        gridTemplateColumns: '24px 100px 1fr',
+        alignItems: 'center',
+        padding: '6px 0',
+        borderBottom: '1px solid #f0f0f0',
+        gap: 8,
+    },
+    previewCheck: {
+        color: '#28a745',
+        fontWeight: 'bold' as const,
+    },
+    previewLabel: {
+        fontSize: 13,
+        color: '#666',
+    },
+    previewValue: {
+        fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+        fontSize: 12,
+        wordBreak: 'break-all' as const,
+    },
+    savedConfigBanner: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 8,
+        padding: '8px 12px',
+        background: '#e7f3ff',
+        border: '1px solid #b3d7ff',
+        borderRadius: 6,
+        marginBottom: 12,
+        fontSize: 13,
+    },
+    corsGuidance: {
+        background: '#fff3cd',
+        border: '1px solid #ffeaa7',
+        borderRadius: 6,
+        padding: 12,
+        fontSize: 13,
+    },
+    originRow: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        marginTop: 8,
+    },
+    originBadge: {
+        background: '#fff',
+        padding: '4px 8px',
+        borderRadius: 3,
+        fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+        fontSize: 12,
+        border: '1px solid #ddd',
+    },
+    corsDetails: {
+        marginTop: 12,
+        fontSize: 13,
+    },
+    corsSteps: {
+        margin: '8px 0 0 16px',
+        padding: 0,
+    },
+    startRow: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginTop: 24,
+    },
+    checkboxLabel: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        fontSize: 13,
+    },
+    errorBanner: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '8px 24px',
+        background: '#f8d7da',
+        color: '#721c24',
+        borderBottom: '1px solid #f5c6cb',
+        fontSize: 13,
+    },
+    corsErrorBanner: {
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 12,
+        padding: '12px 24px',
+        background: '#fff3cd',
+        color: '#856404',
+        borderBottom: '1px solid #ffeaa7',
+        fontSize: 13,
+    },
+    split: {
+        display: 'grid',
+        gridTemplateRows: '60% 40%',
+        flex: 1,
+        overflow: 'hidden',
+    },
+    bubblePanel: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        borderBottom: '2px solid #ddd',
+    },
+    bubbleList: {
+        flex: 1,
+        overflowY: 'auto' as const,
+        padding: 16,
+    },
+    inputRow: {
+        display: 'flex',
+        gap: 8,
+        padding: 12,
+        borderTop: '1px solid #ddd',
+    },
+    input: {
+        flex: 1,
+        padding: '8px 12px',
+        borderRadius: 6,
+        border: '1px solid #ccc',
+        fontSize: 14,
+    },
+    eventPanel: {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        background: '#fafafa',
+    },
+    eventHeader: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '6px 12px',
+        background: '#2d2d2d',
+        color: '#eee',
+        fontSize: 13,
+    },
+    eventList: {
+        flex: 1,
+        overflowY: 'auto' as const,
+        background: '#fff',
+        color: '#222',
+    },
+};
+
+const btnStyles = {
+    primary: {
+        padding: '8px 16px',
+        background: '#0078d4',
+        color: '#fff',
+        border: 'none',
+        borderRadius: 4,
+        cursor: 'pointer',
+        fontSize: 14,
+    },
+    primaryDisabled: {
+        padding: '8px 16px',
+        background: '#cce4f7',
+        color: '#fff',
+        border: 'none',
+        borderRadius: 4,
+        cursor: 'not-allowed' as const,
+        fontSize: 14,
+    },
+    secondary: {
+        padding: '8px 16px',
+        background: '#6c757d',
+        color: '#fff',
+        border: 'none',
+        borderRadius: 4,
+        cursor: 'pointer',
+        fontSize: 14,
+    },
+    tertiary: {
+        padding: '6px 12px',
+        background: '#f0f0f0',
+        color: '#333',
+        border: '1px solid #ccc',
+        borderRadius: 4,
+        cursor: 'pointer',
+        fontSize: 12,
+    },
+};
+
+export default App;

--- a/samples/streaming-react/src/index.tsx
+++ b/samples/streaming-react/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (!container) throw new Error('Root container not found');
+
+const root = createRoot(container);
+root.render(<App />);

--- a/samples/streaming-react/src/parseWidgetSnippet.ts
+++ b/samples/streaming-react/src/parseWidgetSnippet.ts
@@ -1,0 +1,104 @@
+// Parses a Microsoft Contact Center chat widget snippet (the <script> tag
+// customers copy from the OC admin app) into the three values the SDK needs:
+// widgetId (from data-app-id), orgId (from data-org-id), orgUrl (from data-org-url).
+//
+// Handles two formats found in real snippets:
+//   1. Inline script element with the data-* attributes.
+//   2. Same script element but with a fallback onerror handler that re-creates
+//      the script and sets the attributes via setAttribute('data-app-id', '...').
+// We try DOMParser first (robust for #1), then fall back to regex (covers #2).
+
+export interface WidgetConfig {
+    widgetId: string;
+    orgId: string;
+    orgUrl: string;
+}
+
+export type ParseResult =
+    | { ok: true; config: WidgetConfig }
+    | { ok: false; error: string };
+
+const GUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const URL_PATTERN = /^https?:\/\/[^\s]+/i;
+
+export function parseWidgetSnippet(snippet: string): ParseResult {
+    const trimmed = snippet.trim();
+    if (!trimmed) {
+        return { ok: false, error: 'Paste a widget snippet to continue.' };
+    }
+
+    let widgetId: string | undefined;
+    let orgId: string | undefined;
+    let orgUrl: string | undefined;
+
+    // 1. Try DOM parsing — picks up data-* attributes on script elements.
+    try {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(trimmed, 'text/html');
+        const script = doc.querySelector('script[data-app-id], script[data-org-id], script[data-org-url]');
+        if (script) {
+            widgetId = script.getAttribute('data-app-id') ?? undefined;
+            orgId = script.getAttribute('data-org-id') ?? undefined;
+            orgUrl = script.getAttribute('data-org-url') ?? undefined;
+        }
+    } catch {
+        // fall through to regex
+    }
+
+    // 2. Regex fallback — handles attributes only present inside the onerror
+    // setAttribute calls, plus catches malformed snippets DOMParser may miss.
+    widgetId = widgetId ?? extractAttribute(trimmed, 'data-app-id');
+    orgId = orgId ?? extractAttribute(trimmed, 'data-org-id');
+    orgUrl = orgUrl ?? extractAttribute(trimmed, 'data-org-url');
+
+    const missing = [
+        !widgetId && 'data-app-id',
+        !orgId && 'data-org-id',
+        !orgUrl && 'data-org-url',
+    ].filter(Boolean) as string[];
+
+    if (missing.length > 0) {
+        return {
+            ok: false,
+            error: `Snippet is missing required attributes: ${missing.join(', ')}. Make sure you copied the full <script> tag from the OC admin app.`,
+        };
+    }
+
+    if (!GUID_PATTERN.test(widgetId!)) {
+        return { ok: false, error: `data-app-id is not a valid GUID: "${widgetId}".` };
+    }
+    if (!GUID_PATTERN.test(orgId!)) {
+        return { ok: false, error: `data-org-id is not a valid GUID: "${orgId}".` };
+    }
+    if (!URL_PATTERN.test(orgUrl!)) {
+        return { ok: false, error: `data-org-url is not a valid URL: "${orgUrl}".` };
+    }
+
+    return {
+        ok: true,
+        config: {
+            widgetId: widgetId!,
+            orgId: orgId!,
+            orgUrl: orgUrl!,
+        },
+    };
+}
+
+// Extract a data-* attribute value from raw snippet text. Tries two patterns:
+//   1. data-name="value" or data-name='value'  (inline attribute)
+//   2. 'data-name', 'value' or "data-name", "value"  (setAttribute call inside onerror)
+function extractAttribute(snippet: string, name: string): string | undefined {
+    const patterns = [
+        new RegExp(`${escapeRegex(name)}\\s*=\\s*["']([^"']+)["']`, 'i'),
+        new RegExp(`['"]${escapeRegex(name)}['"]\\s*,\\s*['"]([^'"]+)['"]`, 'i'),
+    ];
+    for (const pattern of patterns) {
+        const match = snippet.match(pattern);
+        if (match) return match[1];
+    }
+    return undefined;
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/samples/streaming-react/src/storage.ts
+++ b/samples/streaming-react/src/storage.ts
@@ -1,0 +1,44 @@
+// Local-only persistence for one customer's widget config. No server, no
+// telemetry, no syncing — just localStorage in the user's own browser.
+
+import type { WidgetConfig } from './parseWidgetSnippet';
+
+const STORAGE_KEY = 'oc-streaming-demo-config-v1';
+
+export interface StoredConfig extends WidgetConfig {
+    savedAt: string;  // ISO timestamp
+}
+
+export function loadSavedConfig(): StoredConfig | null {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as Partial<StoredConfig>;
+        if (parsed && parsed.widgetId && parsed.orgId && parsed.orgUrl && parsed.savedAt) {
+            return parsed as StoredConfig;
+        }
+    } catch {
+        // Corrupt JSON or storage unavailable — treat as no saved config.
+    }
+    return null;
+}
+
+export function saveConfig(config: WidgetConfig): void {
+    const stored: StoredConfig = {
+        ...config,
+        savedAt: new Date().toISOString(),
+    };
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+    } catch {
+        // Storage unavailable (quota, private browsing) — silently skip persistence.
+    }
+}
+
+export function clearSavedConfig(): void {
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // Best-effort.
+    }
+}

--- a/samples/streaming-react/staticwebapp.config.json
+++ b/samples/streaming-react/staticwebapp.config.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json.schemastore.org/staticwebapp.config.json",
+    "navigationFallback": {
+        "rewrite": "/index.html",
+        "exclude": ["/static/*", "/*.{js,css,map}"]
+    },
+    "globalHeaders": {
+        "Cache-Control": "no-cache, no-store, must-revalidate"
+    },
+    "mimeTypes": {
+        ".json": "application/json",
+        ".map": "application/json"
+    },
+    "responseOverrides": {
+        "404": {
+            "rewrite": "/index.html"
+        }
+    }
+}

--- a/samples/streaming-react/tsconfig.json
+++ b/samples/streaming-react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "jsx": "react-jsx",
+        "strict": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "lib": ["DOM", "DOM.Iterable", "ES2020"]
+    },
+    "include": ["src/**/*"]
+}

--- a/samples/streaming-react/webpack.config.js
+++ b/samples/streaming-react/webpack.config.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
+
+module.exports = (_env, argv) => {
+    const isProd = argv.mode === 'production';
+
+    return {
+        entry: './src/index.tsx',
+        output: {
+            path: path.resolve(__dirname, 'dist'),
+            filename: isProd ? 'bundle.[contenthash].js' : 'bundle.js',
+            clean: true,
+        },
+        resolve: {
+            extensions: ['.tsx', '.ts', '.js'],
+            // The SDK has a conditional require('react-native') for cross-platform
+            // support. We're not in React Native here — silence the warning.
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.tsx?$/,
+                    use: 'ts-loader',
+                    exclude: /node_modules/,
+                },
+            ],
+        },
+        plugins: [
+            new HtmlWebpackPlugin({
+                template: './public/index.html',
+            }),
+            // Mirror the polyfill pattern from playwright/esbuild.config.js so that
+            // @azure/communication-chat's real-time notifications work in the browser.
+            // Webpack 5 dropped Node polyfills; node-polyfill-webpack-plugin restores them.
+            new NodePolyfillPlugin(),
+            // Suppress the harmless 'react-native' resolution warning.
+            new webpack.IgnorePlugin({ resourceRegExp: /^react-native$/ }),
+        ],
+        devServer: {
+            static: { directory: path.join(__dirname, 'public') },
+            port: 3000,
+            hot: true,
+            historyApiFallback: true,
+        },
+        devtool: isProd ? 'source-map' : 'inline-source-map',
+    };
+};

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -83,7 +83,9 @@ import OmnichannelChatToken from "@microsoft/omnichannel-amsclient/lib/Omnichann
 import OmnichannelConfig from "./core/OmnichannelConfig";
 import OmnichannelErrorCodes from "./core/OmnichannelErrorCodes";
 import OmnichannelMessage from "./core/messaging/OmnichannelMessage";
+import OmnichannelStreamingMessage from "./core/messaging/OmnichannelStreamingMessage";
 import OnNewMessageOptionalParams from "./core/messaging/OnNewMessageOptionalParams";
+import OnStreamingMessageOptionalParams from "./core/messaging/OnStreamingMessageOptionalParams";
 import PersonType from "@microsoft/omnichannel-ic3core/lib/model/PersonType";
 import PluggableLogger from "@microsoft/omnichannel-amsclient/lib/PluggableLogger";
 import PostChatContext from "./core/PostChatContext";
@@ -1838,6 +1840,62 @@ class OmnichannelChatSDK {
                     ChatId: this.chatToken.chatId as string
                 });
             }
+        }
+    }
+
+    public async onStreamingMessage(
+        onStreamingMessageCallback: (message: OmnichannelStreamingMessage) => void,
+        optionalParams?: OnStreamingMessageOptionalParams
+    ): Promise<void> {
+        this.scenarioMarker.startScenario(TelemetryEvent.OnStreamingMessage, {
+            RequestId: this.requestId,
+            ChatId: this.chatToken?.chatId as string ?? ""
+        });
+
+        // Mirror the isInitialized check used by sibling subscription APIs
+        // (onNewMessage, onTypingEvent, onAgentEndSession) so the error
+        // surface for "called before initialize()" is consistent across the
+        // SDK. The conversation check below catches the separate
+        // "initialize() but not startChat()" case.
+        if (!this.isInitialized) {
+            exceptionThrowers.throwUninitializedChatSDK(this.scenarioMarker, TelemetryEvent.OnStreamingMessage);
+        }
+
+        try {
+            if (this.liveChatVersion !== LiveChatVersion.V2) {
+                throw new ChatSDKError(ChatSDKErrorName.UnsupportedLiveChatVersion);
+            }
+            if (!this.conversation) {
+                throw new ChatSDKError(ChatSDKErrorName.UninitializedConversation);
+            }
+
+            await (this.conversation as ACSConversation).registerOnStreamingMessage(
+                onStreamingMessageCallback,
+                optionalParams
+            );
+
+            this.scenarioMarker.completeScenario(TelemetryEvent.OnStreamingMessage, {
+                RequestId: this.requestId,
+                ChatId: this.chatToken?.chatId as string ?? ""
+            });
+        } catch (error) {
+            // Wrap generic errors from ACSConversation into a typed ChatSDKError.
+            // Validation errors above are already ChatSDKError — preserve them.
+            const wrappedError = (error instanceof ChatSDKError)
+                ? error
+                : new ChatSDKError(
+                    ChatSDKErrorName.StreamingSubscriptionFailure,
+                    undefined,
+                    { response: 'StreamingSubscriptionFailure', errorObject: `${error}` }
+                );
+
+            this.scenarioMarker.failScenario(TelemetryEvent.OnStreamingMessage, {
+                RequestId: this.requestId,
+                ChatId: this.chatToken?.chatId as string ?? "",
+                ExceptionDetails: JSON.stringify(wrappedError.exceptionDetails ?? wrappedError.message)
+            });
+
+            throw wrappedError;
         }
     }
 

--- a/src/core/ChatSDKError.ts
+++ b/src/core/ChatSDKError.ts
@@ -67,6 +67,10 @@ export enum ChatSDKErrorName {
     /** Failure in mid-conversation authentication */
     MidConversationAuthFailure = "MidConversationAuthFailure",
 
+    /** Streaming requires an active conversation; called before startChat() */
+    UninitializedConversation = "UninitializedConversation",
+    /** Failure to subscribe to ACS streaming events */
+    StreamingSubscriptionFailure = "StreamingSubscriptionFailure",
 }
 
 export class ChatSDKError {

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -1,6 +1,6 @@
 import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from "@azure/communication-common";
 import { ChatClient, ChatMessage, ChatParticipant, ChatThreadClient } from "@azure/communication-chat";
-import { ChatMessageEditedEvent, ChatMessageReceivedEvent, ParticipantsRemovedEvent, TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
+import { ChatMessageEditedEvent, ChatMessageReceivedEvent, ParticipantsRemovedEvent, StreamingChatMessageChunkReceivedEvent, StreamingChatMessageStartEvent, TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
 import { MessagePrinterFactory, PrinterType } from "../../utils/printers/MessagePrinterFactory";
 
 import ACSChatMessageType from "./ACSChatMessageType";
@@ -15,8 +15,11 @@ import DeliveryMode from "@microsoft/omnichannel-ic3core/lib/model/DeliveryMode"
 import LiveChatVersion from "../LiveChatVersion";
 import { MessageSource } from "../../telemetry/MessageSource";
 import OmnichannelMessage from "./OmnichannelMessage";
+import OmnichannelStreamingMessage from "./OmnichannelStreamingMessage";
+import OnStreamingMessageOptionalParams from "./OnStreamingMessageOptionalParams";
 import TelemetryEvent from "../../telemetry/TelemetryEvent";
 import createOmnichannelMessage from "../../utils/createOmnichannelMessage";
+import createOmnichannelStreamingMessage from "../../utils/createOmnichannelStreamingMessage";
 import { defaultMessageTags } from "./MessageTags";
 
 enum ACSClientEvent {
@@ -24,6 +27,7 @@ enum ACSClientEvent {
     InitializeACSConversation = 'InitializeACSConversation',
     GetParticipants = 'GetParticipants',
     RegisterOnNewMessage = 'RegisterOnNewMessage',
+    RegisterOnStreamingMessage = 'RegisterOnStreamingMessage',
     RegisterOnThreadUpdate = 'RegisterOnThreadUpdate',
     OnTypingEvent = 'OnTypingEvent',
     GetMessages = 'GetMessages',
@@ -55,6 +59,8 @@ export class ACSConversation {
     private eventListeners: EventListenersMapping;
     private keepPolling = false;
     private pollingTimer: NodeJS.Timeout | number | null = null;
+    private streamSequenceCounters: Map<string, number> = new Map();
+    private finalizedMessageIds: Set<string> = new Set();
 
     constructor(tokenCredential: AzureCommunicationTokenCredential, chatClient: ChatClient, logger: ACSClientLogger | null = null) {
         this.logger = logger;
@@ -270,6 +276,152 @@ export class ACSConversation {
             });
 
             throw new Error(ACSClientEvent.RegisterOnNewMessage);
+        }
+    }
+
+    public async registerOnStreamingMessage(
+        onStreamingMessageCallback: (message: OmnichannelStreamingMessage) => void,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        optionalParams: OnStreamingMessageOptionalParams = {}
+    ): Promise<void> {
+        this.logger?.startScenario(ACSClientEvent.RegisterOnStreamingMessage);
+
+        try {
+            const invokeWithIsolation = (event: { id: string }, message: OmnichannelStreamingMessage) => {
+                // Listener-isolation guarantee: a consumer's callback must never
+                // break the streaming subscription, whether it throws sync or
+                // returns a rejecting Promise (async callbacks). Sync throws are
+                // caught by the surrounding try/catch; async rejections need an
+                // explicit .catch on the returned Promise (the callback is typed
+                // as () => void, but consumers commonly pass async functions).
+                // Cast through unknown because the callback is typed () => void;
+                // TS strict mode rejects testing void for truthiness, but consumers
+                // commonly pass async functions whose returned Promise we need to
+                // observe for rejection.
+                const result = onStreamingMessageCallback(message) as unknown;
+                if (result && typeof (result as Promise<unknown>).catch === 'function') {
+                    (result as Promise<unknown>).catch((rejected: unknown) => {
+                        this.logger?.recordIndividualEvent(
+                            TelemetryEvent.StreamingHandlerAsyncRejected,
+                            MessageSource.WebSocketStreaming,
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            { messageId: event.id, error: `${rejected}` } as any
+                        );
+                    });
+                }
+            };
+
+            const onStart = (event: StreamingChatMessageStartEvent) => {
+                try {
+                    const message = createOmnichannelStreamingMessage(event, {
+                        liveChatVersion: LiveChatVersion.V2,
+                        eventName: 'streamingChatMessageStarted',
+                        sequenceCounters: this.streamSequenceCounters,
+                        finalizedMessageIds: this.finalizedMessageIds,
+                        logger: this.logger,
+                    });
+                    if (message === undefined) {
+                        return;
+                    }
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingMessageReceived,
+                        MessageSource.WebSocketStreaming,
+                        MessagePrinterFactory.printifyMessage(event, PrinterType.Streaming)
+                    );
+                    invokeWithIsolation(event, message);
+                } catch (err) {
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingHandlerThrew,
+                        MessageSource.WebSocketStreaming,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        { messageId: event.id, error: `${err}` } as any
+                    );
+                }
+            };
+
+            const onChunk = (event: StreamingChatMessageChunkReceivedEvent) => {
+                try {
+                    const message = createOmnichannelStreamingMessage(event, {
+                        liveChatVersion: LiveChatVersion.V2,
+                        eventName: 'streamingChatMessageChunkReceived',
+                        sequenceCounters: this.streamSequenceCounters,
+                        finalizedMessageIds: this.finalizedMessageIds,
+                        logger: this.logger,
+                    });
+                    if (message === undefined) {
+                        return;
+                    }
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingMessageReceived,
+                        MessageSource.WebSocketStreaming,
+                        MessagePrinterFactory.printifyMessage(event, PrinterType.Streaming)
+                    );
+                    invokeWithIsolation(event, message);
+
+                    // Backwards-compat: when a streaming message reaches "final",
+                    // also deliver the assembled message to consumers who only
+                    // registered onNewMessage. Without this fire-through, a bot
+                    // that switches from non-streaming to streaming responses
+                    // would silently disappear from existing consumers' UIs.
+                    //
+                    // Assumption: ACS does NOT fire chatMessageReceived for
+                    // streaming messages (only the streamingChat* events). If
+                    // this assumption is incorrect under any ACS configuration,
+                    // this fire-through could cause duplicate onNewMessage
+                    // invocations and a dedup tracking step would be needed.
+                    //
+                    // Note on event shape: the StreamingChatMessageChunkReceivedEvent
+                    // is structurally compatible with ChatMessageEditedEvent (carries
+                    // editedOn). The chatMessageReceived inner listener at
+                    // registerOnNewMessage uses Object.keys(event).includes("editedOn")
+                    // to detect edits — so this fire-through is treated as an "edit"
+                    // by that path, which means the consumer's onNewMessage callback
+                    // fires regardless of whether the message id was already posted.
+                    // That's intentional — the final-chunk fire is the authoritative
+                    // assembled content and should win over any earlier delivery.
+                    if (message.streamingMetadata.streamingMessageType === 'final') {
+                        const newMessageListeners = this.eventListeners['chatMessageReceived'] ?? [];
+                        for (const listener of newMessageListeners) {
+                            try {
+                                listener(event);
+                            } catch (err) {
+                                this.logger?.recordIndividualEvent(
+                                    TelemetryEvent.StreamingHandlerThrew,
+                                    MessageSource.WebSocketStreaming,
+                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                                    { messageId: event.id, error: `${err}`, source: 'newMessageFireThrough' } as any
+                                );
+                            }
+                        }
+                    }
+                } catch (err) {
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingHandlerThrew,
+                        MessageSource.WebSocketStreaming,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        { messageId: event.id, error: `${err}` } as any
+                    );
+                }
+            };
+
+            this.chatClient?.on('streamingChatMessageStarted', onStart);
+            this.chatClient?.on('streamingChatMessageChunkReceived', onChunk);
+            this.trackListener('streamingChatMessageStarted', onStart);
+            this.trackListener('streamingChatMessageChunkReceived', onChunk);
+
+            this.logger?.completeScenario(ACSClientEvent.RegisterOnStreamingMessage);
+        } catch (error) {
+            const exceptionDetails = { errorObject: `${error}` };
+            this.logger?.failScenario(ACSClientEvent.RegisterOnStreamingMessage, {
+                ExceptionDetails: JSON.stringify(exceptionDetails),
+            });
+
+            // Preserve the original cause in the thrown message so downstream
+            // error classifiers (e.g., CORS detection in consuming apps) can
+            // inspect the underlying failure. Mirrors the pattern used by
+            // ACSConversation.initialize() which embeds `${error}` into the
+            // exceptionDetails it throws.
+            throw new Error(`${ACSClientEvent.RegisterOnStreamingMessage}: ${error}`);
         }
     }
 

--- a/src/core/messaging/OmnichannelStreamingMessage.ts
+++ b/src/core/messaging/OmnichannelStreamingMessage.ts
@@ -1,0 +1,15 @@
+import OmnichannelMessage from "./OmnichannelMessage";
+import PolicyViolation from "./PolicyViolation";
+import StreamingMetadata from "./StreamingMetadata";
+
+/**
+ * Streaming message chunk delivered through chatSDK.onStreamingMessage.
+ * Extends OmnichannelMessage with required streamingMetadata; policyViolation
+ * is optional and only present when ACS moderation flagged the chunk.
+ */
+export interface OmnichannelStreamingMessage extends OmnichannelMessage {
+    streamingMetadata: StreamingMetadata;
+    policyViolation?: PolicyViolation;
+}
+
+export default OmnichannelStreamingMessage;

--- a/src/core/messaging/OnStreamingMessageOptionalParams.ts
+++ b/src/core/messaging/OnStreamingMessageOptionalParams.ts
@@ -1,0 +1,10 @@
+/**
+ * Reserved for future per-handler streaming configuration. Currently empty.
+ * Defined as a named type so adding fields later does not require changing
+ * the public method signature on OmnichannelChatSDK or ACSConversation.
+ */
+export interface OnStreamingMessageOptionalParams {
+    // Intentionally empty. Add fields when concrete need surfaces.
+}
+
+export default OnStreamingMessageOptionalParams;

--- a/src/core/messaging/PolicyViolation.ts
+++ b/src/core/messaging/PolicyViolation.ts
@@ -1,0 +1,9 @@
+/**
+ * ACS content moderation result. Surfaces on streaming chunks when a
+ * server-side moderation policy has flagged the content.
+ */
+export interface PolicyViolation {
+    result: "contentBlocked" | "warning";
+}
+
+export default PolicyViolation;

--- a/src/core/messaging/StreamingMetadata.ts
+++ b/src/core/messaging/StreamingMetadata.ts
@@ -1,0 +1,12 @@
+/**
+ * Metadata describing a streaming message's lifecycle position.
+ * Mirrors ACS's StreamingMessageMetadata, with all fields required after
+ * SDK-side normalization in createOmnichannelStreamingMessage.
+ */
+export interface StreamingMetadata {
+    streamingMessageType: "start" | "informative" | "streaming" | "final";
+    streamingSequenceNumber: number;
+    streamEndReason?: "completed" | "expired" | "canceled";
+}
+
+export default StreamingMetadata;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ import IRawMessage from "@microsoft/omnichannel-ic3core/lib/model/IRawMessage";
 import MessageContentType from "@microsoft/omnichannel-ic3core/lib/model/MessageContentType";
 import MessageType from "@microsoft/omnichannel-ic3core/lib/model/MessageType";
 import OmnichannelChatSDK from "./OmnichannelChatSDK";
+import OmnichannelStreamingMessage from "./core/messaging/OmnichannelStreamingMessage";
+import OnStreamingMessageOptionalParams from "./core/messaging/OnStreamingMessageOptionalParams";
 import PersonType from "@microsoft/omnichannel-ic3core/lib/model/PersonType";
+import PolicyViolation from "./core/messaging/PolicyViolation";
+import StreamingMetadata from "./core/messaging/StreamingMetadata";
 
 export {
     OmnichannelChatSDK,
@@ -57,6 +61,10 @@ export {
     UploadFileAttachmentResponse,
     GetMessagesResponse,
     GetCurrentLiveChatContextResponse,
+    OmnichannelStreamingMessage,
+    OnStreamingMessageOptionalParams,
+    PolicyViolation,
+    StreamingMetadata,
 }
 
 export default {

--- a/src/telemetry/AriaTelemetry.ts
+++ b/src/telemetry/AriaTelemetry.ts
@@ -29,6 +29,7 @@ interface NPMPackagesInfo {
     IC3Core?: string;
     ACSChat?: string;
     ACSCommon?: string;
+    ACSAdapter?: string;
     AMSClient?: string;
 }
 
@@ -90,6 +91,7 @@ interface ACSClientContract {
     ExceptionDetails?: string;
     ElapsedTimeInMilliseconds?: string;
     ACSChatVersion: string;
+    ACSAdapterVersion?: string;
 }
 
 interface ACSAdapterContract {
@@ -675,6 +677,7 @@ class AriaTelemetry {
             IC3Core: require('@microsoft/omnichannel-ic3core/package.json').version,
             ACSChat: require('@azure/communication-chat/package.json').version,
             ACSCommon: require('@azure/communication-common/package.json').version,
+            ACSAdapter: require('@microsoft/botframework-webchat-adapter-azure-communication-chat/package.json').version,
             AMSClient:  require('@microsoft/omnichannel-amsclient/package.json').version,
         };
 
@@ -808,7 +811,8 @@ class AriaTelemetry {
             Event: '',
             ExceptionDetails: '',
             ElapsedTimeInMilliseconds: '',
-            ACSChatVersion: require('@azure/communication-chat/package.json').version
+            ACSChatVersion: require('@azure/communication-chat/package.json').version,
+            ACSAdapterVersion: require('@microsoft/botframework-webchat-adapter-azure-communication-chat/package.json').version
         }
     }
 

--- a/src/telemetry/MessageSource.ts
+++ b/src/telemetry/MessageSource.ts
@@ -1,5 +1,6 @@
 export enum MessageSource {
     Polling = "Poll",
     WebSocket = "WS",
+    WebSocketStreaming = "WSStream",
     GetRestCall = "Get"
 }

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -49,6 +49,25 @@ enum TelemetryEvent {
     GetPersistentChatHistory = "GetPersistentChatHistory",
     WaitForConversationalSurvey = "WaitForConversationalSurvey",
     MidConversationAuth = "MidConversationAuth",
+
+    // ACS streaming
+    OnStreamingMessage = "OnStreamingMessage",
+    StreamingMessageReceived = "StreamingMessageReceived",
+    StreamingMessageStarted = "StreamingMessageStarted",
+    StreamingMessageEnded = "StreamingMessageEnded",
+    StreamingEndedExpired = "StreamingEndedExpired",
+    StreamingEndedCanceled = "StreamingEndedCanceled",
+    StreamingDisconnect = "StreamingDisconnect",
+    StreamingHandlerThrew = "StreamingHandlerThrew",
+    StreamingHandlerAsyncRejected = "StreamingHandlerAsyncRejected",
+    StreamingMetadataMissingType = "StreamingMetadataMissingType",
+    StreamingFinalMissingReason = "StreamingFinalMissingReason",
+    StreamingChunkNoContent = "StreamingChunkNoContent",
+    StreamingDuplicateFinal = "StreamingDuplicateFinal",
+    StreamingChunkAfterFinal = "StreamingChunkAfterFinal",
+    StreamingCounterEvicted = "StreamingCounterEvicted",
+    StreamingSubscriptionFailed = "StreamingSubscriptionFailed",
+    StreamingPolicyViolation = "StreamingPolicyViolation",
 }
 
 export default TelemetryEvent;

--- a/src/utils/createOmnichannelStreamingMessage.ts
+++ b/src/utils/createOmnichannelStreamingMessage.ts
@@ -1,0 +1,151 @@
+import {
+    StreamingChatMessageChunkReceivedEvent,
+    StreamingChatMessageStartEvent,
+} from '@azure/communication-signaling';
+
+import LiveChatVersion from '../core/LiveChatVersion';
+import OmnichannelStreamingMessage from '../core/messaging/OmnichannelStreamingMessage';
+import StreamingMetadata from '../core/messaging/StreamingMetadata';
+import TelemetryEvent from '../telemetry/TelemetryEvent';
+import { MessageSource } from '../telemetry/MessageSource';
+import createOmnichannelMessage from './createOmnichannelMessage';
+
+const MAX_TRACKED_STREAMS = 256;
+
+export interface CreateOmnichannelStreamingMessageOptionalParams {
+    liveChatVersion: LiveChatVersion;
+    eventName: 'streamingChatMessageStarted' | 'streamingChatMessageChunkReceived';
+    sequenceCounters: Map<string, number>;
+    finalizedMessageIds: Set<string>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logger: { recordIndividualEvent: (event: string, source: string, props: any) => void } | null;
+}
+
+const createOmnichannelStreamingMessage = (
+    event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent,
+    params: CreateOmnichannelStreamingMessageOptionalParams
+): OmnichannelStreamingMessage | undefined => {
+    // Drop duplicate finals — log and bail before doing any other work.
+    const incomingType = event.streamingMetadata?.streamingMessageType;
+    if (incomingType === 'final' && params.finalizedMessageIds.has(event.id)) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingDuplicateFinal,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id }
+        );
+        return undefined;
+    }
+
+    // ACS chunks are typed as ChatMessageEditedEvent; defensively log if the
+    // content field is missing (should be impossible per protocol but the
+    // type system lets it slip through). createOmnichannelMessage handles
+    // the absent-content case by falling back to empty string.
+    if (event.message === undefined || event.message === null) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingChunkNoContent,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id, eventName: params.eventName }
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseMessage = createOmnichannelMessage(event as any, {
+        liveChatVersion: params.liveChatVersion,
+    });
+    const streamingMetadata = normalizeStreamingMetadata(event, params);
+
+    if (streamingMetadata.streamingMessageType === 'final') {
+        params.finalizedMessageIds.add(event.id);
+        params.sequenceCounters.delete(event.id);
+    } else if (params.finalizedMessageIds.has(event.id)) {
+        // Late chunk after final — log but still emit so consumers can
+        // decide UX behavior.
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingChunkAfterFinal,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id }
+        );
+    }
+
+    // Surface policyViolation (only present on chunk-typed events).
+    const policyViolation = (event as StreamingChatMessageChunkReceivedEvent).policyViolation;
+    if (policyViolation) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingPolicyViolation,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id, result: policyViolation.result }
+        );
+    }
+
+    return {
+        ...baseMessage,
+        streamingMetadata,
+        ...(policyViolation ? { policyViolation } : {}),
+    } as OmnichannelStreamingMessage;
+};
+
+function normalizeStreamingMetadata(
+    event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent,
+    params: CreateOmnichannelStreamingMessageOptionalParams
+): StreamingMetadata {
+    const fallbackType: StreamingMetadata['streamingMessageType'] =
+        params.eventName === 'streamingChatMessageStarted' ? 'start' : 'streaming';
+
+    if (event.streamingMetadata?.streamingMessageType === undefined) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingMetadataMissingType,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id, eventName: params.eventName }
+        );
+    }
+
+    const inferredType = event.streamingMetadata?.streamingMessageType ?? fallbackType;
+    const inferredSequence = recordAndGetSequence(event, params);
+
+    let endReason = event.streamingMetadata?.streamEndReason;
+    if (inferredType === 'final' && endReason === undefined) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingFinalMissingReason,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id }
+        );
+        endReason = 'completed';
+    }
+
+    return {
+        streamingMessageType: inferredType,
+        streamingSequenceNumber: inferredSequence,
+        streamEndReason: endReason,
+    };
+}
+
+function recordAndGetSequence(
+    event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent,
+    params: CreateOmnichannelStreamingMessageOptionalParams
+): number {
+    const fromAcs = event.streamingMetadata?.streamingSequenceNumber;
+    if (fromAcs !== undefined) {
+        return fromAcs;
+    }
+
+    // SDK fallback: monotonic counter per messageId, LRU-bounded at MAX_TRACKED_STREAMS.
+    if (
+        params.sequenceCounters.size >= MAX_TRACKED_STREAMS &&
+        !params.sequenceCounters.has(event.id)
+    ) {
+        const oldestKey = params.sequenceCounters.keys().next().value;
+        if (oldestKey !== undefined) {
+            params.sequenceCounters.delete(oldestKey);
+            params.logger?.recordIndividualEvent(
+                TelemetryEvent.StreamingCounterEvicted,
+                MessageSource.WebSocketStreaming,
+                { evictedMessageId: oldestKey }
+            );
+        }
+    }
+    const next = (params.sequenceCounters.get(event.id) ?? 0) + 1;
+    params.sequenceCounters.set(event.id, next);
+    return next;
+}
+
+export default createOmnichannelStreamingMessage;

--- a/src/utils/printers/MessagePrinterFactory.ts
+++ b/src/utils/printers/MessagePrinterFactory.ts
@@ -1,15 +1,18 @@
 import { ChatMessage, ChatMessageEditedEvent, ChatMessageReceivedEvent } from "@azure/communication-chat";
+import { StreamingChatMessageChunkReceivedEvent, StreamingChatMessageStartEvent } from "@azure/communication-signaling";
 
 import { MessageType } from "./types/MessageType";
 import OmnichannelMessage from "../../core/messaging/OmnichannelMessage";
 import { OmnichannelMessagePrinter } from "./OmnichannelMessagePrinter";
 import { PollingMessagePrinter } from "./PollingMessagePrinter";
 import { PrintableMessage } from "./types/PrintableMessageType";
+import { StreamingMessagePrinter } from "./StreamingMessagePrinter";
 import { WebSocketMessagePrinter } from "./WebsocketMessagePrinter";
 
 export enum PrinterType {
     Polling = "Polling",
     WebSocket = "WebSocket",
+    Streaming = "Streaming",
     Omnichannel = "Rest"
 }
 
@@ -20,6 +23,8 @@ export class MessagePrinterFactory {
             return PollingMessagePrinter;
         case PrinterType.WebSocket:
             return WebSocketMessagePrinter;
+        case PrinterType.Streaming:
+            return StreamingMessagePrinter;
         case PrinterType.Omnichannel:
             return OmnichannelMessagePrinter;
         default:
@@ -35,6 +40,10 @@ export class MessagePrinterFactory {
             return (printer as typeof PollingMessagePrinter).printify(message as ChatMessage);
         case PrinterType.WebSocket:
             return (printer as typeof WebSocketMessagePrinter).printify(message as ChatMessageReceivedEvent | ChatMessageEditedEvent);
+        case PrinterType.Streaming:
+            return (printer as typeof StreamingMessagePrinter).printify(
+                message as StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent
+            );
         case PrinterType.Omnichannel:
             return (printer as typeof OmnichannelMessagePrinter).printify(message as OmnichannelMessage);
         default:

--- a/src/utils/printers/StreamingMessagePrinter.ts
+++ b/src/utils/printers/StreamingMessagePrinter.ts
@@ -1,0 +1,33 @@
+import {
+    StreamingChatMessageChunkReceivedEvent,
+    StreamingChatMessageStartEvent,
+} from "@azure/communication-signaling";
+
+import { PrintableMessage } from "./types/PrintableMessageType";
+
+export class StreamingMessagePrinter {
+    static printify(
+        event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent
+    ): PrintableMessage {
+        const result: PrintableMessage = {} as PrintableMessage;
+        if (!event) {
+            return result;
+        }
+        result.id = event.id;
+        result.tags = event?.metadata?.tags ? event.metadata.tags.replace(/"/g, "").split(",").filter((tag: string) => tag.length > 0) : [];
+        result.bot = event?.metadata?.tags?.includes("public") ? false : true;
+        result.card = false;
+        // Privacy: never log raw streaming content. Stamp the byte length only.
+        result.content = event?.message ? `${event.message.length} chars` : "";
+        result.created = event.createdOn;
+        // Streaming-specific fields. PrintableMessage doesn't formally carry these
+        // today; the cast lets dashboards consume them as additional context.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result as any).streamingMessageType = event?.streamingMetadata?.streamingMessageType;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result as any).streamingSequenceNumber = event?.streamingMetadata?.streamingSequenceNumber;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result as any).streamEndReason = event?.streamingMetadata?.streamEndReason;
+        return result;
+    }
+}

--- a/src/utils/printers/types/MessageType.ts
+++ b/src/utils/printers/types/MessageType.ts
@@ -1,5 +1,14 @@
 import { ChatMessage, ChatMessageEditedEvent, ChatMessageReceivedEvent } from "@azure/communication-chat";
+import { StreamingChatMessageChunkReceivedEvent, StreamingChatMessageStartEvent } from "@azure/communication-signaling";
+
 import IMessage from "@microsoft/omnichannel-ic3core/lib/model/IMessage";
 import OmnichannelMessage from "../../../core/messaging/OmnichannelMessage";
 
-export type MessageType = OmnichannelMessage | ChatMessage | ChatMessageReceivedEvent | ChatMessageEditedEvent | IMessage;
+export type MessageType =
+    | OmnichannelMessage
+    | ChatMessage
+    | ChatMessageReceivedEvent
+    | ChatMessageEditedEvent
+    | StreamingChatMessageStartEvent
+    | StreamingChatMessageChunkReceivedEvent
+    | IMessage;


### PR DESCRIPTION
## Summary

Adds public `OmnichannelChatSDK.onStreamingMessage(callback)` API for ACS-driven streaming message chunks (start / informative / streaming / final lifecycle), enabling typing-style progressive UX in consumer apps.

- **Public API:** new `onStreamingMessage` method delivers `OmnichannelStreamingMessage` (extends `OmnichannelMessage`) per chunk with full assembled-so-far content, sequence number, and lifecycle phase. Optional `policyViolation` field surfaces ACS content moderation.
- **Backwards-compatible:** existing `onNewMessage` consumers continue to receive streaming-bot responses as a single complete message at completion (fire-through on `final`), no code changes required.
- **Dependency bumps required for ACS streaming events:**
  - `@azure/communication-chat`: 1.5.4 → 1.6.0-beta.7
  - `@azure/communication-common`: 2.3.1 → 2.4.0
  - `@microsoft/botframework-webchat-adapter-azure-communication-chat`: ^0.0.1-beta.6 → 0.0.1-beta.7

## What's in this PR

**Commit 1 (`feat`)** — SDK implementation:
- New types: `OmnichannelStreamingMessage`, `StreamingMetadata`, `PolicyViolation`, `OnStreamingMessageOptionalParams`
- Streaming subscription on `ACSConversation` (mirrors existing `registerOnNewMessage` pattern; cleanup via existing `trackListener` / `disconnect()` mechanism)
- `createOmnichannelStreamingMessage` converter with defensive normalization, per-message-id sequence counters with 256-stream LRU cap, finalized-message tracking, duplicate-final dedup, late-chunk-after-final handling, policy-violation passthrough
- Stateless `StreamingMessagePrinter` for telemetry-side payload conversion (`PrinterType.Streaming` wired into `MessagePrinterFactory`)
- New `ChatSDKErrorName` entries: `UninitializedConversation`, `StreamingSubscriptionFailure`
- New `TelemetryEvent` entries for scenario tracking and per-chunk observability; new `MessageSource.WebSocketStreaming`
- Adapter package version stamped into telemetry context (`ACSAdapter` / `ACSAdapterVersion` fields) for production debugging
- 23 new unit tests (10 converter + 3 printer + 6 ACSConversation + 4 SDK), 585 total passing across 33 suites
- README "On Streaming Message" section + CHANGELOG entry

**Commit 2 (`test`)** — E2E playwright spec scaffolds for streaming, intentionally `test.skip()`'d pending a streaming-capable test bot:
- `streaming-happy-path`, `streaming-no-handler` (lazy opt-in verification), `streaming-disconnect-recovery`, `streaming-with-adapter` (dual-subscription verification)

**Commit 3 (`feat(samples)`)** — `samples/streaming-react/`: React + Webpack 5 + TypeScript demo app for testing the streaming API against any Microsoft Contact Center tenant. Multi-customer mode where customers paste their widget snippet at runtime; localStorage persistence; CORS-friendly error handling; deployable to Azure Static Web Apps.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build:tsc` passes
- [x] `npm test` — 585/585 across 33 suites
- [x] Sample app `npm run typecheck` and `npm run build` pass
- [x] Sample app dev server starts and renders setup screen against the new SDK
- [x] Pre-merge code review (general PR review + silent-failure audit) — high/medium severity findings addressed in this branch
- [ ] **Pending end-to-end verification** — confirm the backwards-compat fire-through works as designed against a real streaming-capable bot (see open question below)
- [ ] **Pending runtime verification** — confirm the two resolved versions of `@azure/communication-chat` in `node_modules` (1.6.0-beta.7 top-level + 1.6.0-beta.5 nested under adapter) don't cause `instanceof` issues at runtime
- [ ] LiveChatWidget / chat-widget consumer impact assessment for `channelData.streamType` activities

## Open question for reviewers

**Backwards-compat fire-through assumption.** When a streaming `final` chunk arrives, `ACSConversation.registerOnStreamingMessage` invokes the registered `chatMessageReceived` listeners with the chunk event so existing `onNewMessage` consumers see the assembled message at completion. This assumes ACS does NOT also fire `chatMessageReceived` for streaming messages (only the `streamingChat*` events). If this assumption is incorrect under any ACS configuration, the fire-through would cause duplicate `onNewMessage` invocations and we'd need to add dedup tracking. The assumption is documented in the code comment at `ACSClient.ts` and should be empirically verified against a streaming bot before merging to a release branch.

## Why draft

Pending the empirical verification items above. Functionally complete and tests green; opening as draft so the team can review the API surface, error handling, and architecture choices in parallel.