### PR TITLE
Preserve informative streamType on the streaming start event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed streaming final messages not delivered to `onStreamingMessage` when ACS sends them as `chatMessageReceived` (event 200) instead of `streamingChatMessageChunkReceived` (event 251)
 - Fixed `streamingMessageType` never being `"start"` — ACS sends `"streaming"` for start events; SDK now overrides to `"start"` based on event name
+- Fixed `"informative"` streaming updates (transient status such as "Searching for references...") being collapsed to `"start"` when delivered as the first streaming event; the `"informative"` type is now preserved end-to-end so consumers can render it as a status indicator rather than response content
 - Backward compatibility: `onNewMessage` always fires for the final complete message alongside `onStreamingMessage`, ensuring existing consumers are unaffected
 
 ### Added

--- a/__tests__/core/messaging/ACSClient.streaming.spec.ts
+++ b/__tests__/core/messaging/ACSClient.streaming.spec.ts
@@ -89,6 +89,44 @@ describe('ACSClient - Streaming', () => {
             expect(msg.content).toBe('Hello');
         });
 
+        it('should preserve "informative" type when it arrives as the start event', async () => {
+            const { client, conversation } = await createConversation();
+            const callback = jest.fn();
+
+            await conversation.registerOnStreamingMessage(callback);
+
+            const onStart = client.chatClient.on.mock.calls[0][1];
+
+            const fakeInformativeStartEvent = {
+                id: 'msg-1',
+                message: 'Searching for references...',
+                sender: { communicationUserId: 'bot', kind: 'communicationUser' },
+                senderDisplayName: 'Bot',
+                createdOn: new Date(),
+                editedOn: new Date(),
+                threadId: 'thread-1',
+                recipient: { communicationUserId: 'user', kind: 'communicationUser' },
+                type: 'text',
+                version: '1',
+                metadata: {},
+                streamingMetadata: {
+                    streamingMessageType: 'informative',
+                    streamingSequenceNumber: 1,
+                },
+            };
+
+            onStart(fakeInformativeStartEvent);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            const msg = callback.mock.calls[0][0];
+            // An informative status delivered as the first streaming event must not be
+            // collapsed into "start" — consumers rely on the "informative" type to render
+            // it as a transient status indicator rather than response content.
+            expect(msg.streamingMetadata.streamingMessageType).toBe('informative');
+            expect(msg.content).toBe('Searching for references...');
+        });
+
+
         it('should invoke callback when a chunk event fires', async () => {
             const { client, conversation } = await createConversation();
             const callback = jest.fn();

--- a/__tests__/utils/createOmnichannelStreamingMessage.spec.ts
+++ b/__tests__/utils/createOmnichannelStreamingMessage.spec.ts
@@ -94,6 +94,78 @@ describe('createOmnichannelStreamingMessage', () => {
             expect(result!.streamingMetadata.streamingMessageType).toBe('start');
         });
 
+        it('should preserve "informative" type on chunk events', () => {
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'informative', streamingSequenceNumber: 2 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageChunkReceived' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.streamingMetadata.streamingMessageType).toBe('informative');
+        });
+
+        it('should preserve "informative" type on the start event (not force "start")', () => {
+            // An informative status ("Searching for references...") can be the very first
+            // streaming event. Its type must survive the start-event normalization so
+            // downstream renders it as a status indicator, not response content.
+            const event = makeFakeEvent({
+                streamingMetadata: { streamingMessageType: 'informative', streamingSequenceNumber: 1 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageStarted' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result).toBeDefined();
+            expect(result!.streamingMetadata.streamingMessageType).toBe('informative');
+        });
+
+        it('should still override to "start" for non-informative start events', () => {
+            // Guards the informative exception: streaming/undefined start events must
+            // continue to normalize to "start".
+            const streamingStart = createOmnichannelStreamingMessage(
+                makeFakeEvent({ streamingMetadata: { streamingMessageType: 'streaming', streamingSequenceNumber: 1 } }),
+                makeParams({ eventName: 'streamingChatMessageStarted' }),
+            );
+            expect(streamingStart!.streamingMetadata.streamingMessageType).toBe('start');
+        });
+
+        it('should carry informative content through unchanged', () => {
+            const event = makeFakeEvent({
+                message: 'Searching for references...',
+                streamingMetadata: { streamingMessageType: 'informative', streamingSequenceNumber: 1 },
+            });
+            const params = makeParams({ eventName: 'streamingChatMessageChunkReceived' });
+
+            const result = createOmnichannelStreamingMessage(event, params);
+
+            expect(result!.content).toBe('Searching for references...');
+            expect(result!.streamingMetadata.streamingMessageType).toBe('informative');
+        });
+
+        it('should not finalize or drop an informative chunk (informative precedes final)', () => {
+            const finalizedMessageIds = new Set<string>();
+            const params = makeParams({ finalizedMessageIds, eventName: 'streamingChatMessageChunkReceived' });
+
+            // Two informative updates for the same message id both flow through — informative
+            // is transient and must never be treated as a (deduped) final.
+            const first = createOmnichannelStreamingMessage(
+                makeFakeEvent({ message: 'Searching...', streamingMetadata: { streamingMessageType: 'informative', streamingSequenceNumber: 1 } }),
+                params,
+            );
+            const second = createOmnichannelStreamingMessage(
+                makeFakeEvent({ message: 'Generating response...', streamingMetadata: { streamingMessageType: 'informative', streamingSequenceNumber: 2 } }),
+                params,
+            );
+
+            expect(first).toBeDefined();
+            expect(second).toBeDefined();
+            expect(second!.content).toBe('Generating response...');
+            // Informative never marks the message id as finalized.
+            expect(finalizedMessageIds.has('msg-1')).toBe(false);
+        });
+
         it('should use ACS sequence number when provided', () => {
             const event = makeFakeEvent({
                 streamingMetadata: { streamingMessageType: 'streaming', streamingSequenceNumber: 42 },

--- a/src/utils/createOmnichannelStreamingMessage.ts
+++ b/src/utils/createOmnichannelStreamingMessage.ts
@@ -111,12 +111,20 @@ function normalizeStreamingMetadata(
         );
     }
 
-    // For start events, the event name takes precedence over what ACS sends.
-    // ACS currently sends streamingMessageType: "streaming" even for the start event
+    // For start events, the event name normally takes precedence over what ACS sends.
+    // ACS sends streamingMessageType: "streaming" (or omits it) for the start event
     // (event 250 / streamingChatMessageStarted), so we override to "start".
+    //
+    // Exception: an "informative" update (e.g. "Searching for references...") is a
+    // transient status shown before the response streams, and it can arrive as the very
+    // first streaming event. Its type must be preserved end-to-end so consumers render it
+    // as a status indicator rather than as response content — forcing it to "start" would
+    // lose that distinction. We therefore only override to "start" when ACS did not
+    // explicitly mark the start event as informative.
+    const acsType = event.streamingMetadata?.streamingMessageType;
     const inferredType = params.eventName === 'streamingChatMessageStarted'
-        ? 'start'
-        : (event.streamingMetadata?.streamingMessageType ?? fallbackType);
+        ? (acsType === 'informative' ? 'informative' : 'start')
+        : (acsType ?? fallbackType);
     const inferredSequence = recordAndGetSequence(event, params);
 
     let endReason = event.streamingMetadata?.streamEndReason;


### PR DESCRIPTION
## Summary
ACS delivers streaming updates of `streamType: "informative"` (transient status such as *"Searching for references..."*, *"Generating response..."*) that are shown **before** the response streams, per the [Teams streaming UX guidance](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux). `createOmnichannelStreamingMessage` normalized **every** `streamingChatMessageStarted` event to type `"start"`, which collapsed an informative update that arrives as the *first* streaming event into `"start"` and lost the distinction consumers need to render it as a status indicator rather than response content.

## Change
- In `normalizeStreamingMetadata`, only override a start event to `"start"` when ACS did **not** explicitly mark it `"informative"`; otherwise preserve `"informative"` end-to-end.
- Chunk-event `informative` was already passed through. `streaming`/undefined start events still normalize to `"start"` as before, so existing behavior is unchanged.

## Tests
- `createOmnichannelStreamingMessage.spec.ts` (+5): informative preserved on chunk **and** start events; non-informative start still → `start`; content carried through; consecutive informatives both flow through and never mark the id finalized.
- `ACSClient.streaming.spec.ts` (+1): integration — informative delivered as the start event reaches `onStreamingMessage` with type `informative`.
- Full suite green: node 677/677, jsdom 74/74; `tsc --noEmit` and ESLint clean.

## Notes
- Type-only preservation; no public API surface change (the `StreamingMetadata.streamingMessageType` union already included `"informative"`).
- CHANGELOG updated under `[Unreleased]`.