### PR TITLE
docs: correct 2.0.0 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Corrected the version `2.0.0` feature documentation.
+
 ## [2.0.0] - 2026-08-13
 
 ### Changes published to npm after v1.11.6
@@ -52,12 +56,6 @@ GitHub Release automation started with `v2.0.0`. Versions `1.11.7` and `1.11.8` 
 - Added `SendReadReceiptFailure`, `SendReadReceiptInvalidParams`, `UnreadMessageCountRetrievalFailure` to `ChatSDKErrorName` enum
 - Added throw helpers in `exceptionThrowers.ts` for read receipt error handling
 - HTTP error mapping: 404 → `InvalidConversation`, 400 → `SendReadReceiptInvalidParams`, others → retrieval/send failure
-- Added `authenticateChat` public method to authenticate an ongoing unauthenticated chat session mid-conversation
-- Added `MidConversationAuth` telemetry event for scenario tracking
-- Added `MidConversationAuthFailure` to `ChatSDKErrorName` enum
-- Added internal deferred-initial-authentication handling for optional sign-in flows
-- Uses structured `ChatSDKExceptionDetails` with `JSON.stringify` for all telemetry `ExceptionDetails`
-- Throws `ChatSDKError` consistently on all failure paths (token resolution, empty token, API call, token refresh)
 - Added `en-AU` (Australian English) locale code `3081` to locale mapping
 
 ### Changed
@@ -65,9 +63,9 @@ GitHub Release automation started with `v2.0.0`. Versions `1.11.7` and `1.11.8` 
 - Standardized local, pull-request, release, and consumer runtime support on Node.js `>=22.12.0`.
 - Updated `@microsoft/ocsdk` to `0.6.0` and `@microsoft/omnichannel-amsclient` to `0.2.0`.
 - Hardened official releases with tag validation, scoped GitHub permissions, and one tarball shared by npm and GitHub Releases.
-- Added public migration guidance and API examples for streaming messages and mid-conversation authentication.
+- Added public migration guidance and API examples for streaming messages and read-state APIs.
 - Added a complete `2.0.0` migration, validation, deployment, and rollback guide.
-- Documented authentication, streaming, and read-state prerequisites for the new public APIs.
+- Documented streaming and read-state prerequisites for the new public APIs.
 - Replaced the obsolete release-agent prompt with the canonical pull-request and tag workflow.
 - Removed unused direct Axios, `form-data`, and `follow-redirects` dependencies; the remediated OC SDK now owns the patched HTTP dependency floor.
 - Removed the obsolete brace-expansion override after the regenerated lockfile resolved patched dev-only versions.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Please make sure you have a chat widget configured before using this package or 
 - [SDK Methods](#sdk-methods)
   - [Initialization](#initialization)
   - [Start Chat](#start-chat)
-  - [Authenticate Chat](#authenticate-chat)
   - [End Chat](#end-chat)
   - [Get Pre-Chat Survey](#get-pre-chat-survey)
   - [Get Live Chat Config](#get-live-chat-config)
@@ -135,7 +134,7 @@ The npm `latest` dist-tag can point to a `main` prerelease. Use the exact versio
 
 Regenerate the application lockfile after the update. Then run the application build and tests on Node.js 22.
 
-Version `2.0.0` adds progressive bot-message streaming, mid-conversation authentication, read receipts, and unread-message counts. Existing `onNewMessage` handlers continue to receive final streaming messages.
+Version `2.0.0` adds progressive bot-message streaming, read receipts, and unread-message counts. Existing `onNewMessage` handlers continue to receive final streaming messages.
 
 See the [2.0 migration guide](docs/MIGRATION_2.0.md) for the complete upgrade and validation procedure.
 
@@ -330,32 +329,6 @@ const optionalParams = {
 
 await chatSDK.startChat(optionalParams);
 ```
-
-### Authenticate Chat
-
-It authenticates an active unauthenticated conversation. Enable optional authenticated sign-in for the workstream before you use this method.
-
-Call `initialize()` and `startChat()` before `authenticateChat()`. The first argument can be a token or an asynchronous token provider.
-
-```ts
-await chatSDK.initialize();
-await chatSDK.startChat();
-
-await chatSDK.authenticateChat(async () => {
-    const response = await fetch("https://contoso.example/token");
-    if (!response.ok) {
-        throw new Error("Token request failed");
-    }
-
-    return response.text();
-}, {
-    refreshChatToken: true
-});
-```
-
-Set `refreshChatToken` to `true` when subsequent SDK calls must use a refreshed authenticated chat token.
-
-The method throws `InvalidConversation` when no conversation is active. It throws `MidConversationAuthFailure` when token resolution or authentication fails.
 
 ### End Chat
 

--- a/docs/MIGRATION_2.0.md
+++ b/docs/MIGRATION_2.0.md
@@ -41,14 +41,6 @@ Set `supportsLcwStreaming: true` only when the application can render progressiv
 
 See [On Streaming Message](../README.md#on-streaming-message) for the API contract and example.
 
-## Mid-Conversation Authentication
-
-The new `authenticateChat` method authenticates an active unauthenticated conversation.
-
-Enable optional authenticated sign-in for the workstream before you use this method. The method accepts a token or an asynchronous token provider.
-
-See [Authenticate Chat](../README.md#authenticate-chat) for the API contract, errors, and example.
-
 ## Read State APIs
 
 Version `2.0.0` adds these APIs:


### PR DESCRIPTION
## Summary

- Correct the version 2.0.0 feature list in the README and changelog.
- Remove withheld API guidance from the README and migration guide.
- Keep the published SDK implementation unchanged.

## Verification

- Searched the public Markdown documentation for the removed feature terms.
- Ran `git diff --check`.

The published GitHub release notes were corrected separately.
