### PR TITLE
feat(streaming): add ACS streaming message support with onStreamingMessage API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added `onStreamingMessage` public API for progressive bot message rendering via ACS streaming
+- Added `OmnichannelStreamingMessage`, `StreamingMetadata`, `PolicyViolation`, `OnStreamingMessageOptionalParams` exported types
+- Added streaming message telemetry events: `StreamingMessageReceived`, `StreamingDuplicateFinal`, `StreamingChunkNoContent`, `StreamingChunkAfterFinal`, `StreamingPolicyViolation`, `StreamingMetadataMissingType`, `StreamingFinalMissingReason`, `StreamingCounterEvicted`, `StreamingHandlerThrew`, `StreamingHandlerAsyncRejected`
+- Added `StreamingMessagePrinter` for structured telemetry logging of streaming events
+- Added duplicate final detection and LRU-bounded sequence counter management in `createOmnichannelStreamingMessage`
+
+### Fixed
+
+- Fixed streaming final messages not delivered to `onStreamingMessage` when ACS sends them as `chatMessageReceived` (event 200) instead of `streamingChatMessageChunkReceived` (event 251)
+- Fixed `streamingMessageType` never being `"start"` — ACS sends `"streaming"` for start events; SDK now overrides to `"start"` based on event name
+- Backward compatibility: `onNewMessage` always fires for the final complete message alongside `onStreamingMessage`, ensuring existing consumers are unaffected
+
+### Added
+
 - Added `getUnreadMessageCount` public method to fetch unread message count for authenticated users (auth-only, pre-session badge use case)
 - Added `sendReadReceipt` public method to mark messages as read (authenticated: via MRT, unauthenticated: via ACS directly)
 - Added `sendReadReceipt` to `ACSClient` for direct ACS read receipt delivery (unauthenticated path)

--- a/__tests__/OmnichannelChatSDK.streaming.spec.ts
+++ b/__tests__/OmnichannelChatSDK.streaming.spec.ts
@@ -1,0 +1,277 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const OmnichannelChatSDK = require('../src/OmnichannelChatSDK').default;
+
+import LiveChatVersion from "../src/core/LiveChatVersion";
+import { AWTLogManager } from "../src/external/aria/webjs/AriaSDK";
+
+describe('OmnichannelChatSDK - Streaming', () => {
+    AWTLogManager.initialize = jest.fn();
+
+    const omnichannelConfig = {
+        orgUrl: '[data-org-url]',
+        orgId: '[data-org-id]',
+        widgetId: '[data-app-id]'
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('onStreamingMessage()', () => {
+        it('should call conversation.registerOnStreamingMessage()', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient = {
+                sessionInit: jest.fn(),
+                createConversation: jest.fn()
+            };
+
+            chatSDK.AMSClient = {
+                initialize: jest.fn()
+            };
+
+            jest.spyOn(chatSDK.ACSClient, 'initialize').mockResolvedValue(Promise.resolve());
+            jest.spyOn(chatSDK.ACSClient, 'joinConversation').mockResolvedValue(Promise.resolve({
+                registerOnNewMessage: jest.fn(),
+                registerOnStreamingMessage: jest.fn()
+            }));
+
+            await chatSDK.startChat();
+
+            const callback = jest.fn();
+            await chatSDK.onStreamingMessage(callback);
+
+            expect(chatSDK.conversation.registerOnStreamingMessage).toHaveBeenCalledTimes(1);
+            expect(chatSDK.conversation.registerOnStreamingMessage.mock.calls[0][0]).toBe(callback);
+        });
+
+        it('should throw if chat is not started (no conversation)', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            // Force V2 but don't start chat
+            chatSDK.liveChatVersion = LiveChatVersion.V2;
+
+            try {
+                await chatSDK.onStreamingMessage(() => {});
+                throw new Error('Expected to throw');
+            } catch (error: any) {
+                expect(error.message).toContain('UninitializedConversation');
+            }
+        });
+
+        it('should throw if liveChatVersion is not V2', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            // Force V1
+            chatSDK.liveChatVersion = LiveChatVersion.V1;
+            chatSDK.conversation = { registerOnStreamingMessage: jest.fn() };
+
+            try {
+                await chatSDK.onStreamingMessage(() => {});
+                throw new Error('Expected to throw');
+            } catch (error: any) {
+                expect(error.message).toContain('UnsupportedLiveChatVersion');
+            }
+        });
+    });
+
+    describe('supportsLcwStreaming flag in startChat', () => {
+        const setupForStartChat = async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            const chatToken = {
+                ChatId: 'ChatId',
+                Token: 'Token',
+                RegionGtms: '{}'
+            };
+            jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve(chatToken));
+            jest.spyOn(chatSDK.OCClient, 'sessionInit').mockResolvedValue(Promise.resolve());
+            jest.spyOn(chatSDK.OCClient, 'createConversation').mockResolvedValue(Promise.resolve(chatToken));
+
+            return chatSDK;
+        };
+
+        it('should inject supportsLcwStreaming into customContextData when flag is true', async () => {
+            const chatSDK = await setupForStartChat();
+
+            await chatSDK.startChat({ supportsLcwStreaming: true });
+
+            // createConversation is the default path (sessionInit only when useCreateConversation.disable)
+            expect(chatSDK.OCClient.createConversation).toHaveBeenCalledTimes(1);
+            const requestOptionalParams = chatSDK.OCClient.createConversation.mock.calls[0][1];
+            const customContextData = requestOptionalParams.initContext.customContextData;
+
+            expect(customContextData).toBeDefined();
+            expect(customContextData.supportsLcwStreaming).toEqual({
+                value: "true",
+                isDisplayable: false
+            });
+        });
+
+        it('should inject supportsLcwStreaming as "false" when flag is explicitly false', async () => {
+            const chatSDK = await setupForStartChat();
+
+            await chatSDK.startChat({ supportsLcwStreaming: false });
+
+            const requestOptionalParams = chatSDK.OCClient.createConversation.mock.calls[0][1];
+            const customContextData = requestOptionalParams.initContext.customContextData;
+
+            expect(customContextData).toBeDefined();
+            expect(customContextData.supportsLcwStreaming).toEqual({
+                value: "false",
+                isDisplayable: false
+            });
+        });
+
+        it('should NOT inject supportsLcwStreaming when flag is omitted', async () => {
+            const chatSDK = await setupForStartChat();
+
+            await chatSDK.startChat();
+
+            const requestOptionalParams = chatSDK.OCClient.createConversation.mock.calls[0][1];
+            const customContextData = requestOptionalParams?.initContext?.customContextData;
+
+            // Should not have supportsLcwStreaming at all
+            if (customContextData) {
+                expect(customContextData.supportsLcwStreaming).toBeUndefined();
+            }
+        });
+
+        it('should preserve existing customContext when adding supportsLcwStreaming', async () => {
+            const chatSDK = await setupForStartChat();
+
+            await chatSDK.startChat({
+                customContext: {
+                    myKey: { value: "myValue", isDisplayable: true }
+                },
+                supportsLcwStreaming: true
+            });
+
+            const requestOptionalParams = chatSDK.OCClient.createConversation.mock.calls[0][1];
+            const customContextData = requestOptionalParams.initContext.customContextData;
+
+            // Custom context should still be present
+            expect(customContextData.myKey).toEqual({ value: "myValue", isDisplayable: true });
+            // And supportsLcwStreaming should also be there
+            expect(customContextData.supportsLcwStreaming).toEqual({
+                value: "true",
+                isDisplayable: false
+            });
+        });
+
+        it('should survive initContext override — supportsLcwStreaming injected after initContext', async () => {
+            const chatSDK = await setupForStartChat();
+
+            await chatSDK.startChat({
+                initContext: {
+                    locale: "en-US",
+                    os: "Windows",
+                },
+                supportsLcwStreaming: true
+            });
+
+            const requestOptionalParams = chatSDK.OCClient.createConversation.mock.calls[0][1];
+            const customContextData = requestOptionalParams.initContext.customContextData;
+
+            // initContext override should be preserved
+            expect(requestOptionalParams.initContext.locale).toBe("en-US");
+            expect(requestOptionalParams.initContext.os).toBe("Windows");
+            // supportsLcwStreaming should still be injected despite initContext override
+            expect(customContextData).toBeDefined();
+            expect(customContextData.supportsLcwStreaming).toEqual({
+                value: "true",
+                isDisplayable: false
+            });
+        });
+    });
+
+    describe('backward compatibility', () => {
+        it('onNewMessage still works without onStreamingMessage registered', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK.getChatToken = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            chatSDK.OCClient = {
+                sessionInit: jest.fn(),
+                createConversation: jest.fn()
+            };
+
+            chatSDK.AMSClient = {
+                initialize: jest.fn()
+            };
+
+            const registerOnNewMessageMock = jest.fn();
+            jest.spyOn(chatSDK.ACSClient, 'initialize').mockResolvedValue(Promise.resolve());
+            jest.spyOn(chatSDK.ACSClient, 'joinConversation').mockResolvedValue(Promise.resolve({
+                registerOnNewMessage: registerOnNewMessageMock,
+                registerOnStreamingMessage: jest.fn()
+            }));
+
+            await chatSDK.startChat();
+            await chatSDK.onNewMessage(() => {});
+
+            expect(registerOnNewMessageMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('startChat without supportsLcwStreaming does not affect session init', async () => {
+            const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
+            chatSDK.getChatConfig = jest.fn();
+            chatSDK["isAMSClientAllowed"] = true;
+
+            await chatSDK.initialize();
+
+            chatSDK.ACSClient.initialize = jest.fn();
+            chatSDK.ACSClient.joinConversation = jest.fn();
+            chatSDK.AMSClient.initialize = jest.fn();
+
+            const chatToken = {
+                ChatId: 'ChatId',
+                Token: 'Token',
+                RegionGtms: '{}'
+            };
+            jest.spyOn(chatSDK.OCClient, 'getChatToken').mockResolvedValue(Promise.resolve(chatToken));
+            jest.spyOn(chatSDK.OCClient, 'sessionInit').mockResolvedValue(Promise.resolve());
+            jest.spyOn(chatSDK.OCClient, 'createConversation').mockResolvedValue(Promise.resolve(chatToken));
+
+            await chatSDK.startChat();
+
+            // createConversation should be called normally
+            expect(chatSDK.OCClient.createConversation).toHaveBeenCalledTimes(1);
+            const requestOptionalParams = chatSDK.OCClient.createConversation.mock.calls[0][1];
+
+            // No streaming-related data in the request
+            const customContextData = requestOptionalParams?.initContext?.customContextData;
+            if (customContextData) {
+                expect(customContextData.supportsLcwStreaming).toBeUndefined();
+            }
+        });
+    });
+});

--- a/__tests__/core/messaging/ACSClient.streaming.spec.ts
+++ b/__tests__/core/messaging/ACSClient.streaming.spec.ts
@@ -1,0 +1,309 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import ACSClient from "../../../src/core/messaging/ACSClient";
+
+jest.mock('@azure/communication-common');
+jest.mock('@azure/communication-chat');
+
+describe('ACSClient - Streaming', () => {
+    const createConversation = async () => {
+        const client: any = new ACSClient();
+        const config = { token: 'token', environmentUrl: 'url' };
+        await client.initialize(config);
+
+        const chatThreadClient: any = {};
+        chatThreadClient.listParticipants = jest.fn(() => ({
+            next: jest.fn(() => ({ value: 'value', done: jest.fn() })),
+        }));
+        chatThreadClient.listMessages = jest.fn(() => ({
+            next: jest.fn(() => ({ value: 'value', done: jest.fn() })),
+        }));
+
+        client.chatClient = {};
+        client.chatClient.getChatThreadClient = jest.fn(() => chatThreadClient);
+        client.chatClient.startRealtimeNotifications = jest.fn();
+        client.chatClient.on = jest.fn();
+
+        const conversation = await client.joinConversation({
+            id: 'id',
+            threadId: 'threadId',
+            pollingInterval: 1000,
+        });
+
+        return { client, conversation };
+    };
+
+    describe('registerOnStreamingMessage', () => {
+        it('should subscribe to streamingChatMessageStarted and streamingChatMessageChunkReceived events', async () => {
+            const { client, conversation } = await createConversation();
+
+            await conversation.registerOnStreamingMessage(() => {});
+
+            expect(client.chatClient.on).toHaveBeenCalledTimes(2);
+            expect(client.chatClient.on.mock.calls[0][0]).toEqual('streamingChatMessageStarted');
+            expect(client.chatClient.on.mock.calls[1][0]).toEqual('streamingChatMessageChunkReceived');
+        });
+
+        it('should store the callback reference for streaming final routing', async () => {
+            const { conversation } = await createConversation();
+            const callback = jest.fn();
+
+            await conversation.registerOnStreamingMessage(callback);
+
+            expect(conversation['streamingMessageCallback']).toBe(callback);
+        });
+
+        it('should invoke callback when a start event fires', async () => {
+            const { client, conversation } = await createConversation();
+            const callback = jest.fn();
+
+            await conversation.registerOnStreamingMessage(callback);
+
+            // Get the onStart handler that was registered
+            const onStart = client.chatClient.on.mock.calls[0][1];
+
+            const fakeStartEvent = {
+                id: 'msg-1',
+                message: 'Hello',
+                sender: { communicationUserId: 'bot', kind: 'communicationUser' },
+                senderDisplayName: 'Bot',
+                createdOn: new Date(),
+                editedOn: new Date(),
+                threadId: 'thread-1',
+                recipient: { communicationUserId: 'user', kind: 'communicationUser' },
+                type: 'text',
+                version: '1',
+                metadata: {},
+                streamingMetadata: {
+                    streamingMessageType: 'streaming', // ACS sends 'streaming' even for start
+                    streamingSequenceNumber: 1,
+                },
+            };
+
+            onStart(fakeStartEvent);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            const msg = callback.mock.calls[0][0];
+            expect(msg.streamingMetadata.streamingMessageType).toBe('start');
+            expect(msg.content).toBe('Hello');
+        });
+
+        it('should invoke callback when a chunk event fires', async () => {
+            const { client, conversation } = await createConversation();
+            const callback = jest.fn();
+
+            await conversation.registerOnStreamingMessage(callback);
+
+            const onChunk = client.chatClient.on.mock.calls[1][1];
+
+            const fakeChunkEvent = {
+                id: 'msg-1',
+                message: 'Hello world',
+                sender: { communicationUserId: 'bot', kind: 'communicationUser' },
+                senderDisplayName: 'Bot',
+                createdOn: new Date(),
+                editedOn: new Date(),
+                threadId: 'thread-1',
+                recipient: { communicationUserId: 'user', kind: 'communicationUser' },
+                type: 'text',
+                version: '1',
+                metadata: {},
+                streamingMetadata: {
+                    streamingMessageType: 'streaming',
+                    streamingSequenceNumber: 2,
+                },
+            };
+
+            onChunk(fakeChunkEvent);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            const msg = callback.mock.calls[0][0];
+            expect(msg.streamingMetadata.streamingMessageType).toBe('streaming');
+        });
+
+        it('should fire-through to chatMessageReceived listeners on final', async () => {
+            const { client, conversation } = await createConversation();
+            const streamCallback = jest.fn();
+            const newMessageCallback = jest.fn();
+
+            // Register onNewMessage first (which subscribes to chatMessageReceived)
+            conversation.keepPolling = true;
+            jest.spyOn(conversation, 'getMessages').mockResolvedValue([{ id: 'id', sender: { displayName: 'name' } }]);
+            (global as any).setTimeout = jest.fn();
+            await conversation.registerOnNewMessage(newMessageCallback);
+
+            // Now register streaming
+            await conversation.registerOnStreamingMessage(streamCallback);
+
+            const onChunk = client.chatClient.on.mock.calls.find(
+                (call: any) => call[0] === 'streamingChatMessageChunkReceived'
+            )[1];
+
+            const fakeFinalEvent = {
+                id: 'msg-final',
+                message: 'Complete message',
+                sender: { communicationUserId: 'bot', kind: 'communicationUser' },
+                senderDisplayName: 'Bot',
+                createdOn: new Date(),
+                editedOn: new Date(),
+                threadId: 'thread-1',
+                recipient: { communicationUserId: 'user', kind: 'communicationUser' },
+                type: 'text',
+                version: '1',
+                metadata: {},
+                streamingMetadata: {
+                    streamingMessageType: 'final',
+                    streamEndReason: 'completed',
+                    streamingSequenceNumber: 5,
+                },
+            };
+
+            onChunk(fakeFinalEvent);
+
+            // Streaming callback should be called
+            expect(streamCallback).toHaveBeenCalledTimes(1);
+            expect(streamCallback.mock.calls[0][0].streamingMetadata.streamingMessageType).toBe('final');
+
+            // Fire-through: newMessageCallback should also be called
+            expect(newMessageCallback).toHaveBeenCalledWith(fakeFinalEvent);
+        });
+
+        it('should not crash when callback throws synchronously', async () => {
+            const { client, conversation } = await createConversation();
+            const throwingCallback = jest.fn(() => { throw new Error('consumer error'); });
+
+            await conversation.registerOnStreamingMessage(throwingCallback);
+
+            const onStart = client.chatClient.on.mock.calls[0][1];
+
+            const fakeEvent = {
+                id: 'msg-1',
+                message: 'Hello',
+                sender: { communicationUserId: 'bot', kind: 'communicationUser' },
+                senderDisplayName: 'Bot',
+                createdOn: new Date(),
+                editedOn: new Date(),
+                threadId: 'thread-1',
+                recipient: { communicationUserId: 'user', kind: 'communicationUser' },
+                type: 'text',
+                version: '1',
+                metadata: {},
+                streamingMetadata: { streamingMessageType: 'streaming', streamingSequenceNumber: 1 },
+            };
+
+            // Should not throw — error is caught internally
+            expect(() => onStart(fakeEvent)).not.toThrow();
+        });
+
+        it('should deduplicate finals arriving on both chunk and chatMessageReceived', async () => {
+            const { client, conversation } = await createConversation();
+            const streamCallback = jest.fn();
+
+            // Register new message first
+            conversation.keepPolling = true;
+            jest.spyOn(conversation, 'getMessages').mockResolvedValue([{ id: 'id', sender: { displayName: 'name' } }]);
+            (global as any).setTimeout = jest.fn();
+            await conversation.registerOnNewMessage(() => {});
+
+            // Register streaming
+            await conversation.registerOnStreamingMessage(streamCallback);
+
+            const onChunk = client.chatClient.on.mock.calls.find(
+                (call: any) => call[0] === 'streamingChatMessageChunkReceived'
+            )[1];
+
+            const fakeFinalEvent = {
+                id: 'msg-dedup',
+                message: 'Final',
+                sender: { communicationUserId: 'bot', kind: 'communicationUser' },
+                senderDisplayName: 'Bot',
+                createdOn: new Date(),
+                editedOn: new Date(),
+                threadId: 'thread-1',
+                recipient: { communicationUserId: 'user', kind: 'communicationUser' },
+                type: 'text',
+                version: '1',
+                metadata: {},
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed', streamingSequenceNumber: 5 },
+            };
+
+            // First final via chunk event
+            onChunk(fakeFinalEvent);
+            expect(streamCallback).toHaveBeenCalledTimes(1);
+
+            // Second final via chatMessageReceived (simulate)
+            // The chatMessageReceived handler checks finalizedMessageIds
+            const chatMsgHandler = client.chatClient.on.mock.calls.find(
+                (call: any) => call[0] === 'chatMessageReceived'
+            )[1];
+
+            // Simulate the same message arriving on chatMessageReceived with streaming final metadata
+            chatMsgHandler(fakeFinalEvent);
+
+            // Should still only have been called once via the streaming path (duplicate detected)
+            expect(streamCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should remove previous listeners when registerOnStreamingMessage is called twice', async () => {
+            const { client, conversation } = await createConversation();
+            const callback1 = jest.fn();
+            const callback2 = jest.fn();
+
+            // First registration
+            await conversation.registerOnStreamingMessage(callback1);
+            expect(client.chatClient.on).toHaveBeenCalledTimes(2);
+
+            // Mock chatClient.off to track unsubscriptions
+            client.chatClient.off = jest.fn();
+
+            // Second registration — should clean up first
+            await conversation.registerOnStreamingMessage(callback2);
+
+            // Old listeners should have been removed
+            expect(client.chatClient.off).toHaveBeenCalledWith('streamingChatMessageStarted', expect.any(Function));
+            expect(client.chatClient.off).toHaveBeenCalledWith('streamingChatMessageChunkReceived', expect.any(Function));
+
+            // Callback reference should be updated to cb2
+            expect(conversation['streamingMessageCallback']).toBe(callback2);
+        });
+
+        it('should log telemetry when replacing streaming registration', async () => {
+            const { client, conversation } = await createConversation();
+            client.chatClient.off = jest.fn();
+            const logger = { startScenario: jest.fn(), completeScenario: jest.fn(), failScenario: jest.fn(), recordIndividualEvent: jest.fn() };
+            conversation['logger'] = logger;
+
+            await conversation.registerOnStreamingMessage(jest.fn());
+            await conversation.registerOnStreamingMessage(jest.fn());
+
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                'StreamingRegistrationReplaced',
+                expect.any(String),
+                expect.objectContaining({ reason: expect.stringContaining('already registered') })
+            );
+        });
+    });
+
+    describe('disconnect - streaming cleanup', () => {
+        it('should clear streaming state on disconnect', async () => {
+            const { client, conversation } = await createConversation();
+            const callback = jest.fn();
+
+            await conversation.registerOnStreamingMessage(callback);
+
+            // Simulate some streaming state
+            conversation['streamSequenceCounters'].set('msg-1', 5);
+            conversation['finalizedMessageIds'].add('msg-2');
+            expect(conversation['streamingMessageCallback']).toBe(callback);
+
+            // Mock off for disconnect listener cleanup
+            client.chatClient.off = jest.fn();
+            await conversation.disconnect();
+
+            expect(conversation['streamSequenceCounters'].size).toBe(0);
+            expect(conversation['finalizedMessageIds'].size).toBe(0);
+            expect(conversation['streamingMessageCallback']).toBeNull();
+        });
+    });
+});

--- a/__tests__/utils/createOmnichannelStreamingMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelStreamingMessage.spec.ts
@@ -1,0 +1,388 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import createOmnichannelStreamingMessage, { CreateOmnichannelStreamingMessageOptionalParams } from '../../src/utils/createOmnichannelStreamingMessage';
+import LiveChatVersion from '../../src/core/LiveChatVersion';
+
+const makeFakeEvent = (overrides: Record<string, any> = {}): any => ({
+    id: 'msg-1',
+    message: 'hello world',
+    sender: { communicationUserId: 'bot-id', kind: 'communicationUser' },
+    senderDisplayName: 'Bot',
+    createdOn: new Date('2026-01-01'),
+    editedOn: new Date('2026-01-01'),
+    threadId: 'thread-1',
+    recipient: { communicationUserId: 'user-id', kind: 'communicationUser' },
+    type: 'text',
+    version: '1',
+    streamingMetadata: {
+        streamingMessageType: 'streaming',
+        streamingSequenceNumber: 1,
+    },
+    metadata: {},
+    ...overrides,
+});
+
+const makeParams = (overrides: Partial<CreateOmnichannelStreamingMessageOptionalParams> = {}): CreateOmnichannelStreamingMessageOptionalParams => ({
+    liveChatVersion: LiveChatVersion.V2,
+    eventName: 'streamingChatMessageChunkReceived',
+    sequenceCounters: new Map(),
+    finalizedMessageIds: new Set(),
+    logger: null,
+    ...overrides,
+});
+
+describe('createOmnichannelStreamingMessage', () => {
+    describe('normalizeStreamingMetadata', () => {
+        it('should return "start" type when eventName is streamingChatMessageStarted regardless of ACS value', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'streaming', streamingSequenceNumber: 1 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageStarted' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.streamingMetadata.streamingMessageType).toBe('start');
+        });
+
+        it('should return "streaming" type for chunk events', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'streaming', streamingSequenceNumber: 2 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageChunkReceived' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.streamingMetadata.streamingMessageType).toBe('streaming');
+        });
+
+        it('should return "final" type for final chunk events', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed', streamingSequenceNumber: 5 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageChunkReceived' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.streamingMetadata.streamingMessageType).toBe('final');
+            expect(result!.streamingMetadata.streamEndReason).toBe('completed');
+        });
+
+        it('should fallback to "streaming" when streamingMessageType is undefined on chunk event', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingSequenceNumber: 3 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageChunkReceived' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.streamingMetadata.streamingMessageType).toBe('streaming');
+        });
+
+        it('should override to "start" even when ACS sends undefined on start event', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingSequenceNumber: 1 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageStarted' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.streamingMetadata.streamingMessageType).toBe('start');
+        });
+
+        it('should use ACS sequence number when provided', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'streaming', streamingSequenceNumber: 42 },
+            });
+            const params = makeParams();
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result!.streamingMetadata.streamingSequenceNumber).toBe(42);
+        });
+
+        it('should generate fallback sequence number when ACS does not provide one', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'streaming' },
+            });
+            const params = makeParams();
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result!.streamingMetadata.streamingSequenceNumber).toBe(1);
+
+            // Second call with same message ID should increment
+            const result2 = createOmnichannelStreamingMessage(event, params);
+            expect(result2!.streamingMetadata.streamingSequenceNumber).toBe(2);
+        });
+
+        it('should default streamEndReason to "completed" when final has no endReason', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'final', streamingSequenceNumber: 5 },
+            });
+            const params = makeParams();
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result!.streamingMetadata.streamEndReason).toBe('completed');
+        });
+    });
+
+    describe('duplicate final detection', () => {
+        it('should drop duplicate final for the same message ID', () => {
+            const finalizedMessageIds = new Set<string>();
+            const params = makeParams({ finalizedMessageIds });
+
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed', streamingSequenceNumber: 5 },
+            });
+
+            // First final should succeed
+            const result1 = createOmnichannelStreamingMessage(event, params);
+            expect(result1).toBeDefined();
+
+            // Second final with same ID should be dropped
+            const result2 = createOmnichannelStreamingMessage(event, params);
+            expect(result2).toBeUndefined();
+        });
+
+        it('should track finalized message IDs', () => {
+            const finalizedMessageIds = new Set<string>();
+            const params = makeParams({ finalizedMessageIds });
+
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed', streamingSequenceNumber: 5 },
+            });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            expect(finalizedMessageIds.has('msg-1')).toBe(true);
+        });
+
+        it('should clean up sequence counters on final', () => {
+            const sequenceCounters = new Map<string, number>();
+            sequenceCounters.set('msg-1', 4);
+            const params = makeParams({ sequenceCounters });
+
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed', streamingSequenceNumber: 5 },
+            });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            expect(sequenceCounters.has('msg-1')).toBe(false);
+        });
+    });
+
+    describe('message content', () => {
+        it('should set content from event.message', () => {
+            const event = makeFakeEvent({ message: 'chunk content here' });
+            const params = makeParams();
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result!.content).toBe('chunk content here');
+        });
+
+        it('should handle missing message content gracefully', () => {
+            const event = makeFakeEvent({ message: undefined });
+            const params = makeParams();
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.content).toBe('');
+        });
+    });
+
+    describe('policyViolation', () => {
+        it('should surface policyViolation when present', () => {
+            const event = makeFakeEvent({
+                policyViolation: { result: 'contentBlocked' },
+            });
+            const params = makeParams();
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result!.policyViolation).toEqual({ result: 'contentBlocked' });
+        });
+
+        it('should not include policyViolation when absent', () => {
+            const event = makeFakeEvent();
+            const params = makeParams();
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result!.policyViolation).toBeUndefined();
+        });
+    });
+
+    describe('telemetry logging', () => {
+        it('should log when streamingMessageType is missing', () => {
+            const logger = { recordIndividualEvent: jest.fn() };
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingSequenceNumber: 1 },
+            });
+            const params = makeParams({ logger, eventName: 'streamingChatMessageChunkReceived' });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                expect.stringContaining('MetadataMissingType'),
+                expect.any(String),
+                expect.objectContaining({ messageId: 'msg-1' })
+            );
+        });
+
+        it('should log when final is missing streamEndReason', () => {
+            const logger = { recordIndividualEvent: jest.fn() };
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'final', streamingSequenceNumber: 5 },
+            });
+            const params = makeParams({ logger });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                expect.stringContaining('FinalMissingReason'),
+                expect.any(String),
+                expect.objectContaining({ messageId: 'msg-1' })
+            );
+        });
+
+        it('should log when content is missing', () => {
+            const logger = { recordIndividualEvent: jest.fn() };
+            const event = makeFakeEvent({ message: undefined });
+            const params = makeParams({ logger });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                expect.stringContaining('ChunkNoContent'),
+                expect.any(String),
+                expect.objectContaining({ messageId: 'msg-1' })
+            );
+        });
+
+        it('should log duplicate final', () => {
+            const logger = { recordIndividualEvent: jest.fn() };
+            const finalizedMessageIds = new Set<string>();
+            const params = makeParams({ logger, finalizedMessageIds });
+
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed', streamingSequenceNumber: 5 },
+            });
+
+            createOmnichannelStreamingMessage(event, params);
+            createOmnichannelStreamingMessage(event, params);
+
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                expect.stringContaining('DuplicateFinal'),
+                expect.any(String),
+                expect.objectContaining({ messageId: 'msg-1' })
+            );
+        });
+
+        it('should log policyViolation when present', () => {
+            const logger = { recordIndividualEvent: jest.fn() };
+            const event = makeFakeEvent({
+                policyViolation: { result: 'warning' },
+            });
+            const params = makeParams({ logger });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                expect.stringContaining('PolicyViolation'),
+                expect.any(String),
+                expect.objectContaining({ messageId: 'msg-1', result: 'warning' })
+            );
+        });
+    });
+
+    describe('LRU sequence counter eviction', () => {
+        it('should evict oldest sequence counter when MAX_TRACKED_STREAMS is reached', () => {
+            const sequenceCounters = new Map<string, number>();
+            // Fill to 1000 entries
+            for (let i = 0; i < 1000; i++) {
+                sequenceCounters.set(`existing-${i}`, i);
+            }
+            const logger = { recordIndividualEvent: jest.fn() };
+            const params = makeParams({ sequenceCounters, logger });
+
+            const event = makeFakeEvent({
+                id: 'new-msg',
+                streamingMetadata: { streamingMessageType: 'streaming' },
+            });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            // Oldest entry should have been evicted
+            expect(sequenceCounters.has('existing-0')).toBe(false);
+            // New entry should exist
+            expect(sequenceCounters.has('new-msg')).toBe(true);
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                expect.stringContaining('CounterEvicted'),
+                expect.any(String),
+                expect.objectContaining({ evictedMessageId: 'existing-0' })
+            );
+        });
+    });
+
+    describe('LRU finalizedMessageIds eviction', () => {
+        it('should evict oldest finalized ID when MAX_TRACKED_STREAMS is reached', () => {
+            const finalizedMessageIds = new Set<string>();
+            // Fill to 1000 entries
+            for (let i = 0; i < 1000; i++) {
+                finalizedMessageIds.add(`finalized-${i}`);
+            }
+            const logger = { recordIndividualEvent: jest.fn() };
+            const params = makeParams({ finalizedMessageIds, logger });
+
+            // New message with final type
+            const event = makeFakeEvent({
+                id: 'new-final-msg',
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed' },
+            });
+
+            createOmnichannelStreamingMessage(event, params);
+
+            // Oldest entry should have been evicted
+            expect(finalizedMessageIds.has('finalized-0')).toBe(false);
+            // New entry should exist
+            expect(finalizedMessageIds.has('new-final-msg')).toBe(true);
+            // Size should still be 1000
+            expect(finalizedMessageIds.size).toBe(1000);
+            expect(logger.recordIndividualEvent).toHaveBeenCalledWith(
+                expect.stringContaining('FinalizedIdEvicted'),
+                expect.any(String),
+                expect.objectContaining({ evictedMessageId: 'finalized-0' })
+            );
+        });
+
+        it('should not evict when adding a duplicate final (already in set)', () => {
+            const finalizedMessageIds = new Set<string>();
+            for (let i = 0; i < 1000; i++) {
+                finalizedMessageIds.add(`finalized-${i}`);
+            }
+            const params = makeParams({ finalizedMessageIds });
+
+            // Duplicate final for existing ID — should be dropped before reaching eviction
+            const event = makeFakeEvent({
+                id: 'finalized-500',
+                streamingMetadata: { streamingMessageType: 'final', streamEndReason: 'completed' },
+            });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            // Should be dropped as duplicate
+            expect(result).toBeUndefined();
+            // Size unchanged
+            expect(finalizedMessageIds.size).toBe(1000);
+        });
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.11.9",
       "license": "MIT",
       "dependencies": {
-        "@azure/communication-chat": "1.5.4",
-        "@azure/communication-common": "2.3.1",
+        "@azure/communication-chat": "^1.6.0-beta.7",
+        "@azure/communication-common": "2.4.0",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.8",
         "@microsoft/ocsdk": "0.5.22-main.4367917",
         "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",
@@ -59,63 +59,51 @@
       }
     },
     "node_modules/@azure/communication-chat": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@azure/communication-chat/-/communication-chat-1.5.4.tgz",
-      "integrity": "sha512-sC5IACFEGgvGbt6qzL3kocdMbhuWkldkE0HHsUfRPokPKiK4IfVCpn2syJcc9R8ts6hk0N5XvEY04KM2yayhJg==",
+      "version": "1.6.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@azure/communication-chat/-/communication-chat-1.6.0-beta.7.tgz",
+      "integrity": "sha512-L/v6JbQLKkt2pdkgFBM0BLXl7b0MfaWsg2sfNWLb9kUucu0UUcIz9DuMtCtBx/dc54OXRpYQLhTgcU4rwVQjcg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/communication-common": "^2.3.1",
-        "@azure/communication-signaling": "1.0.0-beta.29",
-        "@azure/core-auth": "^1.3.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/communication-common": "^2.3.2-beta.1",
+        "@azure/communication-signaling": "1.0.0-beta.33",
+        "@azure/core-auth": "^1.9.0",
         "@azure/core-client": "^1.9.2",
         "@azure/core-paging": "^1.1.1",
-        "@azure/core-rest-pipeline": "^1.16.3",
+        "@azure/core-rest-pipeline": "^1.18.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "events": "^3.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/communication-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.3.1.tgz",
-      "integrity": "sha512-6ZQt20iMZbyckQn4m1TDwiDv3Fzyt1h4lnQ1szBBns2x3VQY9XHbnskPtvUdwK/HT+c/1PoUwof3toy1AIznbQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.4.0.tgz",
+      "integrity": "sha512-wwn4AoOgTgoA9OZkO34SKBpQg7/kfcABnzbaYEbc+9bCkBtwwjgMEk6xM+XLEE/uuODZ8q8jidUoNcZHQyP5AQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.3.2",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
-        "events": "^3.0.0",
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "events": "^3.3.0",
         "jwt-decode": "^4.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/communication-common/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@azure/communication-signaling": {
-      "version": "1.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.29.tgz",
-      "integrity": "sha512-bTNxJaS000wjtbLlH/nju3Off9uSybYeRVLvx1Y5k3ajb1rqVGUcsIduSEz1JBf+dRQx9pHRDCAEAXs/hOvzpg==",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.33.tgz",
+      "integrity": "sha512-WdCmwcK3Y2BHV8MVksXg7o6damflHLT1bOKNL14SftFbnuBLgmUM9Uw/HnkPWkpwrhptYC8jeCMv2XKhWmA4YQ==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
@@ -277,7 +265,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1477,26 +1464,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@microsoft/botframework-webchat-adapter-azure-communication-chat/node_modules/@azure/communication-common": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.4.0.tgz",
-      "integrity": "sha512-wwn4AoOgTgoA9OZkO34SKBpQg7/kfcABnzbaYEbc+9bCkBtwwjgMEk6xM+XLEE/uuODZ8q8jidUoNcZHQyP5AQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure-rest/core-client": "^2.3.3",
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-rest-pipeline": "^1.17.0",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "events": "^3.3.0",
-        "jwt-decode": "^4.0.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@microsoft/botframework-webchat-adapter-azure-communication-chat/node_modules/@azure/communication-signaling": {
       "version": "1.0.0-beta.32",
       "resolved": "https://registry.npmjs.org/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.32.tgz",
@@ -1797,7 +1764,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2024,7 +1990,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2388,7 +2353,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2988,7 +2952,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4027,7 +3990,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5867,7 +5829,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6051,7 +6012,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6146,6 +6106,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.5.4",
-    "@azure/communication-common": "2.3.1",
+    "@azure/communication-chat": "^1.6.0-beta.7",
+    "@azure/communication-common": "2.4.0",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.8",
     "@microsoft/ocsdk": "0.5.22-main.4367917",
     "@microsoft/omnichannel-amsclient": "0.1.14-main.9951e38",

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -84,7 +84,9 @@ import OmnichannelChatToken from "@microsoft/omnichannel-amsclient/lib/Omnichann
 import OmnichannelConfig from "./core/OmnichannelConfig";
 import OmnichannelErrorCodes from "./core/OmnichannelErrorCodes";
 import OmnichannelMessage from "./core/messaging/OmnichannelMessage";
+import OmnichannelStreamingMessage from "./core/messaging/OmnichannelStreamingMessage";
 import OnNewMessageOptionalParams from "./core/messaging/OnNewMessageOptionalParams";
+import OnStreamingMessageOptionalParams from "./core/messaging/OnStreamingMessageOptionalParams";
 import PersonType from "@microsoft/omnichannel-ic3core/lib/model/PersonType";
 import PluggableLogger from "@microsoft/omnichannel-amsclient/lib/PluggableLogger";
 import PostChatContext from "./core/PostChatContext";
@@ -1938,6 +1940,72 @@ class OmnichannelChatSDK {
         }
     }
 
+    /**
+     * Subscribes to ACS-driven streaming message chunks for progressive bot message rendering.
+     * Each chunk contains the full assembled text so far (not just the delta).
+     * Existing onNewMessage consumers continue receiving final messages without changes.
+     *
+     * Available only in LiveChatVersion.V2. Must call startChat() before registering.
+     *
+     * @param onStreamingMessageCallback - Called for each streaming chunk
+     * @param optionalParams - Reserved for future configuration
+     * @example
+     * chatSDK.onStreamingMessage((message) => {
+     *     switch (message.streamingMetadata.streamingMessageType) {
+     *         case "streaming": // Update bubble with message.content
+     *         case "final":     // Stream complete
+     *     }
+     * });
+     */
+    public async onStreamingMessage(
+        onStreamingMessageCallback: (message: OmnichannelStreamingMessage) => void,
+        optionalParams?: OnStreamingMessageOptionalParams
+    ): Promise<void> {
+        this.scenarioMarker.startScenario(TelemetryEvent.OnStreamingMessage, {
+            RequestId: this.requestId,
+            ChatId: this.chatToken?.chatId as string ?? ""
+        });
+
+        if (!this.isInitialized) {
+            exceptionThrowers.throwUninitializedChatSDK(this.scenarioMarker, TelemetryEvent.OnStreamingMessage);
+        }
+
+        try {
+            if (this.liveChatVersion !== LiveChatVersion.V2) {
+                throw new ChatSDKError(ChatSDKErrorName.UnsupportedLiveChatVersion);
+            }
+            if (!this.conversation) {
+                throw new ChatSDKError(ChatSDKErrorName.UninitializedConversation);
+            }
+
+            await (this.conversation as ACSConversation).registerOnStreamingMessage(
+                onStreamingMessageCallback,
+                optionalParams
+            );
+
+            this.scenarioMarker.completeScenario(TelemetryEvent.OnStreamingMessage, {
+                RequestId: this.requestId,
+                ChatId: this.chatToken?.chatId as string ?? ""
+            });
+        } catch (error) {
+            const wrappedError = (error instanceof ChatSDKError)
+                ? error
+                : new ChatSDKError(
+                    ChatSDKErrorName.StreamingSubscriptionFailure,
+                    undefined,
+                    { response: 'StreamingSubscriptionFailure', errorObject: `${error}` }
+                );
+
+            this.scenarioMarker.failScenario(TelemetryEvent.OnStreamingMessage, {
+                RequestId: this.requestId,
+                ChatId: this.chatToken?.chatId as string ?? "",
+                ExceptionDetails: JSON.stringify(wrappedError.exceptionDetails ?? wrappedError.message)
+            });
+
+            throw wrappedError;
+        }
+    }
+
     public async onAgentEndSession(onAgentEndSessionCallback: (message: IRawThread | ParticipantsRemovedEvent) => void): Promise<void> {
         this.scenarioMarker.startScenario(TelemetryEvent.OnAgentEndSession, {
             RequestId: this.requestId,
@@ -2768,6 +2836,24 @@ class OmnichannelChatSDK {
         // Override initContext completely
         if (optionalParams.initContext) {
             requestOptionalParams.initContext = optionalParams.initContext;
+        }
+
+        // Forward the widget's streaming-capability signal to the server via customContextData
+        // pass-through. Only inject when the caller explicitly provided the flag — omitting it
+        // preserves the legacy contract (server sees no signal → non-streaming behavior).
+        // The {value, isDisplayable} wrapper is the customContextData variable contract;
+        // isDisplayable: false marks this as an internal capability signal, not for agent UI.
+        // NOTE: This runs AFTER the initContext override to ensure the flag survives even when
+        // the consumer provides their own initContext.
+        const supportsLcwStreaming = (optionalParams as StartChatOptionalParams)?.supportsLcwStreaming;
+        if (supportsLcwStreaming !== undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ctx = ((requestOptionalParams.initContext! as any).customContextData ?? {}) as any;
+            ctx.supportsLcwStreaming = {
+                value: supportsLcwStreaming ? "true" : "false",
+                isDisplayable: false
+            };
+            (requestOptionalParams.initContext! as any).customContextData = ctx; // eslint-disable-line @typescript-eslint/no-explicit-any
         }
 
         if (this.authenticatedUserToken) {

--- a/src/core/ChatSDKError.ts
+++ b/src/core/ChatSDKError.ts
@@ -72,6 +72,11 @@ export enum ChatSDKErrorName {
     SendReadReceiptInvalidParams = "SendReadReceiptInvalidParams",
     /** Failure in retrieving unread message count */
     UnreadMessageCountRetrievalFailure = "UnreadMessageCountRetrievalFailure",
+
+    /** Streaming requires an active conversation; called before startChat() */
+    UninitializedConversation = "UninitializedConversation",
+    /** Failure to subscribe to ACS streaming events */
+    StreamingSubscriptionFailure = "StreamingSubscriptionFailure",
 }
 
 export class ChatSDKError {

--- a/src/core/StartChatOptionalParams.ts
+++ b/src/core/StartChatOptionalParams.ts
@@ -19,4 +19,14 @@ export default interface StartChatOptionalParams {
     portalContactId?: string;
     platform?: string;
     handle?: string;
+    /**
+     * Whether the caller (widget or app embedding the SDK) can handle LCW streaming —
+     * progressive ACS chat message chunks delivered to onStreamingMessage. When true,
+     * the server will stream bot responses; when false or omitted, the server sends
+     * regular non-streaming messages.
+     *
+     * Omitting this flag (or sending false) is the safe default for callers that have
+     * not been updated to render streaming chunks — server falls back to legacy behavior.
+     */
+    supportsLcwStreaming?: boolean;
 }

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -1,6 +1,6 @@
 import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from "@azure/communication-common";
 import { ChatClient, ChatMessage, ChatParticipant, ChatThreadClient } from "@azure/communication-chat";
-import { ChatMessageEditedEvent, ChatMessageReceivedEvent, ParticipantsRemovedEvent, TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
+import { ChatMessageEditedEvent, ChatMessageReceivedEvent, ParticipantsRemovedEvent, StreamingChatMessageChunkReceivedEvent, StreamingChatMessageStartEvent, TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
 import { MessagePrinterFactory, PrinterType } from "../../utils/printers/MessagePrinterFactory";
 
 import ACSChatMessageType from "./ACSChatMessageType";
@@ -15,8 +15,11 @@ import DeliveryMode from "@microsoft/omnichannel-ic3core/lib/model/DeliveryMode"
 import LiveChatVersion from "../LiveChatVersion";
 import { MessageSource } from "../../telemetry/MessageSource";
 import OmnichannelMessage from "./OmnichannelMessage";
+import OmnichannelStreamingMessage from "./OmnichannelStreamingMessage";
+import OnStreamingMessageOptionalParams from "./OnStreamingMessageOptionalParams";
 import TelemetryEvent from "../../telemetry/TelemetryEvent";
 import createOmnichannelMessage from "../../utils/createOmnichannelMessage";
+import createOmnichannelStreamingMessage from "../../utils/createOmnichannelStreamingMessage";
 import { defaultMessageTags } from "./MessageTags";
 
 enum ACSClientEvent {
@@ -24,6 +27,7 @@ enum ACSClientEvent {
     InitializeACSConversation = 'InitializeACSConversation',
     GetParticipants = 'GetParticipants',
     RegisterOnNewMessage = 'RegisterOnNewMessage',
+    RegisterOnStreamingMessage = 'RegisterOnStreamingMessage',
     RegisterOnThreadUpdate = 'RegisterOnThreadUpdate',
     OnTypingEvent = 'OnTypingEvent',
     GetMessages = 'GetMessages',
@@ -56,6 +60,9 @@ export class ACSConversation {
     private eventListeners: EventListenersMapping;
     private keepPolling = false;
     private pollingTimer: NodeJS.Timeout | number | null = null;
+    private streamSequenceCounters: Map<string, number> = new Map();
+    private finalizedMessageIds: Set<string> = new Set();
+    private streamingMessageCallback: ((message: OmnichannelStreamingMessage) => void) | null = null;
 
     constructor(tokenCredential: AzureCommunicationTokenCredential, chatClient: ChatClient, logger: ACSClientLogger | null = null) {
         this.logger = logger;
@@ -247,10 +254,51 @@ export class ACSConversation {
                     return;
                 }
 
+                // Route streaming finals that arrive on chatMessageReceived to the streaming callback.
+                // ACS may deliver the final streaming message as event 200 (chatMessageReceived) instead
+                // of event 251 (streamingChatMessageChunkReceived). Detect this by checking streamingMetadata.
+                const streamingType = (event as ChatMessageReceivedEvent).streamingMetadata?.streamingMessageType;
+                if (streamingType === 'final' && this.streamingMessageCallback) {
+                    try {
+                        const streamingMessage = createOmnichannelStreamingMessage(event as unknown as StreamingChatMessageChunkReceivedEvent, {
+                            liveChatVersion: LiveChatVersion.V2,
+                            eventName: 'streamingChatMessageChunkReceived',
+                            sequenceCounters: this.streamSequenceCounters,
+                            finalizedMessageIds: this.finalizedMessageIds,
+                            logger: this.logger,
+                        });
+                        if (streamingMessage) {
+                            this.streamingMessageCallback(streamingMessage);
+                            this.logger?.recordIndividualEvent(
+                                TelemetryEvent.StreamingMessageReceived,
+                                MessageSource.WebSocketStreaming,
+                                MessagePrinterFactory.printifyMessage(event, PrinterType.Streaming)
+                            );
+                        }
+                    } catch (err) {
+                        this.logger?.recordIndividualEvent(
+                            TelemetryEvent.StreamingHandlerThrew,
+                            MessageSource.WebSocketStreaming,
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            { messageId: event.id, error: `${err}`, source: 'chatMessageReceivedFinalRouting' } as any
+                        );
+                    }
+                } else if (streamingType && streamingType !== 'final') {
+                    // Unexpected: chatMessageReceived should only carry 'final' streaming metadata.
+                    // Log for observability but still deliver to onNewMessage below.
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingUnexpectedTypeOnNewMessage,
+                        MessageSource.WebSocketStreaming,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        { messageId: event.id, streamingType } as any
+                    );
+                }
+
                 // Filter out duplicate messages
                 if (postedMessageIds.has(id) && !isChatMessageEditedEvent) {
                     return;
                 }
+                // Always deliver to onNewMessage for backward compatibility
                 onNewMessageCallback(event);
                 postedMessageIds.add(id);
                 this.logger?.recordIndividualEvent(TelemetryEvent.MessageReceived, MessageSource.WebSocket, MessagePrinterFactory.printifyMessage(event, PrinterType.WebSocket));
@@ -271,6 +319,143 @@ export class ACSConversation {
             });
 
             throw new Error(ACSClientEvent.RegisterOnNewMessage);
+        }
+    }
+
+    public async registerOnStreamingMessage(
+        onStreamingMessageCallback: (message: OmnichannelStreamingMessage) => void,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        optionalParams: OnStreamingMessageOptionalParams = {}
+    ): Promise<void> {
+        this.logger?.startScenario(ACSClientEvent.RegisterOnStreamingMessage);
+
+        // Guard against duplicate registration — remove previous listeners before adding new ones.
+        // This prevents listener leaks if the consumer calls onStreamingMessage() multiple times.
+        if (this.streamingMessageCallback) {
+            this.logger?.recordIndividualEvent(
+                TelemetryEvent.StreamingRegistrationReplaced,
+                MessageSource.WebSocketStreaming,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                { reason: 'registerOnStreamingMessage called while already registered' } as any
+            );
+            const existingStartListeners = this.eventListeners['streamingChatMessageStarted'] ?? [];
+            const existingChunkListeners = this.eventListeners['streamingChatMessageChunkReceived'] ?? [];
+            for (const listener of existingStartListeners) {
+                this.chatClient?.off('streamingChatMessageStarted' as any, listener as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+            }
+            for (const listener of existingChunkListeners) {
+                this.chatClient?.off('streamingChatMessageChunkReceived' as any, listener as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+            }
+            this.eventListeners['streamingChatMessageStarted'] = [];
+            this.eventListeners['streamingChatMessageChunkReceived'] = [];
+        }
+
+        // Store reference so chatMessageReceived listener can route streaming finals
+        this.streamingMessageCallback = onStreamingMessageCallback;
+
+        try {
+            const invokeWithIsolation = (event: { id: string }, message: OmnichannelStreamingMessage) => {
+                const result = onStreamingMessageCallback(message) as unknown;
+                if (result && typeof (result as Promise<unknown>).catch === 'function') {
+                    (result as Promise<unknown>).catch((rejected: unknown) => {
+                        this.logger?.recordIndividualEvent(
+                            TelemetryEvent.StreamingHandlerAsyncRejected,
+                            MessageSource.WebSocketStreaming,
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            { messageId: event.id, error: `${rejected}` } as any
+                        );
+                    });
+                }
+            };
+
+            const onStart = (event: StreamingChatMessageStartEvent) => {
+                try {
+                    const message = createOmnichannelStreamingMessage(event, {
+                        liveChatVersion: LiveChatVersion.V2,
+                        eventName: 'streamingChatMessageStarted',
+                        sequenceCounters: this.streamSequenceCounters,
+                        finalizedMessageIds: this.finalizedMessageIds,
+                        logger: this.logger,
+                    });
+                    if (message === undefined) {
+                        return;
+                    }
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingMessageReceived,
+                        MessageSource.WebSocketStreaming,
+                        MessagePrinterFactory.printifyMessage(event, PrinterType.Streaming)
+                    );
+                    invokeWithIsolation(event, message);
+                } catch (err) {
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingHandlerThrew,
+                        MessageSource.WebSocketStreaming,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        { messageId: event.id, error: `${err}` } as any
+                    );
+                }
+            };
+
+            const onChunk = (event: StreamingChatMessageChunkReceivedEvent) => {
+                try {
+                    const message = createOmnichannelStreamingMessage(event, {
+                        liveChatVersion: LiveChatVersion.V2,
+                        eventName: 'streamingChatMessageChunkReceived',
+                        sequenceCounters: this.streamSequenceCounters,
+                        finalizedMessageIds: this.finalizedMessageIds,
+                        logger: this.logger,
+                    });
+                    if (message === undefined) {
+                        return;
+                    }
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingMessageReceived,
+                        MessageSource.WebSocketStreaming,
+                        MessagePrinterFactory.printifyMessage(event, PrinterType.Streaming)
+                    );
+                    invokeWithIsolation(event, message);
+
+                    // Backwards-compat fire-through: when a streaming message reaches
+                    // "final", also deliver it to chatMessageReceived listeners so
+                    // consumers using only onNewMessage still see the complete message.
+                    if (message.streamingMetadata.streamingMessageType === 'final') {
+                        const newMessageListeners = this.eventListeners['chatMessageReceived'] ?? [];
+                        for (const listener of newMessageListeners) {
+                            try {
+                                listener(event);
+                            } catch (err) {
+                                this.logger?.recordIndividualEvent(
+                                    TelemetryEvent.StreamingHandlerThrew,
+                                    MessageSource.WebSocketStreaming,
+                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                                    { messageId: event.id, error: `${err}`, source: 'newMessageFireThrough' } as any
+                                );
+                            }
+                        }
+                    }
+                } catch (err) {
+                    this.logger?.recordIndividualEvent(
+                        TelemetryEvent.StreamingHandlerThrew,
+                        MessageSource.WebSocketStreaming,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        { messageId: event.id, error: `${err}` } as any
+                    );
+                }
+            };
+
+            this.chatClient?.on('streamingChatMessageStarted', onStart);
+            this.chatClient?.on('streamingChatMessageChunkReceived', onChunk);
+            this.trackListener('streamingChatMessageStarted', onStart);
+            this.trackListener('streamingChatMessageChunkReceived', onChunk);
+
+            this.logger?.completeScenario(ACSClientEvent.RegisterOnStreamingMessage);
+        } catch (error) {
+            const exceptionDetails = { errorObject: `${error}` };
+            this.logger?.failScenario(ACSClientEvent.RegisterOnStreamingMessage, {
+                ExceptionDetails: JSON.stringify(exceptionDetails),
+            });
+
+            throw new Error(`${ACSClientEvent.RegisterOnStreamingMessage}: ${error}`);
         }
     }
 
@@ -439,6 +624,11 @@ export class ACSConversation {
             if (this.pollingTimer) {
                 clearTimeout(this.pollingTimer as number);
             }
+
+            // Clear streaming state to prevent memory leaks across sessions
+            this.streamSequenceCounters.clear();
+            this.finalizedMessageIds.clear();
+            this.streamingMessageCallback = null;
 
             this.logger?.completeScenario(ACSClientEvent.Disconnect);
         } catch {

--- a/src/core/messaging/OmnichannelStreamingMessage.ts
+++ b/src/core/messaging/OmnichannelStreamingMessage.ts
@@ -1,0 +1,15 @@
+import OmnichannelMessage from "./OmnichannelMessage";
+import PolicyViolation from "./PolicyViolation";
+import StreamingMetadata from "./StreamingMetadata";
+
+/**
+ * Streaming message chunk delivered through chatSDK.onStreamingMessage.
+ * Extends OmnichannelMessage with required streamingMetadata; policyViolation
+ * is optional and only present when ACS moderation flagged the chunk.
+ */
+export interface OmnichannelStreamingMessage extends OmnichannelMessage {
+    streamingMetadata: StreamingMetadata;
+    policyViolation?: PolicyViolation;
+}
+
+export default OmnichannelStreamingMessage;

--- a/src/core/messaging/OnStreamingMessageOptionalParams.ts
+++ b/src/core/messaging/OnStreamingMessageOptionalParams.ts
@@ -1,0 +1,10 @@
+/**
+ * Reserved for future per-handler streaming configuration. Currently empty.
+ * Defined as a named type so adding fields later does not require changing
+ * the public method signature on OmnichannelChatSDK or ACSConversation.
+ */
+export interface OnStreamingMessageOptionalParams {
+    // Intentionally empty. Add fields when concrete need surfaces.
+}
+
+export default OnStreamingMessageOptionalParams;

--- a/src/core/messaging/PolicyViolation.ts
+++ b/src/core/messaging/PolicyViolation.ts
@@ -1,0 +1,9 @@
+/**
+ * ACS content moderation result. Surfaces on streaming chunks when a
+ * server-side moderation policy has flagged the content.
+ */
+export interface PolicyViolation {
+    result: "contentBlocked" | "warning";
+}
+
+export default PolicyViolation;

--- a/src/core/messaging/StreamingMetadata.ts
+++ b/src/core/messaging/StreamingMetadata.ts
@@ -1,0 +1,12 @@
+/**
+ * Metadata describing a streaming message's lifecycle position.
+ * Mirrors ACS's StreamingMessageMetadata, with all fields required after
+ * SDK-side normalization in createOmnichannelStreamingMessage.
+ */
+export interface StreamingMetadata {
+    streamingMessageType: "start" | "informative" | "streaming" | "final";
+    streamingSequenceNumber: number;
+    streamEndReason?: "completed" | "expired" | "canceled";
+}
+
+export default StreamingMetadata;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ import IRawMessage from "@microsoft/omnichannel-ic3core/lib/model/IRawMessage";
 import MessageContentType from "@microsoft/omnichannel-ic3core/lib/model/MessageContentType";
 import MessageType from "@microsoft/omnichannel-ic3core/lib/model/MessageType";
 import OmnichannelChatSDK from "./OmnichannelChatSDK";
+import OmnichannelStreamingMessage from "./core/messaging/OmnichannelStreamingMessage";
+import OnStreamingMessageOptionalParams from "./core/messaging/OnStreamingMessageOptionalParams";
 import PersonType from "@microsoft/omnichannel-ic3core/lib/model/PersonType";
+import PolicyViolation from "./core/messaging/PolicyViolation";
+import StreamingMetadata from "./core/messaging/StreamingMetadata";
 
 export {
     OmnichannelChatSDK,
@@ -57,6 +61,10 @@ export {
     UploadFileAttachmentResponse,
     GetMessagesResponse,
     GetCurrentLiveChatContextResponse,
+    OmnichannelStreamingMessage,
+    OnStreamingMessageOptionalParams,
+    PolicyViolation,
+    StreamingMetadata,
 }
 
 export default {

--- a/src/telemetry/MessageSource.ts
+++ b/src/telemetry/MessageSource.ts
@@ -1,5 +1,6 @@
 export enum MessageSource {
     Polling = "Poll",
     WebSocket = "WS",
+    WebSocketStreaming = "WSStream",
     GetRestCall = "Get"
 }

--- a/src/telemetry/TelemetryEvent.ts
+++ b/src/telemetry/TelemetryEvent.ts
@@ -51,6 +51,28 @@ enum TelemetryEvent {
     MidConversationAuth = "MidConversationAuth",
     GetUnreadMessageCount = "GetUnreadMessageCount",
     SendReadReceipt = "SendReadReceipt",
+
+    // ACS streaming
+    OnStreamingMessage = "OnStreamingMessage",
+    StreamingMessageReceived = "StreamingMessageReceived",
+    StreamingMessageStarted = "StreamingMessageStarted",
+    StreamingMessageEnded = "StreamingMessageEnded",
+    StreamingEndedExpired = "StreamingEndedExpired",
+    StreamingEndedCanceled = "StreamingEndedCanceled",
+    StreamingDisconnect = "StreamingDisconnect",
+    StreamingHandlerThrew = "StreamingHandlerThrew",
+    StreamingHandlerAsyncRejected = "StreamingHandlerAsyncRejected",
+    StreamingMetadataMissingType = "StreamingMetadataMissingType",
+    StreamingFinalMissingReason = "StreamingFinalMissingReason",
+    StreamingChunkNoContent = "StreamingChunkNoContent",
+    StreamingDuplicateFinal = "StreamingDuplicateFinal",
+    StreamingChunkAfterFinal = "StreamingChunkAfterFinal",
+    StreamingCounterEvicted = "StreamingCounterEvicted",
+    StreamingFinalizedIdEvicted = "StreamingFinalizedIdEvicted",
+    StreamingRegistrationReplaced = "StreamingRegistrationReplaced",
+    StreamingUnexpectedTypeOnNewMessage = "StreamingUnexpectedTypeOnNewMessage",
+    StreamingSubscriptionFailed = "StreamingSubscriptionFailed",
+    StreamingPolicyViolation = "StreamingPolicyViolation",
 }
 
 export default TelemetryEvent;

--- a/src/utils/createOmnichannelStreamingMessage.ts
+++ b/src/utils/createOmnichannelStreamingMessage.ts
@@ -1,0 +1,168 @@
+import {
+    StreamingChatMessageChunkReceivedEvent,
+    StreamingChatMessageStartEvent,
+} from '@azure/communication-signaling';
+
+import LiveChatVersion from '../core/LiveChatVersion';
+import OmnichannelStreamingMessage from '../core/messaging/OmnichannelStreamingMessage';
+import StreamingMetadata from '../core/messaging/StreamingMetadata';
+import TelemetryEvent from '../telemetry/TelemetryEvent';
+import { MessageSource } from '../telemetry/MessageSource';
+import createOmnichannelMessage from './createOmnichannelMessage';
+
+const MAX_TRACKED_STREAMS = 1000;
+
+export interface CreateOmnichannelStreamingMessageOptionalParams {
+    liveChatVersion: LiveChatVersion;
+    eventName: 'streamingChatMessageStarted' | 'streamingChatMessageChunkReceived';
+    sequenceCounters: Map<string, number>;
+    finalizedMessageIds: Set<string>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logger: { recordIndividualEvent: (event: string, source: string, props: any) => void } | null;
+}
+
+const createOmnichannelStreamingMessage = (
+    event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent,
+    params: CreateOmnichannelStreamingMessageOptionalParams
+): OmnichannelStreamingMessage | undefined => {
+    // Drop duplicate finals — log and bail before doing any other work.
+    const incomingType = event.streamingMetadata?.streamingMessageType;
+    if (incomingType === 'final' && params.finalizedMessageIds.has(event.id)) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingDuplicateFinal,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id }
+        );
+        return undefined;
+    }
+
+    // ACS chunks are typed as ChatMessageEditedEvent; defensively log if the
+    // content field is missing (should be impossible per protocol but the
+    // type system lets it slip through). createOmnichannelMessage handles
+    // the absent-content case by falling back to empty string.
+    if (event.message === undefined || event.message === null) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingChunkNoContent,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id, eventName: params.eventName }
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseMessage = createOmnichannelMessage(event as any, {
+        liveChatVersion: params.liveChatVersion,
+    });
+    const streamingMetadata = normalizeStreamingMetadata(event, params);
+
+    if (streamingMetadata.streamingMessageType === 'final') {
+        // LRU-bounded: evict oldest finalized ID when at capacity.
+        if (params.finalizedMessageIds.size >= MAX_TRACKED_STREAMS && !params.finalizedMessageIds.has(event.id)) {
+            const oldestId = params.finalizedMessageIds.values().next().value;
+            if (oldestId !== undefined) {
+                params.finalizedMessageIds.delete(oldestId);
+                params.logger?.recordIndividualEvent(
+                    TelemetryEvent.StreamingFinalizedIdEvicted,
+                    MessageSource.WebSocketStreaming,
+                    { evictedMessageId: oldestId }
+                );
+            }
+        }
+        params.finalizedMessageIds.add(event.id);
+        params.sequenceCounters.delete(event.id);
+    } else if (params.finalizedMessageIds.has(event.id)) {
+        // Late chunk after final — log but still emit so consumers can
+        // decide UX behavior.
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingChunkAfterFinal,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id }
+        );
+    }
+
+    // Surface policyViolation (only present on chunk-typed events).
+    const policyViolation = (event as StreamingChatMessageChunkReceivedEvent).policyViolation;
+    if (policyViolation) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingPolicyViolation,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id, result: policyViolation.result }
+        );
+    }
+
+    return {
+        ...baseMessage,
+        streamingMetadata,
+        ...(policyViolation ? { policyViolation } : {}),
+    } as OmnichannelStreamingMessage;
+};
+
+function normalizeStreamingMetadata(
+    event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent,
+    params: CreateOmnichannelStreamingMessageOptionalParams
+): StreamingMetadata {
+    const fallbackType: StreamingMetadata['streamingMessageType'] =
+        params.eventName === 'streamingChatMessageStarted' ? 'start' : 'streaming';
+
+    if (event.streamingMetadata?.streamingMessageType === undefined) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingMetadataMissingType,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id, eventName: params.eventName }
+        );
+    }
+
+    // For start events, the event name takes precedence over what ACS sends.
+    // ACS currently sends streamingMessageType: "streaming" even for the start event
+    // (event 250 / streamingChatMessageStarted), so we override to "start".
+    const inferredType = params.eventName === 'streamingChatMessageStarted'
+        ? 'start'
+        : (event.streamingMetadata?.streamingMessageType ?? fallbackType);
+    const inferredSequence = recordAndGetSequence(event, params);
+
+    let endReason = event.streamingMetadata?.streamEndReason;
+    if (inferredType === 'final' && endReason === undefined) {
+        params.logger?.recordIndividualEvent(
+            TelemetryEvent.StreamingFinalMissingReason,
+            MessageSource.WebSocketStreaming,
+            { messageId: event.id }
+        );
+        endReason = 'completed';
+    }
+
+    return {
+        streamingMessageType: inferredType,
+        streamingSequenceNumber: inferredSequence,
+        streamEndReason: endReason,
+    };
+}
+
+function recordAndGetSequence(
+    event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent,
+    params: CreateOmnichannelStreamingMessageOptionalParams
+): number {
+    const fromAcs = event.streamingMetadata?.streamingSequenceNumber;
+    if (fromAcs !== undefined) {
+        return fromAcs;
+    }
+
+    // SDK fallback: monotonic counter per messageId, LRU-bounded at MAX_TRACKED_STREAMS.
+    if (
+        params.sequenceCounters.size >= MAX_TRACKED_STREAMS &&
+        !params.sequenceCounters.has(event.id)
+    ) {
+        const oldestKey = params.sequenceCounters.keys().next().value;
+        if (oldestKey !== undefined) {
+            params.sequenceCounters.delete(oldestKey);
+            params.logger?.recordIndividualEvent(
+                TelemetryEvent.StreamingCounterEvicted,
+                MessageSource.WebSocketStreaming,
+                { evictedMessageId: oldestKey }
+            );
+        }
+    }
+    const next = (params.sequenceCounters.get(event.id) ?? 0) + 1;
+    params.sequenceCounters.set(event.id, next);
+    return next;
+}
+
+export default createOmnichannelStreamingMessage;

--- a/src/utils/printers/MessagePrinterFactory.ts
+++ b/src/utils/printers/MessagePrinterFactory.ts
@@ -1,15 +1,18 @@
 import { ChatMessage, ChatMessageEditedEvent, ChatMessageReceivedEvent } from "@azure/communication-chat";
+import { StreamingChatMessageChunkReceivedEvent, StreamingChatMessageStartEvent } from "@azure/communication-signaling";
 
 import { MessageType } from "./types/MessageType";
 import OmnichannelMessage from "../../core/messaging/OmnichannelMessage";
 import { OmnichannelMessagePrinter } from "./OmnichannelMessagePrinter";
 import { PollingMessagePrinter } from "./PollingMessagePrinter";
 import { PrintableMessage } from "./types/PrintableMessageType";
+import { StreamingMessagePrinter } from "./StreamingMessagePrinter";
 import { WebSocketMessagePrinter } from "./WebsocketMessagePrinter";
 
 export enum PrinterType {
     Polling = "Polling",
     WebSocket = "WebSocket",
+    Streaming = "Streaming",
     Omnichannel = "Rest"
 }
 
@@ -20,6 +23,8 @@ export class MessagePrinterFactory {
             return PollingMessagePrinter;
         case PrinterType.WebSocket:
             return WebSocketMessagePrinter;
+        case PrinterType.Streaming:
+            return StreamingMessagePrinter;
         case PrinterType.Omnichannel:
             return OmnichannelMessagePrinter;
         default:
@@ -35,6 +40,10 @@ export class MessagePrinterFactory {
             return (printer as typeof PollingMessagePrinter).printify(message as ChatMessage);
         case PrinterType.WebSocket:
             return (printer as typeof WebSocketMessagePrinter).printify(message as ChatMessageReceivedEvent | ChatMessageEditedEvent);
+        case PrinterType.Streaming:
+            return (printer as typeof StreamingMessagePrinter).printify(
+                message as StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent
+            );
         case PrinterType.Omnichannel:
             return (printer as typeof OmnichannelMessagePrinter).printify(message as OmnichannelMessage);
         default:

--- a/src/utils/printers/StreamingMessagePrinter.ts
+++ b/src/utils/printers/StreamingMessagePrinter.ts
@@ -1,0 +1,33 @@
+import {
+    StreamingChatMessageChunkReceivedEvent,
+    StreamingChatMessageStartEvent,
+} from "@azure/communication-signaling";
+
+import { PrintableMessage } from "./types/PrintableMessageType";
+
+export class StreamingMessagePrinter {
+    static printify(
+        event: StreamingChatMessageStartEvent | StreamingChatMessageChunkReceivedEvent
+    ): PrintableMessage {
+        const result: PrintableMessage = {} as PrintableMessage;
+        if (!event) {
+            return result;
+        }
+        result.id = event.id;
+        result.tags = event?.metadata?.tags ? event.metadata.tags.replace(/"/g, "").split(",").filter((tag: string) => tag.length > 0) : [];
+        result.bot = event?.metadata?.tags?.includes("public") ? false : true;
+        result.card = false;
+        // Privacy: never log raw streaming content. Stamp the byte length only.
+        result.content = event?.message ? `${event.message.length} chars` : "";
+        result.created = event.createdOn;
+        // Streaming-specific fields. PrintableMessage doesn't formally carry these
+        // today; the cast lets dashboards consume them as additional context.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result as any).streamingMessageType = event?.streamingMetadata?.streamingMessageType;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result as any).streamingSequenceNumber = event?.streamingMetadata?.streamingSequenceNumber;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result as any).streamEndReason = event?.streamingMetadata?.streamEndReason;
+        return result;
+    }
+}

--- a/src/utils/printers/types/MessageType.ts
+++ b/src/utils/printers/types/MessageType.ts
@@ -1,5 +1,14 @@
 import { ChatMessage, ChatMessageEditedEvent, ChatMessageReceivedEvent } from "@azure/communication-chat";
+import { StreamingChatMessageChunkReceivedEvent, StreamingChatMessageStartEvent } from "@azure/communication-signaling";
+
 import IMessage from "@microsoft/omnichannel-ic3core/lib/model/IMessage";
 import OmnichannelMessage from "../../../core/messaging/OmnichannelMessage";
 
-export type MessageType = OmnichannelMessage | ChatMessage | ChatMessageReceivedEvent | ChatMessageEditedEvent | IMessage;
+export type MessageType =
+    | OmnichannelMessage
+    | ChatMessage
+    | ChatMessageReceivedEvent
+    | ChatMessageEditedEvent
+    | StreamingChatMessageStartEvent
+    | StreamingChatMessageChunkReceivedEvent
+    | IMessage;


### PR DESCRIPTION
AB#6454718

# PR Details

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference
[User Story 6454718](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/6454718): [Streaming] OC SDK changes for streaming support

### Description

Add support for streaming bot messages on oc chat sdk.

## Solution Proposed

- Add onStreamingMessage() public API for real-time streaming message delivery
- Add supportsLcwStreaming flag in startChat() for server-side signaling
- Add streaming message normalization, dedup, and LRU-bounded tracking (1000 cap)
- Guard against duplicate registerOnStreamingMessage() calls (listener leak prevention)
- Clear streaming state on disconnect()
- Add streaming telemetry events for observability
- Upgrade @azure/communication-chat to 1.6.0-beta.7 for streaming event support

### Acceptance criteria

_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests

- [ ] You have tested all changes in Popout mode
- [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
- [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y

- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

***Please provide justification if any of the validations has been skipped.***
