### PR TITLE
Update @microsoft/ocsdk to 0.5.22-main.4367917

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@azure/communication-chat": "1.5.4",
         "@azure/communication-common": "2.3.1",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.8",
-        "@microsoft/ocsdk": "0.5.22-main.8dbdcd5",
+        "@microsoft/ocsdk": "0.5.22-main.4367917",
         "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
       },
@@ -1531,9 +1531,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.5.22-main.8dbdcd5",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.22-main.8dbdcd5.tgz",
-      "integrity": "sha512-nVy89H6eC4Ch/PZzL48cEgcE8Gnj4N9eTpiwK+qJ6wGqd2ZqRn4r9SmRWFCzllmyJxCVuWchs4DoEc3MUDnsEg==",
+      "version": "0.5.22-main.4367917",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.5.22-main.4367917.tgz",
+      "integrity": "sha512-Z5xZmtp9h8zbgtvLXuwi3otIJnq+XTW31wjW5se8HcBYc9qeb2PNGKAP8pjFhgZqA6/HQkQ1kEEWFPs+C7pJcQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.10",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@azure/communication-chat": "1.5.4",
     "@azure/communication-common": "2.3.1",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.8",
-    "@microsoft/ocsdk": "0.5.22-main.8dbdcd5",
+    "@microsoft/ocsdk": "0.5.22-main.4367917",
     "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   },


### PR DESCRIPTION
## Summary
  Update @microsoft/ocsdk dependency to version 0.5.22-main.4367917

  ## Changes
  - Updated @microsoft/ocsdk from 0.5.22-main.8dbdcd5 to 0.5.22-main.4367917
  - Resolved merge conflicts with upstream changes (beta.8 adapter update)
  - Regenerated package-lock.json

  ## Testing
  - ✅ Build: TypeScript compilation successful
  - ✅ Tests: All 586 tests passing (31 test suites)
  - ✅ Lint: ESLint validation passed

  ## Related
  - ocsdk package: https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.22-main.4367917
  
  ADO #6383438
