### PR TITLE
fix: type-check metadata.tags in createOmnichannelMessage (AB#6363464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Publish a GitHub Release with the packed `.tgz` and auto-generated release notes whenever a `v*` tag is pushed (runs after the npm publish step in `npm-release.yml`)
 
 ### Fixed
+- Fix type-assumption exception in `createOmnichannelMessage` when `metadata.tags` is not a string. Previously `.replace()` was called unconditionally, throwing when `tags` was an array, null, or another type (e.g. backend/API-version mismatch or custom metadata). Now only strings are parsed via `.replace()/.split()`, arrays are filtered to their string entries, and any other type falls back to an empty list so message transformation never throws
 - Fix V2 `onNewMessage` and `getMessages` losing the ACS message-type field. `createOmnichannelMessage` now propagates it as `contentType` on the returned `OmnichannelMessage` so receivers can render html-typed agent messages (e.g. from D365 Edge) instead of treating the raw HTML body as plain text. Field already existed on the interface; previously left empty. The WebSocket signaling event (`'Text'` / `'RichText/Html'`) and the REST rehydrate path (`'text'` / `'html'`) are normalized to a single lowercase `'text'` / `'html'` contract so consumers don't have to handle both spellings.
 - Fix `sendTypingEvent` failing silently for authenticated and persistent chat when `OCClient.sendTypingIndicator()` returns a `404`; changed to fire-and-forget so `ACSConversation.sendTyping()` always executes regardless of the OC indicator result
 

--- a/__tests__/utils/createOmnichannelMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelMessage.spec.ts
@@ -408,4 +408,103 @@ describe('createOmnichannelMessage', () => {
             expect(omnichannelMessage.properties.originalMessageId).toEqual(sampleMessage.metadata.OriginalMessageId);
         }
     });
+
+    it('createOmnichannelMessage with LiveChatV2 message should not throw when metadata.tags is an array', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: ['tagA', '', 'tagB']
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        let omnichannelMessage: any;
+        expect(() => {
+            omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+                liveChatVersion: LiveChatVersion.V2
+            });
+        }).not.toThrow();
+
+        // empty strings are filtered out, non-empty string tags are preserved
+        expect(omnichannelMessage.tags).toEqual(['tagA', 'tagB']);
+    });
+
+    it('createOmnichannelMessage with LiveChatV2 message should not throw when metadata.tags is null', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: null
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        let omnichannelMessage: any;
+        expect(() => {
+            omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+                liveChatVersion: LiveChatVersion.V2
+            });
+        }).not.toThrow();
+
+        expect(omnichannelMessage.tags).toEqual([]);
+    });
+
+    it('createOmnichannelMessage with LiveChatV2 message should not throw when metadata.tags is a non-string primitive', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: 12345
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        let omnichannelMessage: any;
+        expect(() => {
+            omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+                liveChatVersion: LiveChatVersion.V2
+            });
+        }).not.toThrow();
+
+        expect(omnichannelMessage.tags).toEqual([]);
+    });
+
+    it('createOmnichannelMessage with LiveChatV2 message should still parse a comma-separated string of tags', () => {
+        const sampleMessage = {
+            id: 'id',
+            content: 'content',
+            metadata: {
+                tags: '"tagA","tagB"'
+            },
+            sender: {
+                communicationUserId: 'id',
+                kind: "communicationUser"
+            },
+            senderDisplayName: 'senderDisplayName',
+            createdOn: 'createdOn'
+        };
+
+        const omnichannelMessage = createOmnichannelMessage(sampleMessage as any, {
+            liveChatVersion: LiveChatVersion.V2
+        });
+
+        // quotes stripped, split on comma, empty entries filtered
+        expect(omnichannelMessage.tags).toEqual(['tagA', 'tagB']);
+    });
 });

--- a/src/utils/createOmnichannelMessage.ts
+++ b/src/utils/createOmnichannelMessage.ts
@@ -46,8 +46,21 @@ const createOmnichannelMessage = (message: IRawMessage | ChatMessageReceivedEven
                 : '';
 
         omnichannelMessage.content = '';
-        omnichannelMessage.properties.tags = metadata && metadata.tags ? metadata.tags : [];
-        omnichannelMessage.tags = metadata && metadata.tags ? metadata.tags.replace(/\"/g, "").split(",").filter((tag: string) => tag.length > 0) : []; // eslint-disable-line no-useless-escape
+        // `metadata.tags` is normally a comma-separated string, but the backend
+        // (or an API-version mismatch / custom metadata) can deliver it as an
+        // array or some other type. Only call string methods when it is actually
+        // a string; gracefully handle arrays and fall back to an empty list
+        // otherwise so message transformation never throws. `properties.tags` is
+        // also consumed via `.includes()` downstream (getMessageRole), so only
+        // keep string/array values there and default anything else to [].
+        omnichannelMessage.properties.tags = metadata && metadata.tags && (typeof metadata.tags === "string" || Array.isArray(metadata.tags)) ? metadata.tags : [];
+        if (metadata && typeof metadata.tags === "string") {
+            omnichannelMessage.tags = metadata.tags.replace(/\"/g, "").split(",").filter((tag: string) => tag.length > 0); // eslint-disable-line no-useless-escape
+        } else if (metadata && Array.isArray(metadata.tags)) {
+            omnichannelMessage.tags = metadata.tags.filter((tag: unknown): tag is string => typeof tag === "string" && tag.length > 0);
+        } else {
+            omnichannelMessage.tags = [];
+        }
         omnichannelMessage.timestamp = editedOn ?? createdOn;
         omnichannelMessage.messageType = MessageType.UserMessage; // Backward compatibility
         omnichannelMessage.sender = {


### PR DESCRIPTION
## Summary
Fixes **AB#6363464** — SDK: Type assumption exception in `createOmnichannelMessage` when `metadata.tags` is not a string. `createOmnichannelMessage()` assumed `metadata.tags` was always a comma-separated string and called `.replace()` unconditionally. This threw (`.replace is not a function`) when `tags` arrived as an array, `null`, or another type — e.g. a backend/API-version mismatch or custom metadata. The non-string value was also stored on `properties.tags`, which `getMessageRole()` later calls `.includes()` on (a tightly-coupled second throw path surfaced by the new tests).

## Change
- `src/utils/createOmnichannelMessage.ts`:
  - Strings are parsed via `.replace()/.split()` (unchanged behavior).
  - Arrays are filtered to their non-empty string entries.
  - Any other type falls back to `[]`.
  - `properties.tags` only retains string/array values (others default to `[]`) so downstream `.includes()` never throws.

## Tests
- Added unit tests for `tags` as array (with empty-string filtering), `null`, non-string primitive, and the existing comma-separated-string path.
- Full `createOmnichannelMessage` suite passes (16 tests); `tsc` and `eslint` clean.

## Notes
- Shares `createOmnichannelMessage.ts` with the null-sender fix (AB#6363463) on different lines; a trivial merge conflict is expected if both merge.