### PR TITLE
fix: guard null/undefined sender in createOmnichannelMessage (AB#6363463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Publish a GitHub Release with the packed `.tgz` and auto-generated release notes whenever a `v*` tag is pushed (runs after the npm publish step in `npm-release.yml`)
 
 ### Fixed
+- Fix null reference exception in `createOmnichannelMessage` when the ACS message `sender` is null/undefined (e.g. system messages or certain ACS event types); now reads `sender?.communicationUserId` so message transformation no longer throws and customer `onNewMessage` callbacks still fire
 - Fix V2 `onNewMessage` and `getMessages` losing the ACS message-type field. `createOmnichannelMessage` now propagates it as `contentType` on the returned `OmnichannelMessage` so receivers can render html-typed agent messages (e.g. from D365 Edge) instead of treating the raw HTML body as plain text. Field already existed on the interface; previously left empty. The WebSocket signaling event (`'Text'` / `'RichText/Html'`) and the REST rehydrate path (`'text'` / `'html'`) are normalized to a single lowercase `'text'` / `'html'` contract so consumers don't have to handle both spellings.
 - Fix `sendTypingEvent` failing silently for authenticated and persistent chat when `OCClient.sendTypingIndicator()` returns a `404`; changed to fire-and-forget so `ACSConversation.sendTyping()` always executes regardless of the OC indicator result
 

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -408,4 +408,57 @@ describe('createOmnichannelMessage', () => {
             expect(omnichannelMessage.properties.originalMessageId).toEqual(sampleMessage.metadata.OriginalMessageId);
         }
     });
+
+    it('createOmnichannelMessage with LiveChatV2 message should not throw when sender is undefined', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: 'tags',
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+            // sender intentionally omitted (undefined)
+        };
+
+        let omnichannelMessage: any;
+        expect(() => {
+            omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+                liveChatVersion: LiveChatVersion.V2
+            });
+        }).not.toThrow();
+
+        expect(omnichannelMessage.sender).toEqual({
+            id: undefined,
+            displayName: sampleMessage.senderDisplayName,
+            type: PersonType.Bot
+        });
+        expect(omnichannelMessage.content).toBe(sampleMessage.content);
+    });
+
+    it('createOmnichannelMessage with LiveChatV2 message should not throw when sender is null', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: 'tags',
+            },
+            sender: null,
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        let omnichannelMessage: any;
+        expect(() => {
+            omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+                liveChatVersion: LiveChatVersion.V2
+            });
+        }).not.toThrow();
+
+        expect(omnichannelMessage.sender).toEqual({
+            id: undefined,
+            displayName: sampleMessage.senderDisplayName,
+            type: PersonType.Bot
+        });
+    });
 });

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -461,4 +461,55 @@ describe('createOmnichannelMessage', () => {
             type: PersonType.Bot
         });
     });
+
+    it('createOmnichannelMessage with LiveChatV2 message should emit a debug warning when sender is missing and debug is enabled', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: 'tags',
+            },
+            sender: null,
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+            createOmnichannelMessage(sampleMessage as any, {
+                liveChatVersion: LiveChatVersion.V2,
+                debug: true
+            });
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('has no sender'));
+        } finally {
+            consoleWarnSpy.mockRestore();
+        }
+    });
+
+    it('createOmnichannelMessage with LiveChatV2 message should not emit a debug warning when sender is missing and debug is disabled', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: 'tags',
+            },
+            sender: null,
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+            createOmnichannelMessage(sampleMessage as any, {
+                liveChatVersion: LiveChatVersion.V2
+            });
+
+            expect(consoleWarnSpy).not.toHaveBeenCalled();
+        } finally {
+            consoleWarnSpy.mockRestore();
+        }
+    });
 });

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -53,6 +53,11 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
         // `sender` can be null/undefined for system messages or certain ACS
         // event types. Use optional chaining so message transformation does not
         // throw a null reference exception and silently drop customer callbacks.
+        // Surface a debug log (gated on the same `debug` flag used above) so
+        // unexpected upstream null-sender cases remain observable.
+        if (!sender) {
+            optionalParams.debug && console.warn(`createOmnichannelMessage: message ${id} has no sender; sender.id will be undefined`);
+        }
         omnichannelMessage.sender = {
             id: sender?.communicationUserId,
             displayName: senderDisplayName,

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -50,8 +50,11 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
         omnichannelMessage.tags = metadata && metadata.tags ? metadata.tags.replace(/\"/g, "").split(",").filter((tag: string) => tag.length > 0) : []; // eslint-disable-line no-useless-escape
         omnichannelMessage.timestamp = editedOn ?? createdOn;
         omnichannelMessage.messageType = MessageType.UserMessage; // Backward compatibility
+        // `sender` can be null/undefined for system messages or certain ACS
+        // event types. Use optional chaining so message transformation does not
+        // throw a null reference exception and silently drop customer callbacks.
         omnichannelMessage.sender = {
-            id: sender.communicationUserId,
+            id: sender?.communicationUserId,
             displayName: senderDisplayName,
             type: PersonType.Bot
         } as IPerson;


### PR DESCRIPTION
## Summary
Fixes **AB#6363463** — SDK: Null reference exception in `createOmnichannelMessage` when sender is null/undefined. `createOmnichannelMessage()` assumed the ACS message `sender` object was always present and threw a null reference exception when accessing `sender.communicationUserId`. This occurs for system messages, certain ACS event types, and edge cases (e.g. messages from removed participants). The thrown exception broke message transformation and silently dropped customer `onNewMessage` callbacks.

## Change
- `src/utils/createOmnichannelMessage.ts`: read `sender?.communicationUserId` (optional chaining) so transformation no longer throws when `sender` is null/undefined. When `sender` is present, behavior is identical (zero regression). Added a `debug`-gated warning when `sender` is missing so unexpected upstream cases stay observable.

## Tests
- Added unit tests covering `sender` undefined, `sender` null, and the debug-warning behavior (on/off).
- Full `createOmnichannelMessage` suite passes (16 tests); `tsc` and `eslint` clean.

## Notes
- Independent fix. Shares the file `createOmnichannelMessage.ts` with the `metadata.tags` type-check fix (AB#6363464) on different lines; a trivial merge conflict is expected if both merge.