### PR TITLE
Prepare @microsoft/omnichannel-chat-sdk v2.0.0 official release

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -3,22 +3,24 @@ mode: 'agent'
 description: 'Create a new Release of the Omnichannel Chat SDK'
 ---
 
-Your goals is to create a new release of the Omnichannel Chat SDK and ensure that all necessary actions are performed for the successfull release of new omnichannel chat sdk version.
-Release is created by the .github/workflows/release.yml file which is setted up as a github action.
+Create an official Omnichannel Chat SDK release.
 
-The workflow should perform the following steps:
-    Prompt the user to input the new prerelease version (e.g. 1.11.6-0).
-    Create and checkout a new branch named bump-<prerelease version>.
-    In package.json, update the current version by removing the prerelease tag (e.g., 1.11.5-0 → 1.11.5).
-    Update CHANGELOG.md:
-    Replace the [Unreleased] section with the new version and current date.
-    Add a new section at the top for the new version.
-    Commit the changes with the message: Release version - <version from package.json>.
-    Confirm with the user that the changes are correct and ask for permission to proceed.
-    Create a new Git tag with the release version (e.g., v1.11.5) and push it to the repository.
-    Update package.json to the new prerelease version (e.g., 1.11.6-0).
-    Add a new [Unreleased] section in CHANGELOG.md for the new prerelease version.
-    Commit the changes with the message: Bump version to <new prerelease version>.
-    Push the new branch to the remote repository.
+Read `docs/RELEASING.md` before you make changes. That file is the canonical release procedure.
 
-For reference, you can follow the steps in the PR https://github.com/microsoft/omnichannel-chat-sdk/pull/492 which contains a detailed steps of the release process.
+1. Get the approved semantic version.
+2. Create a release branch from current `upstream/main`.
+3. Update `package.json` and `package-lock.json` with `npm version <version> --no-git-tag-version`.
+4. Move all `CHANGELOG.md` entries from `Unreleased` to the dated version section.
+5. Keep a new empty `Unreleased` section.
+6. Update public API documentation and the README release table.
+7. Run the build, tests, lint, and `npm pack --dry-run`.
+8. Open a pull request and wait for all required checks and reviews.
+9. Do not create the release tag before the pull request merges.
+10. Get the pull-request merge commit.
+11. Create annotated tag `v<version>` on that exact commit.
+12. Push the tag to `microsoft/omnichannel-chat-sdk`.
+13. Do not use workflow dispatch and do not run `npm publish` manually.
+14. Wait for the `npm Release` workflow.
+15. Verify the exact npm version, npm provenance, GitHub Release notes, and attached `.tgz` file.
+
+The tag workflow validates the tag, publishes one tarball to npm, and attaches that same tarball to the GitHub Release.

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -10,13 +10,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
   publish:
     if: github.repository == 'microsoft/omnichannel-chat-sdk'
     runs-on: ubuntu-latest
+    outputs:
+      release-tarball: ${{ steps.pack-release.outputs.filename }}
     steps:
       - name: Checking out for ${{ github.ref }}
         uses: actions/checkout@v4
@@ -37,6 +39,19 @@ jobs:
           echo "name=$(jq -r '.name' package.json)" >> "$GITHUB_OUTPUT"
           echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          EXPECTED_TAG="v${{ steps.read-package-json.outputs.version }}"
+          if [[ "${GITHUB_REF_NAME}" != "${EXPECTED_TAG}" ]]; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} does not match package version ${{ steps.read-package-json.outputs.version }}."
+            exit 1
+          fi
+          if [[ "${{ steps.read-package-json.outputs.version }}" == *-* ]]; then
+            echo "::error::Release tags cannot publish prerelease versions with the latest npm dist-tag."
+            exit 1
+          fi
+
       - name: Determine npm dist-tag
         id: dist-tag
         run: |
@@ -52,26 +67,54 @@ jobs:
       - name: Build
         run: npm run build:tsc
 
+      - name: Pack release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        id: pack-release
+        run: echo "filename=$(npm pack --json | jq -r '.[0].filename')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: npm-tarball
+          path: ${{ steps.pack-release.outputs.filename }}
+          if-no-files-found: error
+
+      - name: Publish release tarball
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: npx npm@11.12.1 publish "${{ steps.pack-release.outputs.filename }}" --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
+
       - name: Publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: npx npm@11.12.1 publish --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
 
-      - name: Pack tarball for GitHub Release
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npm pack
+  github-release:
+    if: needs.publish.result == 'success' && github.repository == 'microsoft/omnichannel-chat-sdk' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking out for ${{ github.ref }}
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download release tarball
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: npm-tarball
 
       - name: Extract CHANGELOG section for ${{ github.ref_name }}
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         id: changelog
         run: |
-          # Strip the leading "v" from the tag (e.g. v1.11.9 -> 1.11.9)
           VERSION="${GITHUB_REF_NAME#v}"
-          # Extract lines between "## [VERSION]" and the next "## [" heading
           awk -v ver="$VERSION" '
             $0 ~ "^## \\[" ver "\\]" {flag=1; next}
             flag && /^## \[/ {flag=0}
             flag {print}
           ' CHANGELOG.md > RELEASE_NOTES.md
-          if [ ! -s RELEASE_NOTES.md ]; then
+          if ! grep -q '[^[:space:]]' RELEASE_NOTES.md; then
             echo "::warning::No CHANGELOG entry found for version $VERSION; falling back to auto-generated notes."
             echo "fallback=true" >> "$GITHUB_OUTPUT"
           else
@@ -79,11 +122,11 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body_path: ${{ steps.changelog.outputs.fallback == 'false' && 'RELEASE_NOTES.md' || '' }}
           generate_release_notes: ${{ steps.changelog.outputs.fallback == 'true' }}
-          files: '*.tgz'
+          files: ${{ needs.publish.outputs.release-tarball }}
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-13
+
 ### Breaking
 
 - Raised the supported consumer runtime to Node.js `>=22.12.0`, matching the remediated OC SDK and AMS client dependencies. This support-policy change requires a major release.
@@ -16,7 +18,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Standardized local, pull-request, release, and consumer runtime support on Node.js `>=22.12.0`.
-- Updated `@microsoft/ocsdk` to `0.6.0-main.dcb2d46` and `@microsoft/omnichannel-amsclient` to `0.2.0-main.3e03701`.
+- Updated `@microsoft/ocsdk` to `0.6.0` and `@microsoft/omnichannel-amsclient` to `0.2.0`.
+- Hardened official releases with tag validation, scoped GitHub permissions, and one tarball shared by npm and GitHub Releases.
 - Removed unused direct Axios, `form-data`, and `follow-redirects` dependencies; the remediated OC SDK now owns the patched HTTP dependency floor.
 - Removed the obsolete brace-expansion override after the regenerated lockfile resolved patched dev-only versions.
 
@@ -54,7 +57,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Pinned `@microsoft/botframework-webchat-adapter-azure-communication-chat` to exact version `0.0.1-beta.8` (removed caret). The previous `^0.0.1-beta.6` range resolved (per semver §11) to the rogue prerelease `0.0.1-beta-1`, which ships an older adapter build whose 15s polling watchdog caused a ~15s delay before the first bot reply rendered in LCW. Pinning forces npm to install the intended `beta.8` build, which contains the fast-poll fix (`iteration <= 45 ? 1000 : delaytm`).
-- Updated botframework-webchat-adapter-azure-communication-chat to "^0.0.1-beta.6"
 
 ### Added
 
@@ -63,11 +65,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Add `github.repository` guard to release workflows to prevent them from running on forks
-- Uptake [@microsoft/ocsdk@0.5.22-main.12fe119](https://www.npmjs.com/package/@microsoft/ocsdk/v/0.5.22-main.12fe119) (adds en-au to supportedLocales)
 - Switch npm publishing to GitHub Actions OIDC trusted publishing (no NPM_TOKEN needed)
 - Dev versions now auto-publish on push to main (e.g. `1.11.9-main.abc1234`)
 - Add `hotfix/**` branch trigger to npm-release workflow
-- Publish a GitHub Release with the packed `.tgz` and auto-generated release notes whenever a `v*` tag is pushed (runs after the npm publish step in `npm-release.yml`)
+- Publish a GitHub Release with changelog notes and the exact npm `.tgz` whenever a `v*` tag is pushed
 
 ### Fixed
 - Fix unhandled exception in the WebSocket `onNewMessage` callback wrapper in `OmnichannelChatSDK`. `createOmnichannelMessage()` was called without a try/catch, so a transformation error became an unhandled promise rejection that broke the callback chain and prevented the customer `onNewMessage` callback from firing for subsequent messages. The transformation is now wrapped in try/catch: failures are recorded via `scenarioMarker.singleRecord` (structured `ExceptionDetails`) and the bad message is skipped, keeping message reception alive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 - Standardized local, pull-request, release, and consumer runtime support on Node.js `>=22.12.0`.
 - Updated `@microsoft/ocsdk` to `0.6.0` and `@microsoft/omnichannel-amsclient` to `0.2.0`.
 - Hardened official releases with tag validation, scoped GitHub permissions, and one tarball shared by npm and GitHub Releases.
+- Added public migration guidance and API examples for streaming messages and mid-conversation authentication.
+- Added a complete `2.0.0` migration, validation, deployment, and rollback guide.
+- Documented authentication, streaming, and read-state prerequisites for the new public APIs.
+- Replaced the obsolete release-agent prompt with the canonical pull-request and tag workflow.
 - Removed unused direct Axios, `form-data`, and `follow-redirects` dependencies; the remediated OC SDK now owns the patched HTTP dependency floor.
 - Removed the obsolete brace-expansion override after the regenerated lockfile resolved patched dev-only versions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,10 @@ npm install
 - **Lint:** `npm run lint` - ESLint validation
 
 **Release:**
-- **Publish:** `npm publish` - Publish to npm registry (requires npm auth)
-- **Version bump:** `npm version <major|minor|patch>` - Semantic versioning
+- **Canonical process:** Follow [docs/RELEASING.md](docs/RELEASING.md)
+- **Official release:** Merge a release PR, then push `v<version>` on that exact merge commit
+- **Automation:** The tag publishes the package to npm and creates the GitHub Release with changelog notes and the exact npm tarball
+- **Prohibited:** Do not run `npm publish` manually and do not use workflow dispatch for an official release
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/%40microsoft%2Fomnichannel-chat-sdk.svg)](https://badge.fury.io/js/%40microsoft%2Fomnichannel-chat-sdk)
 [![install size](https://packagephobia.com/badge?p=@microsoft/omnichannel-chat-sdk)](https://packagephobia.com/result?p=@microsoft/omnichannel-chat-sdk)
-![Release CI](https://github.com/microsoft/omnichannel-chat-sdk/workflows/Release%20CI/badge.svg)
+[![npm Release](https://github.com/microsoft/omnichannel-chat-sdk/actions/workflows/npm-release.yml/badge.svg)](https://github.com/microsoft/omnichannel-chat-sdk/actions/workflows/npm-release.yml)
 ![npm](https://img.shields.io/npm/dm/@microsoft/omnichannel-chat-sdk)
 
 > [!IMPORTANT]
@@ -112,9 +112,9 @@ For a detailed tracking of the releases, please refer to the [Changelog document
 
 _**Important Note:**_ Versions below 1.11.0 are no longer supported after November 1st, 2025. Please update to recent versions to ensure you have the latest features and bug fixes.
 
-
 | Version | Docs | Release Date | End of Support | Deprecated |
 | -- | -- | -- | -- | -- |
+| 2.0.0 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v2.0.0) | Aug 13th 2026 | Aug 13th 2027 | |
 | 1.11.4 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.4) | Jul 17th 2025 | Jul 17th 2026 | |
 | 1.11.3 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.3) | Jul 14th 2025 | Jul 14th 2026 | |
 | 1.11.2 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.2) | Jun 24th 2025 | Jun 24th 2026 | |
@@ -123,6 +123,8 @@ _**Important Note:**_ Versions below 1.11.0 are no longer supported after Novemb
 
 
 ## Installation
+
+Node.js `>=22.12.0` is required.
 
 ```console
 npm install @microsoft/omnichannel-chat-sdk --save
@@ -1323,11 +1325,11 @@ const chatSDK = new OmnichannelChatSDK.OmnichannelChatSDK(omnichannelConfig, cha
 await chatSDK.initialize();
 ```
 
-# Releasing
+## Releasing
 
-See [docs/RELEASING.md](docs/RELEASING.md) for how to publish new versions to npm.
+See [docs/RELEASING.md](docs/RELEASING.md) for development builds, official npm and GitHub releases, release notes, and hotfixes.
 
-# Contributing
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Please make sure you have a chat widget configured before using this package or 
 - [SDK Methods](#sdk-methods)
   - [Initialization](#initialization)
   - [Start Chat](#start-chat)
+  - [Authenticate Chat](#authenticate-chat)
   - [End Chat](#end-chat)
   - [Get Pre-Chat Survey](#get-pre-chat-survey)
   - [Get Live Chat Config](#get-live-chat-config)
@@ -34,6 +35,7 @@ Please make sure you have a chat widget configured before using this package or 
   - [Get Messages](#get-messages)
   - [Send Messages](#send-messages)
   - [On New Message](#on-new-message)
+  - [On Streaming Message](#on-streaming-message)
   - [On Typing Event](#on-typing-event)
   - [On Agent End Session](#on-agent-end-session)
   - [Send Typing Event](#send-typing-event)
@@ -114,13 +116,28 @@ _**Important Note:**_ Versions below 1.11.0 are no longer supported after Novemb
 
 | Version | Docs | Release Date | End of Support | Deprecated |
 | -- | -- | -- | -- | -- |
-| 2.0.0 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v2.0.0) | Aug 13th 2026 | Aug 13th 2027 | |
+| 2.0.0 | [Migration Guide](docs/MIGRATION_2.0.md) / [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v2.0.0) | Aug 13th 2026 | Aug 13th 2027 | |
 | 1.11.4 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.4) | Jul 17th 2025 | Jul 17th 2026 | |
 | 1.11.3 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.3) | Jul 14th 2025 | Jul 14th 2026 | |
 | 1.11.2 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.2) | Jun 24th 2025 | Jun 24th 2026 | |
 | 1.11.1 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.1) | Jun 5th 2025 | Jun 5th 2026 | |
 | 1.11.0 | [Release Notes](https://github.com/microsoft/omnichannel-chat-sdk/releases/tag/v1.11.0) | May 27th 2025 | May 27th 2026 | |
 
+### Upgrade to 2.0.0
+
+Version `2.0.0` requires Node.js `>=22.12.0`. This requirement also applies to the official OC SDK and AMS client dependencies.
+
+```bash
+npm install @microsoft/omnichannel-chat-sdk@2.0.0 --save-exact
+```
+
+The npm `latest` dist-tag can point to a `main` prerelease. Use the exact version for production.
+
+Regenerate the application lockfile after the update. Then run the application build and tests on Node.js 22.
+
+Version `2.0.0` adds progressive bot-message streaming, mid-conversation authentication, read receipts, and unread-message counts. Existing `onNewMessage` handlers continue to receive final streaming messages.
+
+See the [2.0 migration guide](docs/MIGRATION_2.0.md) for the complete upgrade and validation procedure.
 
 ## Installation
 
@@ -314,6 +331,32 @@ const optionalParams = {
 await chatSDK.startChat(optionalParams);
 ```
 
+### Authenticate Chat
+
+It authenticates an active unauthenticated conversation. Enable optional authenticated sign-in for the workstream before you use this method.
+
+Call `initialize()` and `startChat()` before `authenticateChat()`. The first argument can be a token or an asynchronous token provider.
+
+```ts
+await chatSDK.initialize();
+await chatSDK.startChat();
+
+await chatSDK.authenticateChat(async () => {
+    const response = await fetch("https://contoso.example/token");
+    if (!response.ok) {
+        throw new Error("Token request failed");
+    }
+
+    return response.text();
+}, {
+    refreshChatToken: true
+});
+```
+
+Set `refreshChatToken` to `true` when subsequent SDK calls must use a refreshed authenticated chat token.
+
+The method throws `InvalidConversation` when no conversation is active. It throws `MidConversationAuthFailure` when token resolution or authentication fails.
+
 ### End Chat
 
 It ends the current Omnichannel conversation.
@@ -457,6 +500,38 @@ chatSDK.onNewMessage((message) => {
     console.log(message);
 }, optionalParams);
 ```
+
+### On Streaming Message
+
+It subscribes to progressive ACS bot-message updates. This API is available only for Live Chat version 2.
+
+Enable streaming when you start the conversation. Then register the handler after `startChat()` completes.
+
+```ts
+await chatSDK.initialize();
+await chatSDK.startChat({
+    supportsLcwStreaming: true
+});
+
+await chatSDK.onStreamingMessage((message) => {
+    const { streamingMessageType, streamEndReason } = message.streamingMetadata;
+
+    // Each event contains the full assembled content, not only the new text.
+    renderStreamingMessage(message.id, message.content);
+
+    if (message.policyViolation) {
+        handlePolicyViolation(message.policyViolation.result);
+    }
+
+    if (streamingMessageType === "final") {
+        completeStreamingMessage(message.id, streamEndReason);
+    }
+});
+```
+
+`streamingMessageType` can be `start`, `informative`, `streaming`, or `final`. A final message also reaches existing `onNewMessage` handlers.
+
+Calling this method before `startChat()` throws `UninitializedConversation`. Calling it for another Live Chat version throws `UnsupportedLiveChatVersion`.
 
 ### On Typing Event
 
@@ -615,13 +690,15 @@ const agentAvailability = await chatSDK.getAgentAvailability();
 
 Logs a particular message (and all previous messages) as read by the user. Read indicators will appear for Contact Center Representatives and Admins in the Admin Center.
 
+Authenticated chat sends the receipt through Messaging Runtime. Unauthenticated chat sends it through ACS and requires Live Chat version 2.
+
 ```ts
 await chatSDK.sendReadReceipt(messageId: string);
 ```
 
 ### Get Unread Message Count
 
-Returns the number of unread messages in an authenticated persistent conversation. This call is **authenticated-only** — the user must be authenticated, otherwise an `UndefinedAuthToken` error is thrown.
+Returns unread-message data for an authenticated user. An active chat session is not required. This call is **authenticated-only** — the user must be authenticated, otherwise an `UndefinedAuthToken` error is thrown.
 
 ```ts
 const response = await chatSDK.getUnreadMessageCount();

--- a/docs/MIGRATION_2.0.md
+++ b/docs/MIGRATION_2.0.md
@@ -1,0 +1,73 @@
+# Migrate to Omnichannel Chat SDK 2.0
+
+## Scope
+
+This guide applies to applications that upgrade from Chat SDK 1.x to `@microsoft/omnichannel-chat-sdk@2.0.0`.
+
+## Runtime Requirement
+
+Version `2.0.0` requires Node.js `>=22.12.0`. Update local development, build agents, test agents, and production Node.js hosts.
+
+The package also uses these official dependencies:
+
+- `@microsoft/ocsdk@0.6.0`
+- `@microsoft/omnichannel-amsclient@0.2.0`
+
+## Install the Official Version
+
+The npm `latest` dist-tag can point to an automatic `main` prerelease. Pin the official version in production.
+
+```bash
+npm install @microsoft/omnichannel-chat-sdk@2.0.0 --save-exact
+```
+
+Commit the regenerated lockfile. Make sure that it resolves Chat SDK `2.0.0`, OC SDK `0.6.0`, and AMS client `0.2.0`.
+
+## Upgrade Procedure
+
+1. Update all build and runtime environments to Node.js `22.12.0` or later.
+2. Install the exact Chat SDK version.
+3. Regenerate and commit the application lockfile.
+4. Run the application build, unit tests, and integration tests.
+5. Test chat start, message send, message receive, attachments, reconnect, and authenticated chat.
+6. Deploy to a test environment before production.
+7. Monitor SDK error telemetry after deployment.
+
+## Progressive Bot-Message Streaming
+
+Streaming is opt-in. Existing applications continue to receive final messages through `onNewMessage`.
+
+Set `supportsLcwStreaming: true` only when the application can render progressive updates. Register `onStreamingMessage` after `startChat` completes.
+
+See [On Streaming Message](../README.md#on-streaming-message) for the API contract and example.
+
+## Mid-Conversation Authentication
+
+The new `authenticateChat` method authenticates an active unauthenticated conversation.
+
+Enable optional authenticated sign-in for the workstream before you use this method. The method accepts a token or an asynchronous token provider.
+
+See [Authenticate Chat](../README.md#authenticate-chat) for the API contract, errors, and example.
+
+## Read State APIs
+
+Version `2.0.0` adds these APIs:
+
+- `sendReadReceipt(messageId)` marks a message and earlier messages as read.
+- `getUnreadMessageCount()` returns unread-message data for an authenticated user. An active chat session is not required.
+
+Authenticated read receipts use Messaging Runtime. Unauthenticated read receipts use ACS and require Live Chat version 2.
+
+See [Send Read Receipt](../README.md#send-read-receipt) and [Get Unread Message Count](../README.md#get-unread-message-count).
+
+## Release Integrity
+
+The `v2.0.0` GitHub Release contains the same `.tgz` file that the workflow publishes to npm.
+
+The npm package includes a provenance statement from GitHub Actions. Use the exact version and committed lockfile for repeatable installations.
+
+## Rollback
+
+If the application cannot use Node.js 22, restore the last approved 1.x version and its lockfile.
+
+Do not change the npm `latest` dist-tag or the Git tag as an application rollback method.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,63 +9,104 @@ This package uses **GitHub Actions OIDC trusted publishing** — no npm tokens o
 Every push to `main` automatically publishes a dev version to npm:
 
 ```
-1.11.8-main.abc1234
+2.0.0-main.abc1234
        ^^^^^^^^^^^^
        branch + short commit SHA (via version-from-git)
 ```
 
-- **npm tag**: `main` (not `latest`)
-- **Install**: `npm install @microsoft/omnichannel-chat-sdk@main`
+- **npm dist-tag**: `latest`
+- **Install**: Use the exact version from the workflow output, such as `npm install @microsoft/omnichannel-chat-sdk@2.0.0-main.abc1234`
 - **Triggered by**: Any merge/push to the `main` branch
 
-### Release Versions (Manual — Tag Push)
+The workflow intentionally moves `latest` to each `main` prerelease. An install without a version can receive a prerelease.
 
-To publish a release version (e.g. `1.12.0`):
+### Official Releases (Release PR and Tag)
 
-1. **Update the version** in `package.json`:
+Use an approved semantic version. In the examples below, replace `2.0.1` and `578` with the new version and pull-request number.
+
+```bash
+VERSION=2.0.1
+PR_NUMBER=578
+```
+
+1. **Create a release branch from current `upstream/main`.**
+
    ```bash
-   # Edit package.json version field to the new version
+   git fetch upstream
+   git checkout -b "release/v$VERSION" upstream/main
    ```
 
-2. **Update the changelog** in `CHANGELOG.md`
+2. **Set the version in `package.json` and `package-lock.json`.**
 
-3. **Commit and push** to main:
    ```bash
-   git add package.json CHANGELOG.md
-   git commit -m "Bump version to 1.12.0"
-   git push
+   npm version "$VERSION" --no-git-tag-version
    ```
 
-4. **Create and push a tag**:
+3. **Finalize `CHANGELOG.md`.**
+
+   Move all release entries below `## [$VERSION] - YYYY-MM-DD`. Keep a new `## [Unreleased]` section above that heading.
+
+4. **Open a pull request.**
+
+   Include `package.json`, `package-lock.json`, and `CHANGELOG.md`. Merge the pull request only after all required checks pass.
+
+   The merge to `main` publishes a `VERSION-main.SHA` prerelease with the npm `latest` dist-tag. This publish is expected.
+
+5. **Get the pull-request merge commit.**
+
    ```bash
-   git tag v1.12.0
-   git push origin v1.12.0
+   MERGE_SHA=$(gh pr view "$PR_NUMBER" --repo microsoft/omnichannel-chat-sdk --json mergeCommit --jq '.mergeCommit.oid')
+   test -n "$MERGE_SHA"
    ```
 
-5. The `npm-release.yml` workflow will:
-   - Build the package (`npm run build:tsc`)
-   - Publish to npm with `--tag latest`
-   - Include provenance attestation (visible on npmjs.com)
+6. **Create an annotated tag on that merge commit.**
+
+   ```bash
+   git fetch upstream --tags
+   git tag -a "v$VERSION" "$MERGE_SHA" -m "Release v$VERSION"
+   git push upstream "v$VERSION"
+   ```
+
+   The tag must equal `v` plus the version in `package.json`. The workflow rejects mismatched tags and prerelease tags.
+
+7. **Wait for the tag workflows.**
+
+Do not use **Run workflow** for an official release. The pushed tag starts the npm and legacy artifact workflows.
+
+The npm workflow publishes the package with `--tag latest`. Then it creates GitHub Release `v$VERSION` with notes and the published npm tarball.
+
+### GitHub Release Notes
+
+The workflow removes `v` from the tag. For example, it converts `v2.0.1` to `2.0.1`.
+
+It finds `## [2.0.1]` in `CHANGELOG.md`. It copies that section until the next `## [` version heading.
+
+The copied text becomes the GitHub Release body. If the matching section is empty or absent, GitHub generates notes from merged pull requests.
+
+The workflow packs the package once. It publishes that `.tgz` file to npm and attaches the same file to the GitHub Release.
 
 ### Verifying a Publish
 
 ```bash
-# Check latest release version
+# Read the version selected by latest
 npm view @microsoft/omnichannel-chat-sdk version
 
-# Check all dist-tags (latest + main)
+# Read all dist-tags
 npm view @microsoft/omnichannel-chat-sdk dist-tags
 
-# Check a specific dev version
-npm view @microsoft/omnichannel-chat-sdk@main version
+# Check the official version
+npm view "@microsoft/omnichannel-chat-sdk@$VERSION" version
+
+# Check the GitHub Release and its asset
+gh release view "v$VERSION" --repo microsoft/omnichannel-chat-sdk
 ```
 
 ### Tag Format
 
 | Tag pattern | What publishes | npm dist-tag |
 |-------------|---------------|--------------|
-| `v*` (e.g. `v1.12.0`) | Release version from `package.json` | `latest` |
-| Push to `main` | Dev version `X.Y.Z-main.<sha>` | `main` |
+| `v*` (e.g. `v2.0.1`) | Release version from `package.json` | `latest` |
+| Push to `main` | Dev version `X.Y.Z-main.<sha>` | `latest` |
 
 ### Hotfix Versions
 
@@ -95,6 +136,8 @@ For urgent fixes that need to ship against an older release (not `main`), use a 
    npm view @microsoft/omnichannel-chat-sdk@1.11.7-hotfix.<name>.1
    ```
 
+Do not create a `v*` tag for a hotfix prerelease. The workflow rejects prerelease tags to protect the `latest` dist-tag.
+
 #### Hotfix Version Naming Convention
 
 ```
@@ -109,6 +152,8 @@ Example: `1.11.7-hotfix.enau.1`
 
 ### Important Notes
 
-- **Burned versions**: If a publish fails, that version number is consumed by npm. You must bump to the next version.
+- **Published versions**: npm does not permit a second publish of the same version. Use a new version after npm accepts a bad publish.
 - **Trusted publisher**: Configured on npmjs.com to trust `microsoft/omnichannel-chat-sdk` → `npm-release.yml`. No npm tokens needed.
 - **Provenance**: All publishes include a signed provenance statement verifiable on npmjs.com.
+- **Release notes**: A matching changelog section supplies the GitHub Release notes. GitHub generates notes when the section is absent.
+- **Release asset**: Each GitHub Release contains the exact npm `.tgz` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@azure/communication-chat": "1.6.0-beta.7",
         "@azure/communication-common": "2.4.2",
         "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.8",
-        "@microsoft/ocsdk": "0.6.0-main.dcb2d46",
-        "@microsoft/omnichannel-amsclient": "0.2.0-main.3e03701",
+        "@microsoft/ocsdk": "0.6.0",
+        "@microsoft/omnichannel-amsclient": "0.2.0",
         "@microsoft/omnichannel-ic3core": "^0.1.5"
       },
       "devDependencies": {
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@microsoft/ocsdk": {
-      "version": "0.6.0-main.dcb2d46",
-      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.6.0-main.dcb2d46.tgz",
-      "integrity": "sha512-J67spHVLqtY20r67agMPy2cZm/gXImgYb1oie89rf4/DOxJ/XZQFaeuBlWeAycni5AhXcKkQZXRBZEx/bIlG6g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/ocsdk/-/ocsdk-0.6.0.tgz",
+      "integrity": "sha512-mV6YZz+SKb1ASwYnNtmVLjPQo5DqyIwA6zeMt4ie7F293s4dDUVkhWi8/oTvWJPFjO8EUU7sRuS1mwrWb8p59g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -1567,9 +1567,9 @@
       }
     },
     "node_modules/@microsoft/omnichannel-amsclient": {
-      "version": "0.2.0-main.3e03701",
-      "resolved": "https://registry.npmjs.org/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0-main.3e03701.tgz",
-      "integrity": "sha512-j8Rg60ru6O3cW/lXqxxjTQY0qFXyS9XqWLRRjFgoqUYDn39+UA34sATO2br8e40jAMlu6cYIPzNKdU6Nyx6LYQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0.tgz",
+      "integrity": "sha512-wIubYjfzovWv2+P+AInxhOfB1MwVoR7veljAreHbq0Y+6haPMCxtY2LhIq8UGzGVk/UdcUXe3laV0AZdwBxSCw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "@azure/communication-chat": "1.6.0-beta.7",
     "@azure/communication-common": "2.4.2",
     "@microsoft/botframework-webchat-adapter-azure-communication-chat": "0.0.1-beta.8",
-    "@microsoft/ocsdk": "0.6.0-main.dcb2d46",
-    "@microsoft/omnichannel-amsclient": "0.2.0-main.3e03701",
+    "@microsoft/ocsdk": "0.6.0",
+    "@microsoft/omnichannel-amsclient": "0.2.0",
     "@microsoft/omnichannel-ic3core": "^0.1.5"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- uptake the official `@microsoft/ocsdk@0.6.0` and `@microsoft/omnichannel-amsclient@0.2.0` releases
- validate official tags and reject prerelease tags
- publish one tarball to npm and attach that exact artifact to the GitHub Release
- limit `contents: write` to the tag-only GitHub Release job
- finalize the curated `2.0.0` changelog section
- add complete migration, API, release, deployment, validation, integrity, rollback, and agent documentation
- update the README release badge, release table, Node.js requirement, and exact-version installation guidance

## Consumer impact
- `2.0.0` requires Node.js `>=22.12.0`, matching the official root dependencies
- production consumers must pin `2.0.0` because the npm `latest` dist-tag can point to a `main` prerelease
- progressive bot-message streaming is opt-in through `supportsLcwStreaming`; existing `onNewMessage` handlers still receive final messages
- mid-conversation authentication requires optional authenticated sign-in on the workstream
- read receipts and unread-message APIs now have documented authentication and Live Chat version requirements

See [`docs/MIGRATION_2.0.md`](https://github.com/microsoft/omnichannel-chat-sdk/blob/main/docs/MIGRATION_2.0.md) for the complete consumer procedure.

## Release flow
After this PR merges, create annotated tag `v2.0.0` on the merge commit. The tag workflow will publish `@microsoft/omnichannel-chat-sdk@2.0.0` to npm, create GitHub Release `v2.0.0` from the changelog section, and attach the published `.tgz`.

Do not use workflow dispatch and do not run `npm publish` manually.

## Dependency evidence
- `@microsoft/ocsdk@0.6.0` resolves from npm-backed unpkg and jsDelivr
- `@microsoft/omnichannel-amsclient@0.2.0` resolves from npm-backed unpkg and jsDelivr
- the committed lockfile integrity values match the exact GitHub Release tarballs published by the root-package workflows

## Validation
- `npm ls @microsoft/ocsdk @microsoft/omnichannel-amsclient --depth=0`
- `npm run build:tsc`
- `npm test` — 35 suites, 671 tests passed
- `npm run lint` — no errors or warnings
- `npm pack --dry-run`
- workflow YAML, release metadata, changelog extraction, documentation links, and API contracts
