### PR TITLE
fix: emit telemetry on polling message-processing errors (AB#6363460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Publish a GitHub Release with the packed `.tgz` and auto-generated release notes whenever a `v*` tag is pushed (runs after the npm publish step in `npm-release.yml`)
 
 ### Fixed
+- Fix silent error swallowing in the `ACSClient` polling path. Message-processing failures inside `registerOnNewMessage` were only logged to `console.warn`, so no error telemetry was emitted and production failures were invisible. The catch block now records a `MessageProcessingError` fail-scenario (with structured `ExceptionDetails`) via the logger while still continuing the polling loop
 - Fix V2 `onNewMessage` and `getMessages` losing the ACS message-type field. `createOmnichannelMessage` now propagates it as `contentType` on the returned `OmnichannelMessage` so receivers can render html-typed agent messages (e.g. from D365 Edge) instead of treating the raw HTML body as plain text. Field already existed on the interface; previously left empty. The WebSocket signaling event (`'Text'` / `'RichText/Html'`) and the REST rehydrate path (`'text'` / `'html'`) are normalized to a single lowercase `'text'` / `'html'` contract so consumers don't have to handle both spellings.
 - Fix `sendTypingEvent` failing silently for authenticated and persistent chat when `OCClient.sendTypingIndicator()` returns a `404`; changed to fire-and-forget so `ACSConversation.sendTyping()` always executes regardless of the OC indicator result
 

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -306,10 +306,8 @@ describe('ACSClient', () => {
             expect(throwingCallback).toHaveBeenCalledTimes(1);
             expect(logger.failScenario).toHaveBeenCalledTimes(1);
             expect(logger.failScenario.mock.calls[0][0]).toEqual('MessageProcessingError');
-            const exceptionDetails = JSON.parse(logger.failScenario.mock.calls[0][1].ExceptionDetails);
-            // Telemetry carries only the safe error type — never the error message
-            expect(exceptionDetails.errorName).toEqual('Error');
-            expect(exceptionDetails.errorObject).toBeUndefined();
+            // Telemetry records the same static, type-only message as the console — never the error message
+            expect(logger.failScenario.mock.calls[0][1].ExceptionDetails).toEqual('[ACSClient][registerOnNewMessage] Error occurred while processing messages: Error');
             expect(logger.failScenario.mock.calls[0][1].ExceptionDetails).not.toContain('transformation failed');
             // console.warn always fires so consumers without telemetry still see it
             expect(consoleWarnSpy).toHaveBeenCalledWith('[ACSClient][registerOnNewMessage] Error occurred while processing messages: Error');
@@ -381,7 +379,7 @@ describe('ACSClient', () => {
             expect(logger.failScenario).toHaveBeenCalledTimes(1);
             // Telemetry records only the safe error type, not the message content
             const exceptionDetails = logger.failScenario.mock.calls[0][1].ExceptionDetails;
-            expect(JSON.parse(exceptionDetails).errorName).toEqual('TypeError');
+            expect(exceptionDetails).toEqual('[ACSClient][registerOnNewMessage] Error occurred while processing messages: TypeError');
             expect(exceptionDetails).not.toContain(secret);
             // console.warn surfaces the safe error type only — no content leaks
             expect(consoleWarnSpy).toHaveBeenCalledTimes(1);

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -296,14 +296,95 @@ describe('ACSClient', () => {
         // Customer callback throws while processing the message
         const throwingCallback = jest.fn(() => { throw new Error('transformation failed'); });
 
-        // Should not throw out of registerOnNewMessage despite the callback throwing
-        await expect(conversation.registerOnNewMessage(throwingCallback)).resolves.toBeUndefined();
+        // Capture dev-facing console.warn (emitted only in non-production)
+        const originalNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'development';
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-        expect(throwingCallback).toHaveBeenCalledTimes(1);
-        expect(logger.failScenario).toHaveBeenCalledTimes(1);
-        expect(logger.failScenario.mock.calls[0][0]).toEqual('MessageProcessingError');
-        const exceptionDetails = JSON.parse(logger.failScenario.mock.calls[0][1].ExceptionDetails);
-        expect(exceptionDetails.errorObject).toContain('transformation failed');
+        try {
+            // Should not throw out of registerOnNewMessage despite the callback throwing
+            await expect(conversation.registerOnNewMessage(throwingCallback)).resolves.toBeUndefined();
+
+            expect(throwingCallback).toHaveBeenCalledTimes(1);
+            expect(logger.failScenario).toHaveBeenCalledTimes(1);
+            expect(logger.failScenario.mock.calls[0][0]).toEqual('MessageProcessingError');
+            const exceptionDetails = JSON.parse(logger.failScenario.mock.calls[0][1].ExceptionDetails);
+            // Telemetry carries only bounded error metadata (type + message)
+            expect(exceptionDetails.errorName).toEqual('Error');
+            expect(exceptionDetails.errorObject).toContain('transformation failed');
+            // Dev-facing console.warn fires in non-production builds
+            expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('transformation failed'));
+        } finally {
+            consoleWarnSpy.mockRestore();
+            process.env.NODE_ENV = originalNodeEnv;
+        }
+    });
+
+    it('ACSClient.conversation.registerOnNewMessage() should not emit a dev console.warn in production builds', async () => {
+        const client: any = new ACSClient();
+        const config = {
+            token: 'token',
+            environmentUrl: 'url'
+        }
+
+        await client.initialize(config);
+
+        const chatThreadClient: any = {};
+        chatThreadClient.listParticipants = jest.fn(() => ({
+            next: jest.fn(() => ({
+                value: 'value',
+                done: jest.fn()
+            })),
+        }));
+        chatThreadClient.listMessages = jest.fn(() => ({
+            next: jest.fn(() => ({
+                value: 'value',
+                done: jest.fn()
+            })),
+        }));
+
+        client.chatClient = {};
+        client.chatClient.getChatThreadClient = jest.fn(() => chatThreadClient);
+        client.chatClient.startRealtimeNotifications = jest.fn();
+        client.chatClient.on = jest.fn();
+
+        const conversation: any = await client.joinConversation({
+            id: 'id',
+            threadId: 'threadId',
+            pollingInterval: 1000,
+        });
+
+        const logger = {
+            startScenario: jest.fn(),
+            completeScenario: jest.fn(),
+            failScenario: jest.fn(),
+            recordIndividualEvent: jest.fn()
+        };
+        conversation.logger = logger;
+
+        conversation.keepPolling = true;
+        jest.spyOn(conversation, 'getMessages').mockResolvedValue([{id: 'id', sender: {displayName: 'name'}}]);
+
+        (global as any).setTimeout = jest.fn();
+
+        const throwingCallback = jest.fn(() => { throw new Error('transformation failed'); });
+
+        const originalNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+            await expect(conversation.registerOnNewMessage(throwingCallback)).resolves.toBeUndefined();
+
+            // Telemetry still recorded in production
+            expect(logger.failScenario).toHaveBeenCalledTimes(1);
+            expect(logger.failScenario.mock.calls[0][0]).toEqual('MessageProcessingError');
+            // No dev-facing console noise in production
+            expect(consoleWarnSpy).not.toHaveBeenCalled();
+        } finally {
+            consoleWarnSpy.mockRestore();
+            process.env.NODE_ENV = originalNodeEnv;
+        }
     });
 
     it('ACSClient.conversation.registerOnThreadUpdate() should register to "participantsRemoved" event', async () => {

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -245,6 +245,67 @@ describe('ACSClient', () => {
         expect(conversation.getMessages).toHaveBeenCalledTimes(0);
     });
 
+    it('ACSClient.conversation.registerOnNewMessage() should log failScenario telemetry when message processing throws and keep polling', async () => {
+        const client: any = new ACSClient();
+        const config = {
+            token: 'token',
+            environmentUrl: 'url'
+        }
+
+        await client.initialize(config);
+
+        const chatThreadClient: any = {};
+        chatThreadClient.listParticipants = jest.fn(() => ({
+            next: jest.fn(() => ({
+                value: 'value',
+                done: jest.fn()
+            })),
+        }));
+        chatThreadClient.listMessages = jest.fn(() => ({
+            next: jest.fn(() => ({
+                value: 'value',
+                done: jest.fn()
+            })),
+        }));
+
+        client.chatClient = {};
+        client.chatClient.getChatThreadClient = jest.fn(() => chatThreadClient);
+        client.chatClient.startRealtimeNotifications = jest.fn();
+        client.chatClient.on = jest.fn();
+
+        const conversation: any = await client.joinConversation({
+            id: 'id',
+            threadId: 'threadId',
+            pollingInterval: 1000,
+        });
+
+        // Inject a mock logger so we can assert telemetry is recorded
+        const logger = {
+            startScenario: jest.fn(),
+            completeScenario: jest.fn(),
+            failScenario: jest.fn(),
+            recordIndividualEvent: jest.fn()
+        };
+        conversation.logger = logger;
+
+        conversation.keepPolling = true;
+        jest.spyOn(conversation, 'getMessages').mockResolvedValue([{id: 'id', sender: {displayName: 'name'}}]);
+
+        (global as any).setTimeout = jest.fn();
+
+        // Customer callback throws while processing the message
+        const throwingCallback = jest.fn(() => { throw new Error('transformation failed'); });
+
+        // Should not throw out of registerOnNewMessage despite the callback throwing
+        await expect(conversation.registerOnNewMessage(throwingCallback)).resolves.toBeUndefined();
+
+        expect(throwingCallback).toHaveBeenCalledTimes(1);
+        expect(logger.failScenario).toHaveBeenCalledTimes(1);
+        expect(logger.failScenario.mock.calls[0][0]).toEqual('MessageProcessingError');
+        const exceptionDetails = JSON.parse(logger.failScenario.mock.calls[0][1].ExceptionDetails);
+        expect(exceptionDetails.errorObject).toContain('transformation failed');
+    });
+
     it('ACSClient.conversation.registerOnThreadUpdate() should register to "participantsRemoved" event', async () => {
         const client: any = new ACSClient();
         const config = {

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -296,9 +296,7 @@ describe('ACSClient', () => {
         // Customer callback throws while processing the message
         const throwingCallback = jest.fn(() => { throw new Error('transformation failed'); });
 
-        // Capture dev-facing console.warn (emitted only in non-production)
-        const originalNodeEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'development';
+        // Capture the console.warn that surfaces processing failures
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
         try {
@@ -312,15 +310,14 @@ describe('ACSClient', () => {
             // Telemetry carries only bounded error metadata (type + message)
             expect(exceptionDetails.errorName).toEqual('Error');
             expect(exceptionDetails.errorObject).toContain('transformation failed');
-            // Dev-facing console.warn fires in non-production builds
-            expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('transformation failed'));
+            // console.warn always fires so consumers without telemetry still see it
+            expect(consoleWarnSpy).toHaveBeenCalledWith('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
         } finally {
             consoleWarnSpy.mockRestore();
-            process.env.NODE_ENV = originalNodeEnv;
         }
     });
 
-    it('ACSClient.conversation.registerOnNewMessage() should not emit a dev console.warn in production builds', async () => {
+    it('ACSClient.conversation.registerOnNewMessage() console.warn should not leak error content', async () => {
         const client: any = new ACSClient();
         const config = {
             token: 'token',
@@ -367,23 +364,23 @@ describe('ACSClient', () => {
 
         (global as any).setTimeout = jest.fn();
 
-        const throwingCallback = jest.fn(() => { throw new Error('transformation failed'); });
+        // Error message embeds sensitive-looking content that must not reach the console
+        const secret = 'sensitive-customer-pii-12345';
+        const throwingCallback = jest.fn(() => { throw new Error(secret); });
 
-        const originalNodeEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'production';
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
         try {
             await expect(conversation.registerOnNewMessage(throwingCallback)).resolves.toBeUndefined();
 
-            // Telemetry still recorded in production
+            // Telemetry still recorded
             expect(logger.failScenario).toHaveBeenCalledTimes(1);
-            expect(logger.failScenario.mock.calls[0][0]).toEqual('MessageProcessingError');
-            // No dev-facing console noise in production
-            expect(consoleWarnSpy).not.toHaveBeenCalled();
+            // console.warn emits a static, content-free message — no error detail leaks
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+            expect(consoleWarnSpy).toHaveBeenCalledWith('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
+            expect(consoleWarnSpy.mock.calls[0].join(' ')).not.toContain(secret);
         } finally {
             consoleWarnSpy.mockRestore();
-            process.env.NODE_ENV = originalNodeEnv;
         }
     });
 

--- a/__tests__/core/messaging/ACSClient.spec.ts
+++ b/__tests__/core/messaging/ACSClient.spec.ts
@@ -307,17 +307,18 @@ describe('ACSClient', () => {
             expect(logger.failScenario).toHaveBeenCalledTimes(1);
             expect(logger.failScenario.mock.calls[0][0]).toEqual('MessageProcessingError');
             const exceptionDetails = JSON.parse(logger.failScenario.mock.calls[0][1].ExceptionDetails);
-            // Telemetry carries only bounded error metadata (type + message)
+            // Telemetry carries only the safe error type — never the error message
             expect(exceptionDetails.errorName).toEqual('Error');
-            expect(exceptionDetails.errorObject).toContain('transformation failed');
+            expect(exceptionDetails.errorObject).toBeUndefined();
+            expect(logger.failScenario.mock.calls[0][1].ExceptionDetails).not.toContain('transformation failed');
             // console.warn always fires so consumers without telemetry still see it
-            expect(consoleWarnSpy).toHaveBeenCalledWith('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
+            expect(consoleWarnSpy).toHaveBeenCalledWith('[ACSClient][registerOnNewMessage] Error occurred while processing messages: Error');
         } finally {
             consoleWarnSpy.mockRestore();
         }
     });
 
-    it('ACSClient.conversation.registerOnNewMessage() console.warn should not leak error content', async () => {
+    it('ACSClient.conversation.registerOnNewMessage() should not leak error content to telemetry or console', async () => {
         const client: any = new ACSClient();
         const config = {
             token: 'token',
@@ -364,20 +365,27 @@ describe('ACSClient', () => {
 
         (global as any).setTimeout = jest.fn();
 
-        // Error message embeds sensitive-looking content that must not reach the console
+        // Error carries a custom name plus sensitive-looking content in its message
         const secret = 'sensitive-customer-pii-12345';
-        const throwingCallback = jest.fn(() => { throw new Error(secret); });
+        const throwingCallback = jest.fn(() => {
+            const err = new Error(secret);
+            err.name = 'TypeError';
+            throw err;
+        });
 
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
         try {
             await expect(conversation.registerOnNewMessage(throwingCallback)).resolves.toBeUndefined();
 
-            // Telemetry still recorded
             expect(logger.failScenario).toHaveBeenCalledTimes(1);
-            // console.warn emits a static, content-free message — no error detail leaks
+            // Telemetry records only the safe error type, not the message content
+            const exceptionDetails = logger.failScenario.mock.calls[0][1].ExceptionDetails;
+            expect(JSON.parse(exceptionDetails).errorName).toEqual('TypeError');
+            expect(exceptionDetails).not.toContain(secret);
+            // console.warn surfaces the safe error type only — no content leaks
             expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-            expect(consoleWarnSpy).toHaveBeenCalledWith('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
+            expect(consoleWarnSpy).toHaveBeenCalledWith('[ACSClient][registerOnNewMessage] Error occurred while processing messages: TypeError');
             expect(consoleWarnSpy.mock.calls[0].join(' ')).not.toContain(secret);
         } finally {
             consoleWarnSpy.mockRestore();

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -226,15 +226,17 @@ export class ACSConversation {
                                 // message content or identifiers), so we deliberately
                                 // exclude it from both telemetry and the console.
                                 const errorName = (error as Error)?.name ?? 'Error';
+                                const errorMessage = `[ACSClient][registerOnNewMessage] Error occurred while processing messages: ${errorName}`;
+
                                 this.logger?.failScenario(ACSClientEvent.MessageProcessingError, {
-                                    ExceptionDetails: JSON.stringify({ errorName })
+                                    ExceptionDetails: errorMessage
                                 });
 
                                 // Always emit a console warning so consumers without
                                 // access to telemetry still know a message failed to
                                 // process. The message is static apart from the safe
                                 // error type, so no error content can leak.
-                                console.warn(`[ACSClient][registerOnNewMessage] Error occurred while processing messages: ${errorName}`);
+                                console.warn(errorMessage);
                             }
 
                         }

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -32,6 +32,7 @@ enum ACSClientEvent {
     SendReadReceipt = 'SendReadReceipt',
     StartPolling = 'StartPolling',
     StopPolling = 'StopPolling',
+    MessageProcessingError = 'MessageProcessingError',
     Disconnect = 'Disconnect'
 }
 
@@ -213,8 +214,13 @@ export class ACSConversation {
                                     onNewMessageCallback(message);
                                     postedMessageIds.add(id);
                                 }
-                            } catch {
-                                console.warn('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
+                            } catch (error) {
+                                // Surface message-processing failures to telemetry instead of
+                                // swallowing them with a console warning. Keep iterating so a
+                                // single bad message does not stop the rest of the batch.
+                                this.logger?.failScenario(ACSClientEvent.MessageProcessingError, {
+                                    ExceptionDetails: JSON.stringify({ errorObject: `${error}` })
+                                });
                             }
 
                         }

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -215,12 +215,29 @@ export class ACSConversation {
                                     postedMessageIds.add(id);
                                 }
                             } catch (error) {
-                                // Surface message-processing failures to telemetry instead of
-                                // swallowing them with a console warning. Keep iterating so a
-                                // single bad message does not stop the rest of the batch.
+                                // Surface message-processing failures instead of
+                                // swallowing them. Keep iterating so a single bad
+                                // message does not stop the rest of the batch.
+                                //
+                                // Telemetry (centralized monitoring): record only
+                                // bounded, non-content error metadata — the error
+                                // type and message. We deliberately avoid
+                                // serializing the full error object, stack, or any
+                                // service response so customer/conversation data
+                                // that an upstream error might embed does not leak
+                                // into centralized telemetry.
+                                const errorName = (error as Error)?.name ?? 'Error';
+                                const errorMessage = (error as Error)?.message ?? `${error}`;
                                 this.logger?.failScenario(ACSClientEvent.MessageProcessingError, {
-                                    ExceptionDetails: JSON.stringify({ errorObject: `${error}` })
+                                    ExceptionDetails: JSON.stringify({ errorName, errorObject: errorMessage })
                                 });
+
+                                // Dev-facing log for local debugging only. Gated to
+                                // non-production builds so it never adds noise (or
+                                // surfaces verbose error detail) in production.
+                                if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+                                    console.warn(`ACSClient/registerOnNewMessage: failed to process message: ${error}`);
+                                }
                             }
 
                         }

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -232,12 +232,12 @@ export class ACSConversation {
                                     ExceptionDetails: JSON.stringify({ errorName, errorObject: errorMessage })
                                 });
 
-                                // Dev-facing log for local debugging only. Gated to
-                                // non-production builds so it never adds noise (or
-                                // surfaces verbose error detail) in production.
-                                if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
-                                    console.warn(`ACSClient/registerOnNewMessage: failed to process message: ${error}`);
-                                }
+                                // Always emit a console warning so consumers without
+                                // access to telemetry still know a message failed to
+                                // process. The message is intentionally static and
+                                // content-free to avoid leaking customer/conversation
+                                // data that an upstream error might embed.
+                                console.warn('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
                             }
 
                         }

--- a/src/core/messaging/ACSClient.ts
+++ b/src/core/messaging/ACSClient.ts
@@ -219,25 +219,22 @@ export class ACSConversation {
                                 // swallowing them. Keep iterating so a single bad
                                 // message does not stop the rest of the batch.
                                 //
-                                // Telemetry (centralized monitoring): record only
-                                // bounded, non-content error metadata — the error
-                                // type and message. We deliberately avoid
-                                // serializing the full error object, stack, or any
-                                // service response so customer/conversation data
-                                // that an upstream error might embed does not leak
-                                // into centralized telemetry.
+                                // Record only the error type (error.name), never the
+                                // error message/object/stack or any service response.
+                                // error.message can embed customer/conversation data
+                                // (e.g. a consumer callback or the ACS SDK may include
+                                // message content or identifiers), so we deliberately
+                                // exclude it from both telemetry and the console.
                                 const errorName = (error as Error)?.name ?? 'Error';
-                                const errorMessage = (error as Error)?.message ?? `${error}`;
                                 this.logger?.failScenario(ACSClientEvent.MessageProcessingError, {
-                                    ExceptionDetails: JSON.stringify({ errorName, errorObject: errorMessage })
+                                    ExceptionDetails: JSON.stringify({ errorName })
                                 });
 
                                 // Always emit a console warning so consumers without
                                 // access to telemetry still know a message failed to
-                                // process. The message is intentionally static and
-                                // content-free to avoid leaking customer/conversation
-                                // data that an upstream error might embed.
-                                console.warn('[ACSClient][registerOnNewMessage] Error occurred while processing messages');
+                                // process. The message is static apart from the safe
+                                // error type, so no error content can leak.
+                                console.warn(`[ACSClient][registerOnNewMessage] Error occurred while processing messages: ${errorName}`);
                             }
 
                         }


### PR DESCRIPTION
## Summary
Fixes **AB#6363460** — SDK: Silent error swallowing in polling path prevents visibility into message processing failures. The per-message catch block in `ACSClient.registerOnNewMessage` (polling path) swallowed all exceptions with only a `console.warn`. No error telemetry was emitted, so production failures (e.g. `createOmnichannelMessage` throwing during transformation, or a customer callback throwing) were invisible.

## Change
- `src/core/messaging/ACSClient.ts`:
  - Added `MessageProcessingError` to the `ACSClientEvent` enum.
  - The catch block records `failScenario(MessageProcessingError)` so the failure is captured in telemetry, and still emits an (always-on) `console.warn` so consumers without telemetry access stay informed.
  - **PII hardening:** both sinks share one static, content-free message — `[ACSClient][registerOnNewMessage] Error occurred while processing messages: ${errorName}` — recording only the safe `error.name` (type), never `error.message`, which could embed customer/conversation data thrown by a consumer callback or the ACS SDK.
  - The polling loop still continues, so a single bad message does not stop the rest of the batch.

## Tests
- Added unit tests asserting telemetry + console carry the same type-only message and that sensitive error content never leaks to either sink.
- Full `ACSClient` suite passes (20 tests); `tsc` and `eslint` clean.

## Notes
- Independent fix; no file overlap with the other three PRs.