### PR TITLE
docs: add JSDoc comments and availability date for read receipt APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added `getUnreadMessageCount` public method to fetch unread message count for authenticated users (auth-only, pre-session badge use case)
-- Added `sendReadReceipt` public method to mark messages as read (authenticated: via MRT, unauthenticated: via ACS directly)
+- Added `getUnreadMessageCount` public method to fetch unread message count for authenticated users (auth-only, pre-session badge use case). Available after 05/22/2026.
+- Added `sendReadReceipt` public method to mark messages as read (authenticated: via MRT, unauthenticated: via ACS directly). Available after 05/22/2026.
+- Added JSDoc documentation for `getUnreadMessageCount` and `sendReadReceipt` public APIs
 - Added `sendReadReceipt` to `ACSClient` for direct ACS read receipt delivery (unauthenticated path)
 - Added `GetUnreadMessageCount` and `SendReadReceipt` telemetry events
 - Added `SendReadReceiptFailure`, `SendReadReceiptInvalidParams`, `UnreadMessageCountRetrievalFailure` to `ChatSDKErrorName` enum

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1792,6 +1792,12 @@ class OmnichannelChatSDK {
     /**
      * Fetches unread message count for the authenticated user.
      * Auth-only — does not require an active chat session.
+     *
+     * Available after 05/22/2026.
+     *
+     * @returns Object containing the unread message count
+     * @example
+     * const result = await chatSDK.getUnreadMessageCount();
      */
     public async getUnreadMessageCount(): Promise<object> {
         const telemetryData = {
@@ -1834,6 +1840,12 @@ class OmnichannelChatSDK {
      * Sends a read receipt for a specific message.
      * Authenticated: calls MRT (updates NRD + forwards to ACS).
      * Unauthenticated: calls ACS directly.
+     *
+     * Available after 05/22/2026.
+     *
+     * @param messageId - The ID of the message to mark as read
+     * @example
+     * await chatSDK.sendReadReceipt(message.id);
      */
     public async sendReadReceipt(messageId: string): Promise<void> {
         const telemetryData = {


### PR DESCRIPTION
# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference

### Description

Add JSDoc documentation with @param, @returns, @example tags and "Available after 05/22/2026" notice to getUnreadMessageCount and sendReadReceipt public APIs. Update CHANGELOG accordingly.

## Solution Proposed

_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
