### PR TITLE
docs: remove redundant Live Chat version 2 wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Corrected the version `2.0.0` feature documentation.
+- Removed redundant "Live Chat version 2" wording from the 2.0 migration guide and related API notes.
 
 ## [2.0.0] - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ chatSDK.onNewMessage((message) => {
 
 ### On Streaming Message
 
-It subscribes to progressive ACS bot-message updates. This API is available only for Live Chat version 2.
+It subscribes to progressive ACS bot-message updates.
 
 Enable streaming when you start the conversation. Then register the handler after `startChat()` completes.
 
@@ -504,7 +504,7 @@ await chatSDK.onStreamingMessage((message) => {
 
 `streamingMessageType` can be `start`, `informative`, `streaming`, or `final`. A final message also reaches existing `onNewMessage` handlers.
 
-Calling this method before `startChat()` throws `UninitializedConversation`. Calling it for another Live Chat version throws `UnsupportedLiveChatVersion`.
+Calling this method before `startChat()` throws `UninitializedConversation`. If the conversation does not use ACS, this method throws `UnsupportedLiveChatVersion`.
 
 ### On Typing Event
 
@@ -663,7 +663,7 @@ const agentAvailability = await chatSDK.getAgentAvailability();
 
 Logs a particular message (and all previous messages) as read by the user. Read indicators will appear for Contact Center Representatives and Admins in the Admin Center.
 
-Authenticated chat sends the receipt through Messaging Runtime. Unauthenticated chat sends it through ACS and requires Live Chat version 2.
+Authenticated chat sends the receipt through Messaging Runtime. Unauthenticated chat sends the receipt through ACS.
 
 ```ts
 await chatSDK.sendReadReceipt(messageId: string);

--- a/docs/MIGRATION_2.0.md
+++ b/docs/MIGRATION_2.0.md
@@ -48,7 +48,7 @@ Version `2.0.0` adds these APIs:
 - `sendReadReceipt(messageId)` marks a message and earlier messages as read.
 - `getUnreadMessageCount()` returns unread-message data for an authenticated user. An active chat session is not required.
 
-Authenticated read receipts use Messaging Runtime. Unauthenticated read receipts use ACS and require Live Chat version 2.
+Authenticated read receipts use Messaging Runtime. Unauthenticated read receipts use ACS.
 
 See [Send Read Receipt](../README.md#send-read-receipt) and [Get Unread Message Count](../README.md#get-unread-message-count).
 


### PR DESCRIPTION
## Summary

- Remove "Live Chat version 2" from the 2.0 migration guide. The guide already covers the upgrade to Chat SDK 2.0.
- Keep the useful transport fact: authenticated read receipts use Messaging Runtime, and unauthenticated read receipts use ACS.
- Apply the same wording in the README streaming and read-receipt notes. The `UnsupportedLiveChatVersion` error remains, now described as a non-ACS conversation.

## Verification

- Searched public Markdown for leftover "Live Chat version 2" phrases.
- Ran `git diff --check`.
- Docs-only change. No product code, tests, or build.
