### PR TITLE
fix: use reconnect ID for persistent customer close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Used the reconnect identifier when an enabled persistent-chat customer closes a reconnected conversation.
+
 ### Changed
 
 - Corrected the version `2.0.0` feature documentation.

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -4595,13 +4595,20 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
             chatSDK.isPersistentChat = true;
+            const lcwFcbConfiguration = workstreamGate === 'false'
+                ? Object.defineProperty({}, 'lcwPersistentChatCustomerEndEnabled', {
+                    get: () => {
+                        throw new Error('The rollout gate must not be read when the workstream gate is disabled');
+                    }
+                })
+                : {
+                    lcwPersistentChatCustomerEndEnabled: rolloutGate
+                };
             chatSDK.liveChatConfig = {
                 LiveWSAndLiveChatEngJoin: {
                     msdyn_enablecustomerclosepersistentchat: workstreamGate
                 },
-                LcwFcbConfiguration: {
-                    lcwPersistentChatCustomerEndEnabled: rolloutGate
-                }
+                LcwFcbConfiguration: lcwFcbConfiguration
             };
             chatSDK.updateChatToken = jest.fn();
             global.setInterval = jest.fn() as unknown as typeof setInterval;

--- a/__tests__/OmnichannelChatSDK.spec.ts
+++ b/__tests__/OmnichannelChatSDK.spec.ts
@@ -4569,7 +4569,18 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             clearInterval(chatSDK.refreshTokenTimer);
         });
 
-        it('ChatSDK.endChat() should pass isPersistentChat & isReconnectChat to OCClient.sessionClose() call \'s optional paramaters on Persistent Chat', async () => {
+        it.each([
+            ['both customer-close gates are enabled', 'true', 'true', 'reconnectid', 'reconnectid'],
+            ['the workstream gate is disabled', 'false', 'true', 'reconnectid', 'requestId'],
+            ['the rollout gate is disabled', 'true', 'false', 'reconnectid', 'requestId'],
+            ['there is no reconnectable chat', 'true', 'true', undefined, 'requestId']
+        ])('ChatSDK.endChat() should use the expected session-close identifier on Persistent Chat when %s', async (
+            _scenario,
+            workstreamGate,
+            rolloutGate,
+            reconnectId,
+            expectedIdentifier
+        ) => {
             const chatSDKConfig = {
                 telemetry: {
                     disable: true
@@ -4584,6 +4595,14 @@ describe('Omnichannel Chat SDK, Sequential', () => {
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
             chatSDK.isPersistentChat = true;
+            chatSDK.liveChatConfig = {
+                LiveWSAndLiveChatEngJoin: {
+                    msdyn_enablecustomerclosepersistentchat: workstreamGate
+                },
+                LcwFcbConfiguration: {
+                    lcwPersistentChatCustomerEndEnabled: rolloutGate
+                }
+            };
             chatSDK.updateChatToken = jest.fn();
             global.setInterval = jest.fn() as unknown as typeof setInterval;
             chatSDK["isAMSClientAllowed"] = true;
@@ -4596,17 +4615,23 @@ describe('Omnichannel Chat SDK, Sequential', () => {
 
             jest.spyOn(chatSDK.OCClient, 'sessionInit').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.OCClient, 'createConversation').mockResolvedValue(Promise.resolve());
-            jest.spyOn(chatSDK.OCClient, 'getReconnectableChats').mockResolvedValue(Promise.resolve({
-                reconnectid: 'reconnectid'
-            }));
+            jest.spyOn(chatSDK.OCClient, 'getReconnectableChats').mockResolvedValue(Promise.resolve(
+                reconnectId ? { reconnectid: reconnectId } : {}
+            ));
             jest.spyOn(chatSDK.OCClient, 'sessionClose').mockResolvedValue(Promise.resolve());
 
+            const requestId = chatSDK.requestId;
+            expect(requestId).toBeTruthy();
+            expect(requestId).not.toBe('reconnectid');
             await chatSDK.startChat();
             await chatSDK.endChat();
 
             expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
             expect(chatSDK.OCClient.sessionClose.mock.calls[0][1].isPersistentChat).toBe(true);
-            expect(chatSDK.OCClient.sessionClose.mock.calls[0][1].isReconnectChat).toBe(true);
+            expect(chatSDK.OCClient.sessionClose.mock.calls[0][1].isReconnectChat).toBe(Boolean(reconnectId));
+            expect(chatSDK.OCClient.sessionClose.mock.calls[0][0]).toBe(
+                expectedIdentifier === 'reconnectid' ? expectedIdentifier : requestId
+            );
         });
 
         it('[LiveChatV1] ChatSDK.updateChatToken() should initialize IC3Client with new session info', async () => {

--- a/__tests__/OmnichannelChatSDKParallel.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.spec.ts
@@ -3220,7 +3220,18 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             expect(chatSDK.OCClient.getChatToken.mock.calls[0][1].reconnectId).toBe(chatSDK.reconnectId);
         });
 
-        it('ChatSDK.endChat() should pass isPersistentChat & isReconnectChat to OCClient.sessionClose() call \'s optional paramaters on Persistent Chat', async () => {
+        it.each([
+            ['both customer-close gates are enabled', 'true', 'true', 'reconnectid', 'reconnectid'],
+            ['the workstream gate is disabled', 'false', 'true', 'reconnectid', 'requestId'],
+            ['the rollout gate is disabled', 'true', 'false', 'reconnectid', 'requestId'],
+            ['there is no reconnectable chat', 'true', 'true', undefined, 'requestId']
+        ])('ChatSDK.endChat() should use the expected session-close identifier on Persistent Chat when %s', async (
+            _scenario,
+            workstreamGate,
+            rolloutGate,
+            reconnectId,
+            expectedIdentifier
+        ) => {
             const chatSDKConfig = {
                 telemetry: {
                     disable: true
@@ -3235,6 +3246,14 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
             chatSDK.isPersistentChat = true;
+            chatSDK.liveChatConfig = {
+                LiveWSAndLiveChatEngJoin: {
+                    msdyn_enablecustomerclosepersistentchat: workstreamGate
+                },
+                LcwFcbConfiguration: {
+                    lcwPersistentChatCustomerEndEnabled: rolloutGate
+                }
+            };
             chatSDK.updateChatToken = jest.fn();
             global.setInterval = jest.fn() as unknown as typeof setInterval;
 
@@ -3250,17 +3269,23 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
 
             jest.spyOn(chatSDK.OCClient, 'sessionInit').mockResolvedValue(Promise.resolve());
             jest.spyOn(chatSDK.OCClient, 'createConversation').mockResolvedValue(Promise.resolve());
-            jest.spyOn(chatSDK.OCClient, 'getReconnectableChats').mockResolvedValue(Promise.resolve({
-                reconnectid: 'reconnectid'
-            }));
+            jest.spyOn(chatSDK.OCClient, 'getReconnectableChats').mockResolvedValue(Promise.resolve(
+                reconnectId ? { reconnectid: reconnectId } : {}
+            ));
             jest.spyOn(chatSDK.OCClient, 'sessionClose').mockResolvedValue(Promise.resolve());
 
+            const requestId = chatSDK.requestId;
+            expect(requestId).toBeTruthy();
+            expect(requestId).not.toBe('reconnectid');
             await chatSDK.startChat();
             await chatSDK.endChat();
 
             expect(chatSDK.OCClient.sessionClose).toHaveBeenCalledTimes(1);
             expect(chatSDK.OCClient.sessionClose.mock.calls[0][1].isPersistentChat).toBe(true);
-            expect(chatSDK.OCClient.sessionClose.mock.calls[0][1].isReconnectChat).toBe(true);
+            expect(chatSDK.OCClient.sessionClose.mock.calls[0][1].isReconnectChat).toBe(Boolean(reconnectId));
+            expect(chatSDK.OCClient.sessionClose.mock.calls[0][0]).toBe(
+                expectedIdentifier === 'reconnectid' ? expectedIdentifier : requestId
+            );
         });
 
         it('ChatSDK.isChatReconnect should be true on Chat Reconnect', async () => {

--- a/__tests__/OmnichannelChatSDKParallel.spec.ts
+++ b/__tests__/OmnichannelChatSDKParallel.spec.ts
@@ -3246,13 +3246,20 @@ describe('Omnichannel Chat SDK, Parallel initialization', () => {
             chatSDK.getChatConfig = jest.fn();
             chatSDK.getChatToken = jest.fn();
             chatSDK.isPersistentChat = true;
+            const lcwFcbConfiguration = workstreamGate === 'false'
+                ? Object.defineProperty({}, 'lcwPersistentChatCustomerEndEnabled', {
+                    get: () => {
+                        throw new Error('The rollout gate must not be read when the workstream gate is disabled');
+                    }
+                })
+                : {
+                    lcwPersistentChatCustomerEndEnabled: rolloutGate
+                };
             chatSDK.liveChatConfig = {
                 LiveWSAndLiveChatEngJoin: {
                     msdyn_enablecustomerclosepersistentchat: workstreamGate
                 },
-                LcwFcbConfiguration: {
-                    lcwPersistentChatCustomerEndEnabled: rolloutGate
-                }
+                LcwFcbConfiguration: lcwFcbConfiguration
             };
             chatSDK.updateChatToken = jest.fn();
             global.setInterval = jest.fn() as unknown as typeof setInterval;

--- a/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
+++ b/playwright/integrations/authenticated-chat-with-persistent-chat.spec.ts
@@ -51,13 +51,13 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.initialize();
 
+                await chatSDK.startChat();
+
                 const runtimeContext = {
                     orgUrl: chatSDK.omnichannelConfig.orgUrl,
                     requestId: chatSDK.requestId,
                     authToken
                 };
-
-                await chatSDK.startChat();
 
                 await sleep(chatDuration);
 
@@ -78,7 +78,7 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
     test("ChatSDK.startChat() should have a reconnect id if there's an existing chat session", async ({ page }) => {
         await page.goto(testPage);
 
-        const [_, reconnectableChatsRequest, reconnectableChatsResponse, chatTokenRequest, chatTokenResponse, sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
+        const [, reconnectableChatsRequest, reconnectableChatsResponse, chatTokenRequest, chatTokenResponse, sessionInitRequest, sessionInitResponse, runtimeContext] = await Promise.all([
             await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
@@ -149,13 +149,13 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.initialize();
 
+                await chatSDK.startChat();
+
                 const runtimeContext = {
                     orgUrl: chatSDK.omnichannelConfig.orgUrl,
                     requestId: chatSDK.requestId,
                     authToken
                 };
-
-                await chatSDK.startChat();
 
                 await sleep(chatDuration);
 
@@ -224,13 +224,13 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.initialize();
 
+                await chatSDK.startChat();
+
                 const runtimeContext = {
                     orgUrl: chatSDK.omnichannelConfig.orgUrl,
                     requestId: chatSDK.requestId,
                     authToken
                 };
-
-                await chatSDK.startChat();
 
                 await sleep(chatDuration);
 
@@ -253,7 +253,7 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
     test('ChatSDK.endChat() on an existing session should call session close with isPersistentChat=true & isReconnectChat=true as query params', async ({ page }) => {
         await page.goto(testPage);
 
-        const [_, sessionCloseRequest, sessionCloseResponse, runtimeContext] = await Promise.all([
+        const [, sessionCloseRequest, sessionCloseResponse, runtimeContext] = await Promise.all([
             await page.evaluate(async ({ omnichannelConfig, authUrl }) => {
                 const { OmnichannelChatSDK_1: OmnichannelChatSDK } = window;
 
@@ -306,13 +306,17 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
 
                 await chatSDK.initialize();
 
+                await chatSDK.startChat();
+
                 const runtimeContext = {
                     orgUrl: chatSDK.omnichannelConfig.orgUrl,
                     requestId: chatSDK.requestId,
+                    reconnectId: chatSDK.reconnectId,
+                    customerClosePersistentChatEnabled:
+                        String(chatSDK.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_enablecustomerclosepersistentchat).toLowerCase() === 'true' &&
+                        String(chatSDK.liveChatConfig?.LcwFcbConfiguration?.lcwPersistentChatCustomerEndEnabled).toLowerCase() === 'true',
                     authToken
                 };
-
-                await chatSDK.startChat();
 
                 await sleep(chatDuration);
 
@@ -322,9 +326,11 @@ test.describe('AuthenticatedChat @AuthenticatedChatWithPersistentChat', () => {
             }, { omnichannelConfig, authUrl, chatDuration: testSettings.chatDuration })
         ]);
 
-        const { requestId } = runtimeContext;
-        const sessionCloseRequestUrl = `${runtimeContext.orgUrl}/${OmnichannelEndpoints.LiveChatAuthSessionClosePath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${requestId}?channelId=lcw&isReconnectChat=true&isPersistentChat=true`;
+        const { reconnectId, customerClosePersistentChatEnabled } = runtimeContext;
+        const sessionCloseRequestUrl = `${runtimeContext.orgUrl}/${OmnichannelEndpoints.LiveChatAuthSessionClosePath}/${omnichannelConfig.orgId}/${omnichannelConfig.widgetId}/${reconnectId}?channelId=lcw&isReconnectChat=true&isPersistentChat=true`;
 
+        expect(customerClosePersistentChatEnabled).toBe(true);
+        expect(reconnectId).toBeTruthy();
         expect(sessionCloseRequest.url() === sessionCloseRequestUrl).toBe(true);
         expect(sessionCloseResponse.status()).toBe(200);
     });

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1061,17 +1061,30 @@ class OmnichannelChatSDK {
             try {
 
                 const sessionCloseOptionalParams: ISessionCloseOptionalParams = {};
+                let sessionCloseRequestId = this.requestId;
 
                 if (this.isPersistentChat && !this.chatSDKConfig.persistentChat?.disable) {
                     const isReconnectChat = this.reconnectId !== null ? true : false;
 
                     sessionCloseOptionalParams.isPersistentChat = this.isPersistentChat;
                     sessionCloseOptionalParams.isReconnectChat = isReconnectChat;
+
+                    const customerClosePersistentChatEnabled =
+                        parseLowerCaseString(this.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_enablecustomerclosepersistentchat) === "true" &&
+                        parseLowerCaseString(this.liveChatConfig?.LcwFcbConfiguration?.lcwPersistentChatCustomerEndEnabled) === "true";
+
+                    if (isReconnectChat &&
+                        customerClosePersistentChatEnabled &&
+                        typeof this.reconnectId === "string" &&
+                        this.reconnectId.length > 0) {
+                        sessionCloseRequestId = this.reconnectId;
+                    }
                 }
 
                 if (this.isChatReconnect && !this.chatSDKConfig.chatReconnect?.disable && !this.isPersistentChat) {
                     const isChatReconnect = this.reconnectId !== null ? true : false;
                     this.requestId = isChatReconnect ? (this.reconnectId as string) : this.requestId; // Chat Reconnect session to close
+                    sessionCloseRequestId = this.requestId;
                     sessionCloseOptionalParams.isReconnectChat = isChatReconnect;
                 }
 
@@ -1079,7 +1092,7 @@ class OmnichannelChatSDK {
                     sessionCloseOptionalParams.authenticatedUserToken = this.authenticatedUserToken;
                 }
 
-                await this.OCClient.sessionClose(this.requestId, sessionCloseOptionalParams);
+                await this.OCClient.sessionClose(sessionCloseRequestId, sessionCloseOptionalParams);
 
             } catch (error) {
                 exceptionThrowers.throwConversationClosureFailure(error, this.scenarioMarker, TelemetryEvent.CloseChatSession, {

--- a/src/OmnichannelChatSDK.ts
+++ b/src/OmnichannelChatSDK.ts
@@ -1069,14 +1069,11 @@ class OmnichannelChatSDK {
                     sessionCloseOptionalParams.isPersistentChat = this.isPersistentChat;
                     sessionCloseOptionalParams.isReconnectChat = isReconnectChat;
 
-                    const customerClosePersistentChatEnabled =
-                        parseLowerCaseString(this.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_enablecustomerclosepersistentchat) === "true" &&
-                        parseLowerCaseString(this.liveChatConfig?.LcwFcbConfiguration?.lcwPersistentChatCustomerEndEnabled) === "true";
-
-                    if (isReconnectChat &&
-                        customerClosePersistentChatEnabled &&
+                    if (parseLowerCaseString(this.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_enablecustomerclosepersistentchat) === "true" &&
+                        isReconnectChat &&
                         typeof this.reconnectId === "string" &&
-                        this.reconnectId.length > 0) {
+                        this.reconnectId.length > 0 &&
+                        parseLowerCaseString(this.liveChatConfig?.LcwFcbConfiguration?.lcwPersistentChatCustomerEndEnabled) === "true") {
                         sessionCloseRequestId = this.reconnectId;
                     }
                 }


### PR DESCRIPTION
## Summary
- route persistent-chat customer close through the reconnect identifier for an existing reconnected conversation
- guard the new routing behind both `msdyn_enablecustomerclosepersistentchat` and `lcwPersistentChatCustomerEndEnabled`
- preserve the existing request identifier path when either gate is disabled or no reconnectable chat exists
- update sequential, parallel, and authenticated persistent-chat integration coverage

## Root cause
Persistent reconnect close marked the request as `isReconnectChat=true` but sent the original request identifier. Messaging Runtime authorizes that path using the server-issued reconnect identifier, so authorization could fall through to session-header validation and fail.

## Compatibility
The identifier changes only for persistent reconnects where both customer-close gates are enabled and a non-empty reconnect identifier is available. Fresh persistent chats, gate-disabled flows, and non-persistent reconnect behavior are unchanged.

## Validation
- `npm run build:tsc`
- `npm test` (37 suites, 731 tests)
- ESLint on the updated Playwright integration spec
- source-built package deployed through the LCWv3 test widget; closing after reconnect returned HTTP 200